### PR TITLE
fix:  build without default features

### DIFF
--- a/pkarr/src/error.rs
+++ b/pkarr/src/error.rs
@@ -46,6 +46,7 @@ pub enum Error {
     /// Relay response is not 200 OK
     PublishFailed,
 
+    #[cfg(feature = "dht")]
     #[error(transparent)]
     MainlineError(#[from] mainline::Error),
 }

--- a/pkarr/src/lib.rs
+++ b/pkarr/src/lib.rs
@@ -27,16 +27,19 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 pub const DEFAULT_PKARR_RELAY: &str = "https://relay.pkarr.org";
 
 pub struct PkarrClientBuilder {
+    #[cfg(feature = "dht")]
     settings: DhtSettings,
 }
 
 impl PkarrClientBuilder {
     pub fn new() -> Self {
         Self {
+            #[cfg(feature = "dht")]
             settings: DhtSettings::default(),
         }
     }
 
+    #[cfg(feature = "dht")]
     pub fn bootstrap(mut self, bootstrap: &[String]) -> Self {
         self.settings.bootstrap = Some(bootstrap.to_owned());
         self
@@ -48,6 +51,7 @@ impl PkarrClientBuilder {
             http_client: reqwest::blocking::Client::new(),
             #[cfg(all(feature = "relay", feature = "async"))]
             http_client: reqwest::Client::new(),
+            #[cfg(feature = "dht")]
             dht: Dht::new(self.settings),
         }
     }
@@ -66,6 +70,7 @@ pub struct PkarrClient {
     http_client: reqwest::blocking::Client,
     #[cfg(all(feature = "relay", feature = "async"))]
     http_client: reqwest::Client,
+    #[cfg(feature = "dht")]
     dht: Dht,
 }
 
@@ -76,6 +81,7 @@ impl PkarrClient {
             http_client: reqwest::blocking::Client::new(),
             #[cfg(all(feature = "relay", feature = "async"))]
             http_client: reqwest::Client::new(),
+            #[cfg(feature = "dht")]
             dht: Dht::default(),
         }
     }


### PR DESCRIPTION
`cargo build --no-default-features` currently fails to build because mainline types are used. This PR fixes this by adding more `#[cfg(feature = "dht")]` directives.