### PR TITLE
chore: add config.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 /result
 /.direnv
+config.toml


### PR DESCRIPTION
Add `config.toml` to `.gitignore` to prevent committing local configuration files. This ensures that sensitive configuration data and personal settings remain local and are not accidentally pushed to the repository.

The example configuration file (`config.example.toml`) will remain tracked to serve as a template for users.

Changes:
- Added `relay/config.toml` to .gitignore