### PR TITLE
fix: make ClientBlocking Debug + Clone

### DIFF
--- a/pkarr/src/client/blocking.rs
+++ b/pkarr/src/client/blocking.rs
@@ -12,6 +12,7 @@ impl Client {
 }
 
 /// A blocking (synchronous) version of [Client].
+#[derive(Clone, Debug)]
 pub struct ClientBlocking(Client);
 
 impl ClientBlocking {


### PR DESCRIPTION
Increases parity between blocking and async apis.