### PR TITLE
update benchmarks for Document encoding

### DIFF
--- a/js/benchmarks/README.md
+++ b/js/benchmarks/README.md
@@ -16,10 +16,10 @@ Results:
  |--------------------|------------|----------|------------|
  | json + brotli      | 0.48       | 1 ms     | 1 ms       |
  | bencode + lz4      | 0.52       | 0 ms     | 1 ms       |
- | bencode + brotli   | 0.34       | 25 ms    | 1 ms       |
- | csv + brotli       | 0.33       | 13 ms    | 1 ms       |
- | csv + lz4          | 0.49       | 1 ms     | 1 ms       |
- | custom + brotli    | 0.31       | 13 ms    | 3 ms       |
+ | csv + lz4          | 0.49       | 0 ms     | 1 ms       |
+ | bencode + brotli   | 0.34       | 26 ms    | 0 ms       |
+ | csv + brotli       | 0.33       | 20 ms    | 1 ms       |
+ | custom + brotli    | 0.31       | 14 ms    | 4 ms       |
  └--------------------┴------------┴----------┴------------┘
 ```
 
@@ -29,4 +29,19 @@ Conclusion:
 
 `csv + brotli` seems to offer the best compression, fast decoding, and acceptable encoding time.
 
-`custom + brotli` Where we encode dns type by its code dosen't offer much benifit, it needs two bytes, which only saves 1 byte for `TXT` and 2 for `AAAA`, while complecating decoding. 
+`custom + brotli` Where we encode dns type by its code ~dosen't offer much benifit, it needs two bytes, which only saves 1 byte for `TXT` and 2 for `AAAA`, while complecating decoding.~ 
+
+Actually encoding ipv4 and ipv6 for what is mostly `A`, `AAAA`, and `TXT` records, it starts to pay off.
+
+```
+ ┌--------------------┬------------┬----------┬------------┐
+ | TYPE               | SIZE RATIO | COMPRESS | DECOMPRESS |
+ |--------------------|------------|----------|------------|
+ | json + brotli      | 0.97       | 1 ms     | 1 ms       |
+ | bencode + lz4      | 1.01       | 0 ms     | 1 ms       |
+ | csv + lz4          | 0.96       | 0 ms     | 1 ms       |
+ | bencode + brotli   | 0.78       | 21 ms    | 0 ms       |
+ | csv + brotli       | 0.77       | 10 ms    | 0 ms       |
+ | custom + brotli    | 0.60       | 13 ms    | 5 ms       |
+ └--------------------┴------------┴----------┴------------┘
+ ```

--- a/js/benchmarks/README.md
+++ b/js/benchmarks/README.md
@@ -4,19 +4,29 @@ This directory keeps track of the tests, benchmarks and stress testing used to j
 
 ### compression-vs-encoding
 
-Assess if using CBOR is worth it instead of JSON compression using brtoli.
+First attempt: ~Assess if using CBOR is worth it instead of JSON compression using brtoli.~ CBOR wasn't really worth it
+
+Second attempt: Do we need JSON encoding (which doesn't come for free in all languages like Javascript)?
+
+Results:
 
 ```
