### PR TITLE
fix(relay): remove rate limiting on random port test relay

### DIFF
--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -213,6 +213,7 @@ impl Relay {
         let mut config = Config {
             cache_path: None,
             http_port: 0,
+            rate_limiter: None,
             ..Default::default()
         };
 


### PR DESCRIPTION
This PR removes the rate limiter from the `run_test` ephemeral relay with random port.

Why? 
1. It feels the original intention of this function is to test relays that do not bind to 15411. In which case, the usefulness of these relays for testing is maximised if tests do not fail due to rate limiting.
2. This is needed to successfully run tests with our other crate https://github.com/pubky/pubky-core/tree/main/pubky-testnet
```rust
use pubky_testnet::Testnet;

#[tokio::main]
async fn main () {
  // Run a new testnet.
  let testnet = Testnet::run().await.unwrap();
}
```
Using `pubky-testnet` as is currently, pubky-nexus tests fail due to `429 Too Many Requests`

Alternatively:
1.  This has been attempted: we could use instead `pubky_testnet::Testnet::run_with_hardcoded_configurations()` that uses the builder to build a custom relay with disabled rate limiter. However, this means concurrent tests will fail starting up a pkarr relay that tries to bind to an occupied port. So this is not a solution.
2. We could also use `PkarrRelayBuilder` and create a relay with disabled rate limiter within `pubky_testnet::Testner::run()` instead of using the much more convenient `pkarr_relay::run_test()`. This is a valid solution. But seems to be less optimal that removing the rate limiter here, so we'll do that if there is some reason to keep the rate limiter in `pkarr_relay::run_test()`.

Overall, disabling the rate limiting here seems right as it might be a need for many other use cases of `pkarr_relay::run_test()` (except if testing the rate limiter is a thing!! in which case maybe it is best to use the pkarr-relay builder for that test?).
