### PR TITLE
Feat/signed packet builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to pkarr client and server will be documented in this file.
 
 ### Added
 
+- Add `SignedPacket::builder()` and convenient methods to create `A`, `AAAA`, `CNAME`, `TXT`, `SVCB`, and `HTTPS` records.
 - Use `pubky_timestamp::Timestamp` 
 - Impl `PartialEq, Eq` for `SignedPacket`.
 - Impl `From<PublicKey>` for `CacheKey`.
@@ -32,3 +33,5 @@ All notable changes to pkarr client and server will be documented in this file.
 ### Removed
 
 - Remvoed `relay_client_web`, replaced with *(pkarr::relay::Client)*.
+- Removed `SignedPacket::from_packet`.
+- Removed `SignedPacket::packet` getter.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
@@ -1471,8 +1471,9 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 
 [[package]]
 name = "mainline"
-version = "3.0.1"
-source = "git+https://github.com/pubky/mainline#ce935827349341d2130589486a40e6411c8c790e"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e18c8b0210572062a02c4de8c448865f4ca89824c4ac7da64a0c2669ea2c405"
 dependencies = [
  "bytes",
  "crc",
@@ -1485,7 +1486,7 @@ dependencies = [
  "serde_bencode",
  "serde_bytes",
  "sha1_smol",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -182,7 +182,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.1",
  "tower-layer",
@@ -205,7 +205,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -329,9 +329,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -465,9 +465,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -700,12 +700,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -993,9 +993,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heapless"
@@ -1332,7 +1332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
@@ -1373,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "fb15147158e79fd8b8afd0252522769c4f48725460b37338544d8379d94fc8f9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1394,9 +1394,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libloading"
@@ -1426,9 +1426,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "litrs"
@@ -1864,7 +1864,7 @@ dependencies = [
  "serde",
  "sha1_smol",
  "simple-dns",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -1923,9 +1923,9 @@ checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "postcard"
-version = "1.0.10"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7f0a8d620d71c457dd1d47df76bb18960378da56af4527aaa10f515eee732e"
+checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2189,7 +2189,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper 1.0.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2247,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags",
  "errno",
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2407,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -2506,9 +2506,9 @@ checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "simple-dns"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01607fe2e61894468c6dc0b26103abb073fb08b79a3d9e4b6d76a1a341549958"
+checksum = "92bc7a4124e416342635ff7090cf6883a1835a91a7d2aa01c54c458a650781be"
 dependencies = [
  "bitflags",
 ]
@@ -2536,9 +2536,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2592,9 +2592,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2609,9 +2609,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
 ]
@@ -2920,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2932,9 +2932,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2943,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2964,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2994,9 +2994,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "untrusted"
@@ -3006,9 +3006,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3068,9 +3068,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "21d3b25c3ea1126a2ad5f4f9068483c2af1e64168f847abe863a526b8dbfe00b"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3079,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "52857d4c32e496dc6537646b5b117081e71fd2ff06de792e3577a150627db283"
 dependencies = [
  "bumpalo",
  "log",
@@ -3094,21 +3094,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "951fe82312ed48443ac78b66fa43eded9999f738f6022e67aead7b708659e49a"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "920b0ffe069571ebbfc9ddc0b36ba305ef65577c94b06262ed793716a1afd981"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3116,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "bf59002391099644be3524e23b781fa43d2be0c5aa0719a18c0731b9d195cab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3129,15 +3130,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "e5047c5392700766601942795a436d7d2599af60dcc3cc1248c9120bfb0827b0"
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "476364ff87d0ae6bfb661053a9104ab312542658c3d8f963b7ace80b6f9b26b9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3155,9 +3156,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.6"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3397,9 +3398,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -3409,9 +3410,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3442,18 +3443,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -42,7 +42,7 @@ webpki-roots = { version = "0.26.6", optional = true }
 pubky-timestamp = { version = "0.2.0", default-features = false }
 
 # feat: dht dependencies
-mainline = { git = "https://github.com/pubky/mainline", optional = true }
+mainline = { version = "4.1.0", optional = true }
 
 # feat: relay dependencies
 reqwest = { version = "0.12.7", features = ["rustls-tls"], optional = true }

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -7,6 +7,7 @@ description = "Public-Key Addressable Resource Records (Pkarr); publish and reso
 license = "MIT"
 repository = "https://git.pkarr.org"
 keywords = ["mainline", "dht", "dns", "decentralized", "identity"]
+categories = ["network-programming"]
 
 [dependencies]
 base32 = "0.5.0"

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -10,34 +10,34 @@ keywords = ["mainline", "dht", "dns", "decentralized", "identity"]
 categories = ["network-programming"]
 
 [dependencies]
-base32 = "0.5.0"
-bytes = "1.7.1"
-ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
-self_cell = "1.0.2"
-simple-dns = "0.6.1"
-thiserror = "1.0.49"
-tracing = "0.1.40"
+base32 = "0.5.1"
+bytes = "1.9.0"
+ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
+self_cell = "1.0.4"
+simple-dns = "0.8.0"
+thiserror = "2.0.3"
+tracing = "0.1.41"
 dyn-clone = "1.0.17"
-document-features = "0.2.8"
+document-features = "0.2.10"
 rand = "0.8.5"
-once_cell = {version = "1.19.0", default-features = false }
-lru = { version = "0.12.3", default-features = false }
-flume = { version = "0.11.0", features = ["select", "eventual-fairness", "async"], default-features = false , optional = true }
+once_cell = {version = "1.20.2", default-features = false }
+lru = { version = "0.12.5", default-features = false }
+flume = { version = "0.11.1", features = ["select", "eventual-fairness", "async"], default-features = false , optional = true }
 
 # feat: relay dependencies
-tokio = { version = "1.40.0", optional = true, default-features = false }
+tokio = { version = "1.41.1", optional = true, default-features = false }
 # inherited from feat:dht as well.
 sha1_smol = { version = "1.0.1", optional = true }
 
 # feat: serde dependencies
-serde = { version = "1.0.209", features = ["derive"], optional = true }
+serde = { version = "1.0.215", features = ["derive"], optional = true }
 
 # feat: endpoints dependencies
 futures-lite = { version = "2.5.0", default-features = false, features= ["std"], optional = true }
 genawaiter = { version = "0.99.1", default-features = false, features = ["futures03"], optional = true }
 
 # feat: reqwest-builder
-webpki-roots = { version = "0.26.6", optional = true }
+webpki-roots = { version = "0.26.7", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 pubky-timestamp = { version = "0.2.0", default-features = false }
@@ -46,38 +46,38 @@ pubky-timestamp = { version = "0.2.0", default-features = false }
 mainline = { version = "4.1.0", optional = true }
 
 # feat: relay dependencies
-reqwest = { version = "0.12.7", features = ["rustls-tls"], optional = true }
+reqwest = { version = "0.12.9", features = ["rustls-tls"], optional = true }
 
 # feat: tls
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 webpki = { package = "rustls-webpki", version = "0.102", optional = true }
 
 # feat: lmdb-cache defendencies
-heed = { version = "0.20.0", default-features = false, optional = true }
+heed = { version = "0.20.5", default-features = false, optional = true }
 byteorder = { version = "1.5.0", default-features = false, optional = true }
-libc = { version = "0.2.159", optional = true }
+libc = { version = "0.2.167", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pubky-timestamp = { version = "0.2.0", default-features = false, features = ["httpdate"] }
-js-sys = "0.3.69"
-futures = "0.3.30"
+js-sys = "0.3.73"
+futures = "0.3.31"
 getrandom = { version = "0.2", features = ["js"] }
-reqwest = "0.12.7"
+reqwest = "0.12.9"
 sha1_smol = "1.0.1"
-wasm-bindgen-futures = "0.4.45"
+wasm-bindgen-futures = "0.4.46"
 
 [dev-dependencies]
 anyhow = "1.0.93"
-axum = "0.7.7"
+axum = "0.7.9"
 axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
-postcard = { version = "1.0.10", features = ["alloc"] }
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
+postcard = { version = "1.1.1", features = ["alloc"] }
+tokio = { version = "1.41.1", features = ["macros", "rt-multi-thread"] }
 tokio-rustls = "0.26.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-clap = { version = "4.4.8", features = ["derive"] }
-mockito = "1.4.0"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+clap = { version = "4.5.21", features = ["derive"] }
+mockito = "1.6.1"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [features]
 # Clients 

--- a/pkarr/examples/publish.rs
+++ b/pkarr/examples/publish.rs
@@ -11,7 +11,7 @@ use tracing_subscriber;
 
 use std::time::Instant;
 
-use pkarr::{dns, Keypair, SignedPacket};
+use pkarr::{Keypair, SignedPacket};
 
 #[cfg(feature = "relay")]
 use pkarr::client::relay::Client;
@@ -29,15 +29,9 @@ async fn main() -> anyhow::Result<()> {
 
     let keypair = Keypair::random();
 
-    let mut packet = dns::Packet::new_reply(0);
-    packet.answers.push(dns::ResourceRecord::new(
-        dns::Name::new("_foo")?,
-        dns::CLASS::IN,
-        30,
-        dns::rdata::RData::TXT("bar".try_into()?),
-    ));
-
-    let signed_packet = SignedPacket::from_packet(&keypair, &packet)?;
+    let signed_packet = SignedPacket::builder()
+        .txt("_foo".try_into().unwrap(), "bar".try_into().unwrap(), 30)
+        .sign(&keypair)?;
 
     let instant = Instant::now();
 

--- a/pkarr/src/base/signed_packet.rs
+++ b/pkarr/src/base/signed_packet.rs
@@ -635,7 +635,7 @@ mod tests {
         let mut packet = Packet::new_reply(0);
         packet.answers.push(target.clone());
         packet.answers.push(ResourceRecord::new(
-            Name::new("something else").unwrap(),
+            Name::new("something-else").unwrap(),
             simple_dns::CLASS::IN,
             30,
             RData::A(A {

--- a/pkarr/src/client/dht.rs
+++ b/pkarr/src/client/dht.rs
@@ -585,7 +585,7 @@ mod tests {
     use mainline::Testnet;
 
     use super::*;
-    use crate::{dns, Keypair, SignedPacket};
+    use crate::{Keypair, SignedPacket};
 
     #[test]
     fn shutdown_sync() {
@@ -612,15 +612,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        let mut packet = dns::Packet::new_reply(0);
-        packet.answers.push(dns::ResourceRecord::new(
-            dns::Name::new("foo").unwrap(),
-            dns::CLASS::IN,
-            30,
-            dns::rdata::RData::TXT("bar".try_into().unwrap()),
-        ));
-
-        let signed_packet = SignedPacket::from_packet(&keypair, &packet).unwrap();
+        let signed_packet = SignedPacket::builder()
+            .txt("foo".try_into().unwrap(), "bar".try_into().unwrap(), 30)
+            .sign(&keypair)
+            .unwrap();
 
         a.publish_sync(&signed_packet).unwrap();
 
@@ -642,15 +637,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        let mut packet = dns::Packet::new_reply(0);
-        packet.answers.push(dns::ResourceRecord::new(
-            dns::Name::new("foo").unwrap(),
-            dns::CLASS::IN,
-            30,
-            dns::rdata::RData::TXT("bar".try_into().unwrap()),
-        ));
-
-        let signed_packet = SignedPacket::from_packet(&keypair, &packet).unwrap();
+        let signed_packet = SignedPacket::builder()
+            .txt("foo".try_into().unwrap(), "bar".try_into().unwrap(), 30)
+            .sign(&keypair)
+            .unwrap();
 
         a.publish_sync(&signed_packet).unwrap();
 
@@ -689,15 +679,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        let mut packet = dns::Packet::new_reply(0);
-        packet.answers.push(dns::ResourceRecord::new(
-            dns::Name::new("foo").unwrap(),
-            dns::CLASS::IN,
-            30,
-            dns::rdata::RData::TXT("bar".try_into().unwrap()),
-        ));
-
-        let signed_packet = SignedPacket::from_packet(&keypair, &packet).unwrap();
+        let signed_packet = SignedPacket::builder()
+            .txt("foo".try_into().unwrap(), "bar".try_into().unwrap(), 30)
+            .sign(&keypair)
+            .unwrap();
 
         a.publish(&signed_packet).await.unwrap();
 
@@ -719,15 +704,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        let mut packet = dns::Packet::new_reply(0);
-        packet.answers.push(dns::ResourceRecord::new(
-            dns::Name::new("foo").unwrap(),
-            dns::CLASS::IN,
-            30,
-            dns::rdata::RData::TXT("bar".try_into().unwrap()),
-        ));
-
-        let signed_packet = SignedPacket::from_packet(&keypair, &packet).unwrap();
+        let signed_packet = SignedPacket::builder()
+            .txt("foo".try_into().unwrap(), "bar".try_into().unwrap(), 30)
+            .sign(&keypair)
+            .unwrap();
 
         a.publish(&signed_packet).await.unwrap();
 
@@ -760,8 +740,8 @@ mod tests {
             .unwrap();
 
         let keypair = Keypair::random();
-        let packet = dns::Packet::new_reply(0);
-        let signed_packet = SignedPacket::from_packet(&keypair, &packet).unwrap();
+
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
 
         client
             .cache()

--- a/pkarr/src/client/relay.rs
+++ b/pkarr/src/client/relay.rs
@@ -463,21 +463,16 @@ impl Display for EmptyListOfRelays {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{dns, Keypair, SignedPacket};
+    use crate::{Keypair, SignedPacket};
 
     #[tokio::test]
     async fn publish_resolve() {
         let keypair = Keypair::random();
 
-        let mut packet = dns::Packet::new_reply(0);
-        packet.answers.push(dns::ResourceRecord::new(
-            dns::Name::new("foo").unwrap(),
-            dns::CLASS::IN,
-            30,
-            dns::rdata::RData::TXT("bar".try_into().unwrap()),
-        ));
-
-        let signed_packet = SignedPacket::from_packet(&keypair, &packet).unwrap();
+        let signed_packet = SignedPacket::builder()
+            .txt("foo".try_into().unwrap(), "bar".try_into().unwrap(), 30)
+            .sign(&keypair)
+            .unwrap();
 
         let mut server = mockito::Server::new_async().await;
 
@@ -542,8 +537,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let packet = dns::Packet::new_reply(0);
-        let signed_packet = SignedPacket::from_packet(&keypair, &packet).unwrap();
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
 
         client
             .cache()


### PR DESCRIPTION
Add `SignedPacket::builder()` to replace `SignedPacket::from_packet()` as a more ergonomic API.