-
-| Operation     | Size | Ratio | Time      |
-|---------------|------|-------|-----------|
-| JSON          | 3448 | 1     |           |
-| CBOR          | 2954 | 0.86  |   3.02  ms|
-| JSON + lz4    | 1481 | 0.43  |   0.697 ms|
-| CBOR + lz4    | 1518 | 0.44  |           |
-| JSON + brotli | 994  | 0.29  |  27.657 ms|
-| CBOR + brotli | 1044 | 0.29  |  16.075 ms|
-| BenC + brotli | 1021 | 0.30  |  15.199 ms|
+ ┌--------------------┬------------┬----------┬------------┐
+ | TYPE               | SIZE RATIO | COMPRESS | DECOMPRESS |
+ |--------------------|------------|----------|------------|
+ | json + brotli      | 0.48       | 1 ms     | 1 ms       |
+ | bencode + lz4      | 0.52       | 0 ms     | 1 ms       |
+ | bencode + brotli   | 0.34       | 25 ms    | 1 ms       |
+ | csv + brotli       | 0.33       | 13 ms    | 1 ms       |
+ | csv + lz4          | 0.49       | 1 ms     | 1 ms       |
+ | custom + brotli    | 0.31       | 13 ms    | 3 ms       |
+ └--------------------┴------------┴----------┴------------┘
 ```
 
-JSON + Bitroli (wasm) seem to be the best combination.
+Conclusion:
+
+`json + brotli` is very fast, but doesn't compress data enough.
+
+`csv + brotli` seems to offer the best compression, fast decoding, and acceptable encoding time.
+
+`custom + brotli` Where we encode dns type by its code dosen't offer much benifit, it needs two bytes, which only saves 1 byte for `TXT` and 2 for `AAAA`, while complecating decoding. 

--- a/js/benchmarks/compression-vs-encoding.js
+++ b/js/benchmarks/compression-vs-encoding.js
@@ -1,4 +1,3 @@
-import cbor from 'cbor'
 import lz4 from 'lz4'
 import brotli from 'brotli-compress'
 import assert from 'assert'
@@ -6,98 +5,285 @@ import bencode from 'bencode'
 
 // https://www.lucidchart.com/techblog/2019/12/06/json-compression-alternative-binary-formats-and-compression-methods/
 
-const records = `
-cloudflare.com. 300 IN CAA 0 issuewild "digicert.com; cansignhttpexchanges=yes"
-cloudflare.com. 146 IN A 104.16.132.229
-cloudflare.com. 146 IN A 104.16.133.229
-cloudflare.com. 97 IN AAAA 2606:4700::6810:85e5
-cloudflare.com. 97 IN AAAA 2606:4700::6810:84e5
-cloudflare.com. 44965 IN NS ns5.cloudflare.com.
-cloudflare.com. 44965 IN NS ns7.cloudflare.com.
-cloudflare.com. 44965 IN NS ns6.cloudflare.com.
-cloudflare.com. 44965 IN NS ns4.cloudflare.com.
-cloudflare.com. 44965 IN NS ns3.cloudflare.com.
-cloudflare.com. 1800 IN MX 5 mailstream-canary.mxrecord.io.
-cloudflare.com. 1800 IN MX 20 mailstream-central.mxrecord.mx.
-cloudflare.com. 1800 IN MX 10 mailstream-east.mxrecord.io.
-cloudflare.com. 1800 IN MX 10 mailstream-west.mxrecord.io.
-cloudflare.com. 300 IN TXT "google-site-verification=ZdlQZLBBAPkxeFTCM1rpiB_ibtGff_JF5KllNKwDR9I"
-cloudflare.com. 300 IN TXT "ZOOM_verify_7LFBvOO9SIigypFG2xRlMA"
-cloudflare.com. 300 IN TXT "docker-verification=c578e21c-34fb-4474-9b90-d55ee4cba10c"
-cloudflare.com. 300 IN TXT "atlassian-domain-verification=WxxKyN9aLnjEsoOjUYI6T0bb5vcqmKzaIkC9Rx2QkNb751G3LL/cus8/ZDOgh8xB"
-cloudflare.com. 300 IN TXT "miro-verification=bdd7dfa0a49adfb43ad6ddfaf797633246c07356"
-cloudflare.com. 300 IN TXT "google-site-verification=C7thfNeXVahkVhniiqTI1iSVnElKR_kBBtnEHkeGDlo"
-cloudflare.com. 300 IN TXT "status-page-domain-verification=r14frwljwbxs"
-cloudflare.com. 300 IN TXT "drift-domain-verification=f037808a26ae8b25bc13b1f1f2b4c3e0f78c03e67f24cefdd4ec520efa8e719f"
-cloudflare.com. 300 IN TXT "apple-domain-verification=DNnWJoArJobFJKhJ"
-cloudflare.com. 300 IN TXT "logmein-verification-code=b3433c86-3823-4808-8a7e-58042469f654"
-cloudflare.com. 300 IN TXT "stripe-verification=5096d01ff2cf194285dd51cae18f24fa9c26dc928cebac3636d462b4c6925623"
-cloudflare.com. 300 IN TXT "MS=ms70274184"
-cloudflare.com. 300 IN TXT "facebook-domain-verification=h9mm6zopj6p2po54woa16m5bskm6oo"
-cloudflare.com. 300 IN TXT "v=spf1 ip4:199.15.212.0/22 ip4:173.245.48.0/20 include:_spf.google.com include:spf1.mcsv.net include:spf.mandrillapp.com include:mail.zendesk.com include:stspg-customer.com include:_spf.salesforce.com -all"
-cloudflare.com. 300 IN TXT "cisco-ci-domain-verification=27e926884619804ef987ae4aa1c4168f6b152ada84f4c8bfc74eb2bd2912ad72"
-cloudflare.com. 300 IN TXT "stripe-verification=bf1a94e6b16ace2502a4a7fff574a25c8a45291054960c883c59be39d1788db9"
-cloudflare.com. 300 IN CAA 0 issue "digicert.com; cansignhttpexchanges=yes"
-cloudflare.com. 300 IN CAA 0 issuewild "digicert.com; cansignhttpexchanges=yes"
-cloudflare.com. 300 IN CAA 0 issue "letsencrypt.org"
-cloudflare.com. 300 IN CAA 0 issuewild "comodoca.com"
-cloudflare.com. 300 IN CAA 0 issue "comodoca.com"
-cloudflare.com. 300 IN CAA 0 iodef "mailto:tls-abuse@cloudflare.com"
-cloudflare.com. 300 IN CAA 0 issuewild "letsencrypt.org"
-cloudflare.com. 300 IN CAA 0 issuewild "pki.goog; cansignhttpexchanges=yes"
-cloudflare.com. 300 IN CAA 0 issue "pki.goog; cansignhttpexchanges=yes"
+const csv = `
+cloudflare.com.,300,IN,CAA,0 issuewild "digicert.com; cansignhttpexchanges=yes"
+cloudflare.com.,146,IN,A,104.16.132.229
+cloudflare.com.,146,IN,A,104.16.133.229
+cloudflare.com.,97,IN,AAAA,2606:4700::6810:85e5
+cloudflare.com.,97,IN,AAAA,2606:4700::6810:84e5
+cloudflare.com.,44965,IN,NS,ns5.cloudflare.com.
+cloudflare.com.,44965,IN,NS,ns7.cloudflare.com.
+cloudflare.com.,44965,IN,NS,ns6.cloudflare.com.
+cloudflare.com.,44965,IN,NS,ns4.cloudflare.com.
+cloudflare.com.,44965,IN,NS,ns3.cloudflare.com.
+cloudflare.com.,1800,IN,MX,5 mailstream-canary.mxrecord.io.
+cloudflare.com.,1800,IN,MX,20 mailstream-central.mxrecord.mx.
+cloudflare.com.,1800,IN,MX,10 mailstream-east.mxrecord.io.
+cloudflare.com.,1800,IN,MX,10 mailstream-west.mxrecord.io.
+cloudflare.com.,300,IN,TXT,"google-site-verification=ZdlQZLBBAPkxeFTCM1rpiB_ibtGff_JF5KllNKwDR9I"
+cloudflare.com.,300,IN,TXT,"ZOOM_verify_7LFBvOO9SIigypFG2xRlMA"
+cloudflare.com.,300,IN,TXT,"docker-verification=c578e21c-34fb-4474-9b90-d55ee4cba10c"
+cloudflare.com.,300,IN,TXT,"atlassian-domain-verification=WxxKyN9aLnjEsoOjUYI6T0bb5vcqmKzaIkC9Rx2QkNb751G3LL/cus8/ZDOgh8xB"
+cloudflare.com.,300,IN,TXT,"miro-verification=bdd7dfa0a49adfb43ad6ddfaf797633246c07356"
+cloudflare.com.,300,IN,TXT,"google-site-verification=C7thfNeXVahkVhniiqTI1iSVnElKR_kBBtnEHkeGDlo"
+cloudflare.com.,300,IN,TXT,"status-page-domain-verification=r14frwljwbxs"
+cloudflare.com.,300,IN,TXT,"drift-domain-verification=f037808a26ae8b25bc13b1f1f2b4c3e0f78c03e67f24cefdd4ec520efa8e719f"
+cloudflare.com.,300,IN,TXT,"apple-domain-verification=DNnWJoArJobFJKhJ"
+cloudflare.com.,300,IN,TXT,"logmein-verification-code=b3433c86-3823-4808-8a7e-58042469f654"
+cloudflare.com.,300,IN,TXT,"stripe-verification=5096d01ff2cf194285dd51cae18f24fa9c26dc928cebac3636d462b4c6925623"
+cloudflare.com.,300,IN,TXT,"MS=ms70274184"
+cloudflare.com.,300,IN,TXT,"facebook-domain-verification=h9mm6zopj6p2po54woa16m5bskm6oo"
+cloudflare.com.,300,IN,TXT,"v=spf1 ip4:199.15.212.0/22 ip4:173.245.48.0/20 include:_spf.google.com include:spf1.mcsv.net include:spf.mandrillapp.com include:mail.zendesk.com include:stspg-customer.com include:_spf.salesforce.com -all"
+cloudflare.com.,300,IN,TXT,"cisco-ci-domain-verification=27e926884619804ef987ae4aa1c4168f6b152ada84f4c8bfc74eb2bd2912ad72"
+cloudflare.com.,300,IN,TXT,"stripe-verification=bf1a94e6b16ace2502a4a7fff574a25c8a45291054960c883c59be39d1788db9"
+cloudflare.com.,300,IN,CAA,0 issue "digicert.com; cansignhttpexchanges=yes"
+cloudflare.com.,300,IN,CAA,0 issuewild "digicert.com; cansignhttpexchanges=yes"
+cloudflare.com.,300,IN,CAA,0 issue "letsencrypt.org"
+cloudflare.com.,300,IN,CAA,0 issuewild "comodoca.com"
+cloudflare.com.,300,IN,CAA,0 issue "comodoca.com"
+cloudflare.com.,300,IN,CAA,0 iodef "mailto:tls-abuse@cloudflare.com"
+cloudflare.com.,300,IN,CAA,0 issuewild "letsencrypt.org"
+cloudflare.com.,300,IN,CAA,0 issuewild "pki.goog; cansignhttpexchanges=yes"
+cloudflare.com.,300,IN,CAA,0 issue "pki.goog; cansignhttpexchanges=yes"
 `
