### PR TITLE
feat: allow path component in relay urls

### DIFF
--- a/pkarr/src/lib.rs
+++ b/pkarr/src/lib.rs
@@ -101,7 +101,7 @@ impl PkarrClient {
     #[cfg(all(feature = "relay", not(feature = "async")))]
     /// Resolves a [SignedPacket](crate::SignedPacket) from a [relay](https://github.com/Nuhvi/pkarr/blob/main/design/relays.md).
     pub fn relay_get(&self, url: &Url, public_key: PublicKey) -> Result<Option<SignedPacket>> {
-        let url = format_relay_url(url, &public_key);
+        let url = format_relay_url(url, &public_key)?;
 
         let response = self.http_client.get(url).send()?;
 
@@ -126,7 +126,7 @@ impl PkarrClient {
         url: &Url,
         public_key: PublicKey,
     ) -> Result<Option<SignedPacket>> {
-        let url = format_relay_url(url, &public_key);
+        let url = format_relay_url(url, &public_key)?;
 
         let response = self.http_client.get(url).send().await?;
 
@@ -147,7 +147,7 @@ impl PkarrClient {
     #[cfg(all(feature = "relay", not(feature = "async")))]
     /// Publishes a [SignedPacket] through a [relay](https://github.com/Nuhvi/pkarr/blob/main/design/relays.md).
     pub fn relay_put(&self, url: &Url, signed_packet: &SignedPacket) -> Result<()> {
-        let url = format_relay_url(url, signed_packet.public_key());
+        let url = format_relay_url(url, signed_packet.public_key())?;
 
         let response = self
             .http_client
@@ -169,7 +169,7 @@ impl PkarrClient {
     #[cfg(all(feature = "relay", feature = "async"))]
     /// Publishes a [SignedPacket] through a [relay](https://github.com/Nuhvi/pkarr/blob/main/design/relays.md).
     pub async fn relay_put(&self, url: &Url, signed_packet: &SignedPacket) -> Result<()> {
-        let url = format_relay_url(url, signed_packet.public_key());
+        let url = format_relay_url(url, signed_packet.public_key())?;
 
         let response = self
             .http_client
@@ -323,9 +323,10 @@ impl Default for PkarrClient {
 }
 
 #[cfg(feature = "relay")]
-fn format_relay_url(url: &Url, public_key: &PublicKey) -> Url {
+fn format_relay_url(url: &Url, public_key: &PublicKey) -> Result<Url> {
     let mut url = url.to_owned();
-    url.set_path(&public_key.to_z32());
-
-    url
+    url.path_segments_mut()
+        .map_err(|_| Error::Static("invalid url"))?
+        .push(&public_key.to_z32());
+    Ok(url)
 }


### PR DESCRIPTION
Currently, the relay URL is forced to have an empty path, because the z32 pubkey is set as the full path of the URL. This PR changes this so that the pubkey is appended to the base URL, allowing it to have a base path. This makes it straightforward to provide a pkarr relay on webserver that also has other routes.