### PR TITLE
fix(server): cors on browsers

### DIFF
--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -77,8 +77,9 @@ impl HttpServer {
 
 pub fn create_app(state: AppState, rate_limiter: IpRateLimiter) -> Router {
     let cors = CorsLayer::new()
-        .allow_methods([Method::GET, Method::PUT])
-        .allow_origin(cors::Any);
+        .allow_methods([Method::GET, Method::PUT, Method::OPTIONS])
+        .allow_origin(cors::Any)
+        .allow_headers(cors::Any);
 
     let router = Router::new()
         .route("/:key", get(crate::handlers::get).put(crate::handlers::put))


### PR DESCRIPTION
This pull request proposes a solution to the CORS policy error that has been blocking cross-origin requests from `http://localhost:4200` to `https://relay.pkarr.org`. While this is just an hypothesis, I believe the issue might stem from the server not correctly handling CORS preflight `OPTIONS` requests and missing `Access-Control-Allow-Origin` headers in the response. Consequently, the browser is preventing the requests due to an incomplete CORS configuration.

To address this potential root cause (we'll see if that works), this PR adds `Method::OPTIONS` to the list of allowed methods using `.allow_methods([Method::GET, Method::PUT, Method::OPTIONS])` and changed `.allow_headers(Any)` to allow any headers. While I'm not entirely confident this will fully resolve the issue, it will help rule the server out as cause.