-  .split(/\n/g).filter(Boolean)
-  .map(
-    row => row.split(/\s/g).filter(Boolean)
-      .map(s => {
-        const n = Number(s)
-        return Number.isNaN(n) ? s : n
-      })
-  )
+const records = csvToRecords(csv)
 
-const json = JSON.stringify(records)
-console.log('JSON         :', json.length, 1)
+const BASE = csv.length
 
-console.time('cbor')
-const cborEncoded = cbor.encode(records)
-console.log('\nCBOR         :', cborEncoded.byteLength, (cborEncoded.byteLength / json.length).toFixed(2))
-console.timeEnd('cbor')
+const results = {}
 
-console.time('lz4')
-const jsonLZ4 = lz4.encode(Buffer.from(json))
-console.log('\nJSON + lz4   :', jsonLZ4.byteLength, (jsonLZ4.byteLength / json.length).toFixed(2))
-console.timeEnd('lz4')
+const jsonEncoded = JSON.stringify(records)
 
-const cborLZ4 = lz4.encode(cborEncoded)
-console.log('\nCBOR + lz4   :', cborLZ4.byteLength, (cborLZ4.byteLength / json.length).toFixed(2))
+// Brotli JSON
+{
+  const compressStart = Date.now()
+  const compressed = lz4.encode(jsonEncoded)
+  const compressEnd = Date.now()
 
-console.time('json + brotli')
-const jsonBrotil = await brotli.compress(Buffer.from(json))
-console.log('\nJSON + brotli:', jsonBrotil.byteLength, (jsonBrotil.byteLength / json.length).toFixed(2))
-console.timeEnd('json + brotli')
+  const decompressStart = Date.now()
+  const decompressed = JSON.parse(lz4.decode(compressed).toString())
+  const decompressEnd = Date.now()
 
-console.time('brotli + bencode')
-const bencodeBrotli = await brotli.compress(bencode.encode(records))
-console.log('\nBencode + brotli:', bencodeBrotli.byteLength, (bencodeBrotli.byteLength / json.length).toFixed(2))
-console.timeEnd('brotli + bencode')
+  assert(decompressed.length === records.length)
 
-console.time('brotli + cbor')
-const cborBrtoli = await brotli.compress(cbor.encode(records))
-console.log('\nCBOR + brotli:', cborBrtoli.byteLength, (cborBrtoli.byteLength / json.length).toFixed(2))
-console.timeEnd('brotli + cbor')
+  results['json + brotli'] = {
+    sizeRatio: sizeRatio(compressed),
+    compressTime: compressEnd - compressStart,
+    decompressTime: decompressEnd - decompressStart
+  }
+}
 
