### PR TITLE
fix: devShells now find openssl

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,9 @@
     flake-utils.lib.eachDefaultSystem (
       system:
       let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
         flakeboxLib = flakebox.lib.${system} {
           config = {
             github.ci.buildOutputs = [ ];
@@ -70,7 +73,12 @@
 
         legacyPackages = multiBuild;
 
-        devShells = flakeboxLib.mkShells { };
+        devShells = flakeboxLib.mkShells {
+          packages = [
+            pkgs.pkg-config
+            pkgs.openssl.dev
+          ];
+        };
       }
     );
 }


### PR DESCRIPTION
Super convenient that this library already has the flake for a devshell! However on NixOS its missing libssl. I added it along with pkg-config.