### PR TITLE
chore: Change web app demo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Where we are going, this [https://o4dksfbqk85ogzdb5osziw6befigbuxmuxkuxq8434q89u
 
 ## Demo 
 
-Try the [web app demo](https://app.pkarr.org)
+Try the [web app demo](https://pkdns.net)
 Or if you prefer Rust, check out our [Examples](./pkarr/examples/README.md) 
  
 ## Architecture


### PR DESCRIPTION
Changes the web app demo to pkdns.net