-console.time('\ndecode - json + brotli')
-const d1 = JSON.parse(Buffer.from(await brotli.decompress(jsonBrotil)))
-assert.deepEqual(d1, records)
-console.timeEnd('\ndecode - json + brotli')
+const bencoded = bencode.encode(records)
 
-console.time('\ndecode - cbor + brotli')
-const d2 = cbor.decode(Buffer.from(await brotli.decompress(cborBrtoli)))
-assert.deepEqual(d2, records)
-console.timeEnd('\ndecode - cbor + brotli')
+// LZ4 bencode
+{
+  const compressStart = Date.now()
+  const compressed = lz4.encode(bencoded)
+  const compressEnd = Date.now()
 
-console.time('\ndecode - bencode + brotli')
-const d3 = bencode.decode(Buffer.from(await brotli.decompress(bencodeBrotli)), 'utf-8')
-assert.deepEqual(d3, records)
-console.timeEnd('\ndecode - bencode + brotli')
+  const decompressStart = Date.now()
+  const decompressed = bencode.decode(Buffer.from(lz4.decode(compressed))).map(r => r.map(c => {
+    try {
+      return Buffer.from(c).toString()
+    } catch (error) {
+      return c
+    }
+  }))
+  const decompressEnd = Date.now()
+
+  assert(decompressed.length === records.length)
+
+  results['bencode + lz4'] = {
+    sizeRatio: sizeRatio(compressed),
+    compressTime: compressEnd - compressStart,
+    decompressTime: decompressEnd - decompressStart
+  }
+}
+
+{
+  // Brotli bencode
+  const compressStart = Date.now()
+  const compressed = await brotli.compress(bencoded)
+  const compressEnd = Date.now()
+
+  const decompressStart = Date.now()
+  const decompressed = bencode.decode(await brotli.decompress(compressed)).map(r => r.map(c => {
+    try {
+      return Buffer.from(c).toString()
+    } catch (error) {
+      return c
+    }
+  }))
+  const decompressEnd = Date.now()
+
+  assert(decompressed.length === records.length)
+
+  results['bencode + brotli'] = {
+    sizeRatio: sizeRatio(compressed),
+    compressTime: compressEnd - compressStart,
+    decompressTime: decompressEnd - decompressStart
+  }
+}
+
+// Brotli CSV
+{
+  const compressStart = Date.now()
+  const compressed = await brotli.compress(Buffer.from(csv))
+  const compressEnd = Date.now()
+
+  const decompressStart = Date.now()
+  const decompressed = csvToRecords(Buffer.from((await brotli.decompress(compressed))).toString())
+  const decompressEnd = Date.now()
+
+  assert(decompressed.length === records.length)
+
+  results['csv + brotli'] = {
+    sizeRatio: sizeRatio(compressed),
+    compressTime: compressEnd - compressStart,
+    decompressTime: decompressEnd - decompressStart
+  }
+}
+
+// LZ4 CSV
+{
+  const compressStart = Date.now()
+  const compressed = lz4.encode(csv)
+  const compressEnd = Date.now()
+
+  const decompressStart = Date.now()
+  const decompressed = csvToRecords(lz4.decode(compressed).toString())
+  const decompressEnd = Date.now()
+
+  assert(decompressed.length === records.length)
+
+  results['csv + lz4'] = {
+    sizeRatio: sizeRatio(compressed),
+    compressTime: compressEnd - compressStart,
+    decompressTime: decompressEnd - decompressStart
+  }
+}
+
+// Brotli + custom
+{
+  const compressStart = Date.now()
+  const compressed = await brotli.compress(encode(csv))
+  const compressEnd = Date.now()
+
+  const decompressStart = Date.now()
+  const decompressed = decode(await brotli.decompress(compressed))
+  const decompressEnd = Date.now()
+
+  assert(decompressed.length === records.length)
+
+  results['custom + brotli'] = {
+    sizeRatio: sizeRatio(compressed),
+    compressTime: compressEnd - compressStart,
+    decompressTime: decompressEnd - decompressStart
+  }
+
+  function encode(string) {
+    const result = string.split(/\n/g).filter(Boolean).map(row => {
+      const parts = row.split(',')
+      const name = parts[0]
+      const type = parts[3]
+      const data = parts[4]
+
+      return Buffer.from([
+        (() => {
+          switch (type) {
+            case 'A':
+              return 1
+            case 'NS':
+              return 2
+            case 'MX':
+              return 15
+            case 'AAAA':
+              return 28
+            case 'TXT':
+              return 16
+            default:
+              return 255 // ANY
+          }
+        })(),
+        ...Buffer.from(name),
+        ...Buffer.from(' '),
+        ...Buffer.from(data),
+        ...Buffer.from('\n')
+      ])
+    })
+    return Buffer.concat(result)
+  }
+
+  function decode(buf) {
+    const result = []
+
+    let row = []
+
+    for (let x of buf) {
+      if (x === Buffer.from('\n')[0]) {
+        const type = row[0]
+        const string = Buffer.from(row).toString().slice(1)
+        const name = string.split(' ')[0]
+
+        result.push({
+          type: (() => {
+            switch (type) {
+              case 1:
+                return 'A'
+              case 2:
+                return 'NS'
+              case 15:
+                return 'MX'
+              case 28:
+                return 'AAAA'
+              case 16:
+                return 'TXT'
+              default:
+                return 'ANY'
+            }
+          })(),
+          name,
+          data: string.slice(name.length + 1)
+        })
+        row = []
+      } else {
+        row.push(x)
+      }
+    }
+
+    return result
+  }
+}
+
+function sizeRatio(compressed) {
+  return compressed.length / BASE
+}
+
+function csvToRecords(csv) {
+  const records = csv
+    .split(/\n/g).filter(Boolean)
+    .map(
+      row => {
+        let _row = row.split(/,/g).filter(Boolean)
+          .map(s => {
+            const n = Number(s)
+            return Number.isNaN(n) ? s : n
+          })
+
+        _row[1] = _row[2] = null
+        _row = _row.filter(Boolean)
+
+        return _row
+      }
+    )
+
+  return records
+}
+
+console.log(' ┌--------------------┬------------┬----------┬------------┐')
+console.log(' | TYPE               | SIZE RATIO | COMPRESS | DECOMPRESS |')
+console.log(' |--------------------|------------|----------|------------|')
+for (const [name, row] of Object.entries(results)) {
+  console.log(' | ' + name.padEnd(18) + ' | ' + row.sizeRatio.toFixed(2).padEnd(10) + ' | ' + (row.compressTime + ' ms').padEnd(8) + ' | ' + (row.decompressTime + ' ms').padEnd(10) + ' |')
+}
+console.log(' └--------------------┴------------┴----------┴------------┘')

