### PR TITLE
refactor: update CORS configuration in `http_server` to allow any origin

### DIFF
--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -78,7 +78,7 @@ impl HttpServer {
 pub fn create_app(state: AppState, rate_limiter: IpRateLimiter) -> Router {
     let cors = CorsLayer::new()
         .allow_methods([Method::GET, Method::PUT])
-        .allow_origin(cors::Any);
+        .allow_any_origin();
 
     let router = Router::new()
         .route("/:key", get(crate::handlers::get).put(crate::handlers::put))


### PR DESCRIPTION
This PR updates the CORS configuration in the `create_app` function of `http_server.rs` to use `.allow_any_origin()` instead of `.allow_origin(cors::Any)`. This change ensures that requests from any origin, including those from localhost without a specific HTTP scheme (such as null origins), are properly handled.