### PR TITLE
feat: mvp for persistent cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1432,6 +1432,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1871,8 +1877,10 @@ dependencies = [
  "rustls-webpki",
  "self_cell",
  "serde",
+ "serde_json",
  "sha1_smol",
  "simple-dns",
+ "tempfile",
  "thiserror 2.0.11",
  "tokio",
  "tokio-rustls",
@@ -2328,7 +2336,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -2736,15 +2757,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -3296,7 +3316,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Where we are going, this [https://o4dksfbqk85ogzdb5osziw6befigbuxmuxkuxq8434q89u
 
 ## Demo 
 
-Try the [web app demo](https://app.pkarr.org)
+Try the [web ap demo](https://app.pkarr.org)
 Or if you prefer Rust, check out our [Examples](./pkarr/examples/README.md) 
  
 ## Architecture

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -36,6 +36,8 @@ url = { version = "2.5.4", optional = true }
 
 # feat: endpoints dependencies
 genawaiter = { version = "0.99.1", default-features = false, features = ["futures03"], optional = true }
+serde_json = "1.0.138"
+tempfile = "3.20.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 getrandom = { version = "0.2.15", default-features = false }

--- a/pkarr/src/client/cache.rs
+++ b/pkarr/src/client/cache.rs
@@ -1,10 +1,17 @@
 //! Trait and inmemory implementation of [Cache]
 
+use core::fmt;
 use dyn_clone::DynClone;
 use lru::LruCache;
 use std::fmt::Debug;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};
+
+use serde::{Deserialize, Serialize};
+use std::fs::{File, OpenOptions};
+use std::hash::{BuildHasher, Hash};
+use std::io::{Read, Write};
+use std::path::Path;
 
 use crate::SignedPacket;
 
@@ -126,4 +133,340 @@ impl Cache for InMemoryCache {
             .peek(key)
             .cloned()
     }
+}
+
+struct PersistentLruCache<K, V>
+where
+    K: Eq + std::hash::Hash + Serialize + for<'de> Deserialize<'de>,
+    V: Clone + Serialize + for<'de> Deserialize<'de>
+{
+    cache: LruCache<K, V>,
+    path: String,
+}
+
+impl<K: Hash + Eq + Serialize + for<'de> serde::Deserialize<'de>, V: Clone + Serialize + for<'de> serde::Deserialize<'de>> fmt::Debug for PersistentLruCache<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("LruCache")
+            .field("len", &self.cache.len())
+            .field("cap", &self.cache.cap())
+            .finish()
+    }
+}
+
+impl<K, V> PersistentLruCache<K, V>
+where
+    K: Eq + std::hash::Hash + Serialize + for<'de> Deserialize<'de> + Clone,
+    V: Clone + Serialize + for<'de> Deserialize<'de> + Clone
+{
+    // Create new cache or load from disk if file exists
+    pub fn new(capacity: NonZeroUsize, path: &str) -> Self {
+        let cache = if Path::new(path).exists() {
+            Self::load_from_disk(capacity, path).unwrap_or_else(|_| {
+                LruCache::new(capacity)
+            })
+        } else {
+            LruCache::new(capacity)
+        };
+
+        Self {
+            cache,
+            path: path.to_string(),
+        }
+    }
+
+    // Save current cache state to disk
+    pub fn save_to_disk(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let pairs: Vec<(K, V)> = self.cache
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        let serialized = serde_json::to_string(&pairs)?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&self.path)?;
+
+        file.write_all(serialized.as_bytes())?;
+        Ok(())
+    }
+
+    // Load cache from disk
+    fn load_from_disk(capacity: NonZeroUsize, path: &str) -> Result<LruCache<K, V>, Box<dyn std::error::Error>> {
+        let mut file = File::open(path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        let pairs: Vec<(K, V)> = serde_json::from_str(&contents)?;
+        let mut cache = LruCache::new(capacity);
+
+        for (k, v) in pairs {
+            cache.put(k, v);
+        }
+
+        Ok(cache)
+    }
+
+    // Delegate methods to the underlying LruCache
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        self.cache.get(key)
+    }
+
+    pub fn put(&mut self, key: K, value: V) -> Option<V> {
+        let result = self.cache.put(key, value);
+        // Optionally save to disk after each update
+        // self.save_to_disk().unwrap_or_else(|e| eprintln!("Error saving cache: {}", e));
+        result
+    }
+
+    // Add other methods you need...
+}
+
+#[derive(Debug, Clone)]
+pub struct PersistentMemoryCache {
+    inner: Arc<RwLock<PersistentLruCache<CacheKey, SignedPacket>>>,
+}
+
+impl PersistentMemoryCache {
+    /// Creates a new `LRU` cache that holds at most `cap` items.
+    pub fn new(capacity: NonZeroUsize, path: &str) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(PersistentLruCache::new(capacity, path))),
+        }
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroUsize;
+    use std::fs;
+    use tempfile::tempdir;
+    use serde::{Serialize, Deserialize};
+
+    // Test types that implement required traits
+    #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+    struct TestKey(String);
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct TestValue(i32);
+
+    // Helper function to create a temporary file path
+    fn temp_cache_path() -> (tempfile::TempDir, String) {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test_cache.json").to_string_lossy().to_string();
+        (dir, path)
+    }
+
+    #[test]
+    fn test_new_cache_creation() {
+        let (_temp_dir, path) = temp_cache_path();
+        let capacity = NonZeroUsize::new(5).unwrap();
+
+        // File should not exist yet
+        assert!(!Path::new(&path).exists());
+
+        let cache = PersistentLruCache::<TestKey, TestValue>::new(capacity, &path);
+
+        // Verify cache is empty initially
+        assert_eq!(cache.cache.len(), 0);
+        assert_eq!(cache.cache.cap().get(), 5);
+        assert_eq!(cache.path, path);
+
+        // File should still not exist until we save
+        assert!(!Path::new(&path).exists());
+
+        let result = cache.save_to_disk().expect("Should save cache");
+        assert!(Path::new(&path).exists());
+    }
+
+    /*
+    #[test]
+    fn test_put_and_get() {
+        let (_temp_dir, path) = temp_cache_path();
+        let capacity = NonZeroUsize::new(3).unwrap();
+        let mut cache = PersistentLruCache::new(capacity, &path);
+
+        let key1 = TestKey("key1".to_string());
+        let value1 = TestValue(42);
+
+        // Test putting a value
+        let old_value = cache.put(key1.clone(), value1.clone());
+        assert!(old_value.is_none());
+
+        // Test getting the value
+        let retrieved = cache.get(&key1);
+        assert_eq!(retrieved, Some(&value1));
+
+        // Test getting non-existent key
+        let non_existent = TestKey("missing".to_string());
+        assert!(cache.get(&non_existent).is_none());
+    }
+
+    #[test]
+    fn test_cache_capacity_enforcement() {
+        let (_temp_dir, path) = temp_cache_path();
+        let capacity = NonZeroUsize::new(2).unwrap();
+        let mut cache = PersistentLruCache::new(capacity, &path);
+
+        let key1 = TestKey("key1".to_string());
+        let key2 = TestKey("key2".to_string());
+        let key3 = TestKey("key3".to_string());
+
+        // Fill cache to capacity
+        cache.put(key1.clone(), TestValue(1));
+        cache.put(key2.clone(), TestValue(2));
+        assert_eq!(cache.cache.len(), 2);
+
+        // Adding third item should evict the first
+        cache.put(key3.clone(), TestValue(3));
+        assert_eq!(cache.cache.len(), 2);
+
+        // key1 should be evicted, key2 and key3 should remain
+        assert!(cache.get(&key1).is_none());
+        assert_eq!(cache.get(&key2), Some(&TestValue(2)));
+        assert_eq!(cache.get(&key3), Some(&TestValue(3)));
+    }
+
+    #[test]
+    fn test_save_to_disk() {
+        let (_temp_dir, path) = temp_cache_path();
+        let capacity = NonZeroUsize::new(3).unwrap();
+        let mut cache = PersistentLruCache::new(capacity, &path);
+
+        // Add some data
+        cache.put(TestKey("key1".to_string()), TestValue(10));
+        cache.put(TestKey("key2".to_string()), TestValue(20));
+
+        // Save to disk
+        let result = cache.save_to_disk();
+        assert!(result.is_ok());
+
+        // Verify file was created
+        assert!(std::path::Path::new(&path).exists());
+
+        // Clean up
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_load_from_disk() {
+        let (_temp_dir, path) = temp_cache_path();
+        let capacity = NonZeroUsize::new(3).unwrap();
+
+        // Create and populate first cache
+        {
+            let mut cache1 = PersistentLruCache::new(capacity, &path);
+            cache1.put(TestKey("persistent_key".to_string()), TestValue(100));
+            cache1.put(TestKey("another_key".to_string()), TestValue(200));
+            cache1.save_to_disk().unwrap();
+        }
+
+        // Create new cache that should load from disk
+        let mut cache2 = PersistentLruCache::new(capacity, &path);
+
+        // Verify data was loaded
+        assert_eq!(cache2.get(&TestKey("persistent_key".to_string())), Some(&TestValue(100)));
+        assert_eq!(cache2.get(&TestKey("another_key".to_string())), Some(&TestValue(200)));
+
+        // Clean up
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_debug_format() {
+        let (_temp_dir, path) = temp_cache_path();
+        let capacity = NonZeroUsize::new(2).unwrap();
+        let mut cache = PersistentLruCache::new(capacity, &path);
+
+        cache.put(TestKey("debug_key".to_string()), TestValue(42));
+
+        let debug_str = format!("{:?}", cache);
+        assert!(debug_str.contains("LruCache"));
+        assert!(debug_str.contains("len"));
+        assert!(debug_str.contains("cap"));
+    }
+
+    #[test]
+    fn test_persistent_memory_cache() {
+        let (_temp_dir, path) = temp_cache_path();
+        let capacity = NonZeroUsize::new(5).unwrap();
+
+        let cache = PersistentMemoryCache::new(capacity, &path);
+
+        // Verify it was created successfully
+        assert!(cache.inner.read().is_ok());
+
+        // Test basic thread safety by cloning
+        let cache_clone = cache.clone();
+        assert!(cache_clone.inner.read().is_ok());
+    }
+
+    #[test]
+    fn test_corrupted_cache_file_fallback() {
+        let (_temp_dir, path) = temp_cache_path();
+
+        // Create a corrupted cache file
+        fs::write(&path, "invalid json content").unwrap();
+
+        let capacity = NonZeroUsize::new(3).unwrap();
+        let cache = PersistentLruCache::<TestKey, TestValue>::new(capacity, &path);
+
+        // Should create empty cache when file is corrupted
+        assert_eq!(cache.cache.len(), 0);
+
+        // Clean up
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_lru_behavior() {
+        let (_temp_dir, path) = temp_cache_path();
+        let capacity = NonZeroUsize::new(2).unwrap();
+        let mut cache = PersistentLruCache::new(capacity, &path);
+
+        let key1 = TestKey("old".to_string());
+        let key2 = TestKey("new".to_string());
+        let key3 = TestKey("newest".to_string());
+
+        // Fill cache
+        cache.put(key1.clone(), TestValue(1));
+        cache.put(key2.clone(), TestValue(2));
+
+        // Access key1 to make it recently used
+        cache.get(&key1);
+
+        // Add key3 - should evict key2 (least recently used)
+        cache.put(key3.clone(), TestValue(3));
+
+        // key1 and key3 should remain, key2 should be evicted
+        assert_eq!(cache.get(&key1), Some(&TestValue(1)));
+        assert!(cache.get(&key2).is_none());
+        assert_eq!(cache.get(&key3), Some(&TestValue(3)));
+    }
+
+    #[test]
+    fn test_overwrite_existing_key() {
+        let (_temp_dir, path) = temp_cache_path();
+        let capacity = NonZeroUsize::new(3).unwrap();
+        let mut cache = PersistentLruCache::new(capacity, &path);
+
+        let key = TestKey("overwrite_test".to_string());
+
+        // Put initial value
+        let old_value = cache.put(key.clone(), TestValue(100));
+        assert!(old_value.is_none());
+
+        // Overwrite with new value
+        let old_value = cache.put(key.clone(), TestValue(200));
+        assert_eq!(old_value, Some(TestValue(100)));
+
+        // Verify new value
+        assert_eq!(cache.get(&key), Some(&TestValue(200)));
+        assert_eq!(cache.cache.len(), 1); // Should still be just one item
+    }
+    */
 }


### PR DESCRIPTION
I propose to evaluate an optional persistent cache for pkarr which may:

* increase reliability of the service when it works along with other components/microservices
* partially address the issue https://github.com/pubky/pkarr/issues/42 for which I could add a method/endpoint for getting currently cached records from the service. An external indexer could track changes in pkarr records. 

Let me know your thoughts on this @MiguelMedeiros @SHAcollision @SeverinAlexB.