--- a/js/benchmarks/compression-vs-encoding.js
+++ b/js/benchmarks/compression-vs-encoding.js
@@ -2,50 +2,21 @@ import lz4 from 'lz4'
 import brotli from 'brotli-compress'
 import assert from 'assert'
 import bencode from 'bencode'
+import * as ipCodec from '@leichtgewicht/ip-codec'
 
 // https://www.lucidchart.com/techblog/2019/12/06/json-compression-alternative-binary-formats-and-compression-methods/
 
-const csv = `
-cloudflare.com.,300,IN,CAA,0 issuewild "digicert.com; cansignhttpexchanges=yes"
-cloudflare.com.,146,IN,A,104.16.132.229
-cloudflare.com.,146,IN,A,104.16.133.229
-cloudflare.com.,97,IN,AAAA,2606:4700::6810:85e5
-cloudflare.com.,97,IN,AAAA,2606:4700::6810:84e5
-cloudflare.com.,44965,IN,NS,ns5.cloudflare.com.
-cloudflare.com.,44965,IN,NS,ns7.cloudflare.com.
-cloudflare.com.,44965,IN,NS,ns6.cloudflare.com.
-cloudflare.com.,44965,IN,NS,ns4.cloudflare.com.
-cloudflare.com.,44965,IN,NS,ns3.cloudflare.com.
-cloudflare.com.,1800,IN,MX,5 mailstream-canary.mxrecord.io.
-cloudflare.com.,1800,IN,MX,20 mailstream-central.mxrecord.mx.
-cloudflare.com.,1800,IN,MX,10 mailstream-east.mxrecord.io.
-cloudflare.com.,1800,IN,MX,10 mailstream-west.mxrecord.io.
-cloudflare.com.,300,IN,TXT,"google-site-verification=ZdlQZLBBAPkxeFTCM1rpiB_ibtGff_JF5KllNKwDR9I"
-cloudflare.com.,300,IN,TXT,"ZOOM_verify_7LFBvOO9SIigypFG2xRlMA"
-cloudflare.com.,300,IN,TXT,"docker-verification=c578e21c-34fb-4474-9b90-d55ee4cba10c"
-cloudflare.com.,300,IN,TXT,"atlassian-domain-verification=WxxKyN9aLnjEsoOjUYI6T0bb5vcqmKzaIkC9Rx2QkNb751G3LL/cus8/ZDOgh8xB"
-cloudflare.com.,300,IN,TXT,"miro-verification=bdd7dfa0a49adfb43ad6ddfaf797633246c07356"
-cloudflare.com.,300,IN,TXT,"google-site-verification=C7thfNeXVahkVhniiqTI1iSVnElKR_kBBtnEHkeGDlo"
-cloudflare.com.,300,IN,TXT,"status-page-domain-verification=r14frwljwbxs"
-cloudflare.com.,300,IN,TXT,"drift-domain-verification=f037808a26ae8b25bc13b1f1f2b4c3e0f78c03e67f24cefdd4ec520efa8e719f"
-cloudflare.com.,300,IN,TXT,"apple-domain-verification=DNnWJoArJobFJKhJ"
-cloudflare.com.,300,IN,TXT,"logmein-verification-code=b3433c86-3823-4808-8a7e-58042469f654"
-cloudflare.com.,300,IN,TXT,"stripe-verification=5096d01ff2cf194285dd51cae18f24fa9c26dc928cebac3636d462b4c6925623"
-cloudflare.com.,300,IN,TXT,"MS=ms70274184"
-cloudflare.com.,300,IN,TXT,"facebook-domain-verification=h9mm6zopj6p2po54woa16m5bskm6oo"
-cloudflare.com.,300,IN,TXT,"v=spf1 ip4:199.15.212.0/22 ip4:173.245.48.0/20 include:_spf.google.com include:spf1.mcsv.net include:spf.mandrillapp.com include:mail.zendesk.com include:stspg-customer.com include:_spf.salesforce.com -all"
-cloudflare.com.,300,IN,TXT,"cisco-ci-domain-verification=27e926884619804ef987ae4aa1c4168f6b152ada84f4c8bfc74eb2bd2912ad72"
-cloudflare.com.,300,IN,TXT,"stripe-verification=bf1a94e6b16ace2502a4a7fff574a25c8a45291054960c883c59be39d1788db9"
-cloudflare.com.,300,IN,CAA,0 issue "digicert.com; cansignhttpexchanges=yes"
-cloudflare.com.,300,IN,CAA,0 issuewild "digicert.com; cansignhttpexchanges=yes"
-cloudflare.com.,300,IN,CAA,0 issue "letsencrypt.org"
-cloudflare.com.,300,IN,CAA,0 issuewild "comodoca.com"
-cloudflare.com.,300,IN,CAA,0 issue "comodoca.com"
-cloudflare.com.,300,IN,CAA,0 iodef "mailto:tls-abuse@cloudflare.com"
-cloudflare.com.,300,IN,CAA,0 issuewild "letsencrypt.org"
-cloudflare.com.,300,IN,CAA,0 issuewild "pki.goog; cansignhttpexchanges=yes"
-cloudflare.com.,300,IN,CAA,0 issue "pki.goog; cansignhttpexchanges=yes"
+const TYPICAL = `
+@,100,IN,A,104.16.132.229
+fedimint.@,97,IN,AAAA,2606::4700::6810::84e5
+router.@,97,IN,AAAA,2606:2800:220:1:248:1893:25c8:19
+@,97,IN,CNAME,nuh.dev
+_atproto.@,300,IN,TXT,"did=did:plc:zki2d3v7nckil3azsodv72sy"
+_matrix.@,1080,IN,TXT,"handle=@nuhvi:matrix.org"
 `
+
+const csv = TYPICAL
+
 const records = csvToRecords(csv)
 
 const BASE = csv.length
@@ -100,8 +71,27 @@ const bencoded = bencode.encode(records)
   }
 }
 
+// LZ4 CSV
 {
-  // Brotli bencode
+  const compressStart = Date.now()
+  const compressed = lz4.encode(csv)
+  const compressEnd = Date.now()
+
+  const decompressStart = Date.now()
+  const decompressed = csvToRecords(lz4.decode(compressed).toString())
+  const decompressEnd = Date.now()
+
+  assert(decompressed.length === records.length)
+
+  results['csv + lz4'] = {
+    sizeRatio: sizeRatio(compressed),
+    compressTime: compressEnd - compressStart,
+    decompressTime: decompressEnd - decompressStart
+  }
+}
+
+// Brotli bencode
+{
   const compressStart = Date.now()
   const compressed = await brotli.compress(bencoded)
   const compressEnd = Date.now()
@@ -144,25 +134,6 @@ const bencoded = bencode.encode(records)
   }
 }
 
-// LZ4 CSV
-{
-  const compressStart = Date.now()
-  const compressed = lz4.encode(csv)
-  const compressEnd = Date.now()
-
-  const decompressStart = Date.now()
-  const decompressed = csvToRecords(lz4.decode(compressed).toString())
-  const decompressEnd = Date.now()
-
-  assert(decompressed.length === records.length)
-
-  results['csv + lz4'] = {
-    sizeRatio: sizeRatio(compressed),
-    compressTime: compressEnd - compressStart,
-    decompressTime: decompressEnd - decompressStart
-  }
-}
-
 // Brotli + custom
 {
   const compressStart = Date.now()
@@ -181,7 +152,7 @@ const bencoded = bencode.encode(records)
     decompressTime: decompressEnd - decompressStart
   }
 
-  function encode(string) {
+  function encode (string) {
     const result = string.split(/\n/g).filter(Boolean).map(row => {
       const parts = row.split(',')
       const name = parts[0]
@@ -189,49 +160,73 @@ const bencoded = bencode.encode(records)
       const data = parts[4]
 
       return Buffer.from([
-        (() => {
+        ...(() => {
           switch (type) {
             case 'A':
-              return 1
+              return Buffer.from([0, 1])
             case 'NS':
-              return 2
+              return Buffer.from([0, 2])
+            case 'CNAME':
+              return Buffer.from([0, 5])
             case 'MX':
-              return 15
+              return Buffer.from([0, 15])
             case 'AAAA':
-              return 28
+              return Buffer.from([0, 28])
             case 'TXT':
-              return 16
+              return Buffer.from([0, 16])
             default:
-              return 255 // ANY
+              return Buffer.from([0, 255])
           }
         })(),
         ...Buffer.from(name),
         ...Buffer.from(' '),
-        ...Buffer.from(data),
+        ...(() => {
+          switch (type) {
+            case 'A':
+              return ipCodec.v4.encode(data)
+            case 'AAAA':
+              return ipCodec.v6.encode(data)
+            case 'TXT':
+              return Buffer.from(data.slice(1, data.length - 2))
+            default:
+              return Buffer.from(data)
+          }
+        })(),
         ...Buffer.from('\n')
       ])
     })
     return Buffer.concat(result)
   }
 
-  function decode(buf) {
+  function decode (buf) {
     const result = []
 
     let row = []
 
-    for (let x of buf) {
+    for (const x of buf) {
       if (x === Buffer.from('\n')[0]) {
-        const type = row[0]
-        const string = Buffer.from(row).toString().slice(1)
-        const name = string.split(' ')[0]
+        const type = row[1]
+        const rest = Buffer.from(row).subarray(2)
+        let name = []
 
-        result.push({
+        for (const d of rest) {
+          if (d === Buffer.from(' ')[0]) {
+            break
+          }
+          name.push(d)
+        }
+
+        name = Buffer.from(name).toString()
+
+        const _row = {
           type: (() => {
             switch (type) {
               case 1:
                 return 'A'
               case 2:
                 return 'NS'
+              case 5:
+                return 'CNAME'
               case 15:
                 return 'MX'
               case 28:
@@ -242,9 +237,22 @@ const bencoded = bencode.encode(records)
                 return 'ANY'
             }
           })(),
-          name,
-          data: string.slice(name.length + 1)
-        })
+          name: name.replace(/@$/, 'o4dksfbqk85ogzdb5osziw6befigbuxmuxkuxq8434q89uj56uyy.'),
+          data: (() => {
+            const _data = rest.subarray(name.length + 1)
+
+            switch (type) {
+              case 1:
+                return ipCodec.v4.decode(_data)
+              case 28:
+                return ipCodec.v6.decode(_data)
+              default:
+                return _data
+            }
+          })()
+        }
+
+        result.push(_row)
         row = []
       } else {
         row.push(x)
@@ -255,11 +263,11 @@ const bencoded = bencode.encode(records)
   }
 }
 
-function sizeRatio(compressed) {
+function sizeRatio (compressed) {
   return compressed.length / BASE
 }
 
-function csvToRecords(csv) {
+function csvToRecords (csv) {
   const records = csv
     .split(/\n/g).filter(Boolean)
     .map(

--- a/js/benchmarks/package.json
+++ b/js/benchmarks/package.json
@@ -14,5 +14,8 @@
     "brotli": "^1.3.3",
     "cbor": "^8.1.0",
     "lz4": "^0.6.5"
+  },
+  "dependencies": {
+    "@leichtgewicht/ip-codec": "^2.0.4"
   }
 }


### PR DESCRIPTION
I suspected `json` wasn't a good choice, as it requires extra dependency for clients, and add a lot of overhead (brackets). 

Evidently, `csv` + `brotli` is hard to beat as I suspected.

We are very early, so I will probably break backward compatibility (not support the `brotli` + `json` encoded documents)

I am also considering if I should remove the `version` prefix byte, to really discourage any changes to this format in the future!

More versions == more complexity on decoder side.

If you are watching this, and think you have a better corpus of dns records to benchmark against, please let me know.

Also, as you can see from the code, I am disregarding all fields except `name`, `type` and `data` which is just whatever is left.

The logic here is that `TTL` doesn't make sense for these individual records, as they all updated together, and really Pkarr targets very long TTL, to reduce the frequency of contacting the DHT. It seems that in general people use 60 minutes as the sensible default TTL, and that is generally what Pkarr targets as well.

If you have an argument against omitting TTLs, let me know, maybe in Discussions. Regardless, since this is meant to be a `csv`, we can add TTLs later at the end of each row!

As for `Class` field, I think that field is poorly defined and rarely used, so also ignored.