### PR TITLE
(fix) fixes ERR_REQUIRE_ESM 

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -15,8 +15,8 @@
     "lint": "standard --fix",
     "start": "node start.js",
     "test": "brittle test/* --cov",
-    "build:cjs": "tsc --outDir dist/cjs --module commonjs",
-    "build:esm": "tsc --outDir dist/esm --module esnext",
+    "build:cjs": "tsc --outDir dist/cjs --module commonjs && ./scripts/fix-cjs-build.sh",
+    "build:esm": "tsc --outDir dist/esm --module esnext && ./scripts/fix-esm-build.sh",
     "build": "npm run build:cjs && npm run build:esm",
     "fullcheck": "npm run lint && npm run build && npm run test",
     "prepublishOnly": "npm run fullcheck"

--- a/js/scripts/fix-cjs-build.sh
+++ b/js/scripts/fix-cjs-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF

--- a/js/scripts/fix-esm-build.sh
+++ b/js/scripts/fix-esm-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cat >dist/esm/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF


### PR DESCRIPTION
Fixes the `ERR_REQUIRE_ESM` when using pkarr in CommonJS.

I am still getting this error though so it's still not building yet.
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /Users/severinbuhler/git/ddns/pkarr/js/node_modules/bittorrent-dht/package.json
```