### PR TITLE
chore: bump version to v3.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1608,38 +1608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkarr"
-version = "3.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a50f65a2b97031863fbdff2f085ba832360b4bef3106d1fcff9ab5bf4063fe"
-dependencies = [
- "async-compat",
- "base32",
- "byteorder",
- "bytes",
- "cfg_aliases",
- "document-features",
- "dyn-clone",
- "ed25519-dalek",
- "futures-lite",
- "getrandom 0.2.16",
- "heed",
- "log",
- "lru",
- "mainline",
- "ntimestamp",
- "page_size",
- "self_cell",
- "serde",
- "sha1_smol",
- "simple-dns",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "pkarr-js"
 version = "3.8.0"
 dependencies = [
@@ -1650,7 +1618,7 @@ dependencies = [
  "getrandom 0.2.16",
  "js-sys",
  "ntimestamp",
- "pkarr 3.8.0",
+ "pkarr",
  "simple-dns",
  "thiserror 2.0.12",
  "url",
@@ -1661,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1672,7 +1640,7 @@ dependencies = [
  "governor",
  "http",
  "httpdate",
- "pkarr 3.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkarr",
  "rustls",
  "serde",
  "thiserror 2.0.12",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "pkarr"
-version = "3.8.0"
-authors = ["Nuh <nuh@nuh.dev>"]
+version = "3.9.0"
+authors = [
+  "Nuh <nuh@nuh.dev>",
+  "SeverinAlexB <severin@synonym.to>",
+  "SHAcollision <shacollision@synonym.to>",
+]
 edition = "2021"
 description = "Public-Key Addressable Resource Records (Pkarr); publish and resolve DNS records over Mainline DHT"
 homepage = "https://pkarr.org"
@@ -25,7 +29,9 @@ self_cell = { version = "1.1.0", optional = true }
 ntimestamp = { version = "1.0.0", features = ["full"], optional = true }
 
 #feat: client dependencies
-futures-lite = { version = "2.6.0", default-features = false, optional = true , features =["std"]}
+futures-lite = { version = "2.6.0", default-features = false, optional = true, features = [
+  "std",
+] }
 futures-buffered = { version = "0.2.9", optional = true }
 dyn-clone = { version = "1.0.18", optional = true }
 lru = { version = "0.13.0", default-features = false, optional = true }
@@ -35,7 +41,9 @@ sha1_smol = { version = "1.0.1", optional = true }
 url = { version = "2.5.4", optional = true }
 
 # feat: endpoints dependencies
-genawaiter = { version = "0.99.1", default-features = false, features = ["futures03"], optional = true }
+genawaiter = { version = "0.99.1", default-features = false, features = [
+  "futures03",
+], optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 getrandom = { version = "0.2.15", default-features = false }
@@ -64,7 +72,7 @@ webpki = { package = "rustls-webpki", version = "0.102", optional = true }
 getrandom = { version = "0.2.15", default-features = false, features = ["js"] }
 
 #feat: client dependencies
-log = { version = "0.4.25", optional = true}
+log = { version = "0.4.25", optional = true }
 wasm-bindgen-futures = { version = "0.4.50", optional = true }
 
 # feat: relay dependencies
@@ -97,7 +105,13 @@ cfg_aliases = "0.2.1"
 [features]
 # Basic types
 keys = []
-signed_packet = ["keys", "dep:simple-dns", "dep:ntimestamp", "dep:bytes", 'dep:self_cell']
+signed_packet = [
+  "keys",
+  "dep:simple-dns",
+  "dep:ntimestamp",
+  "dep:bytes",
+  'dep:self_cell',
+]
 
 # Clients 
 ## Enable the [Client] with [mainline] support.
@@ -143,8 +157,16 @@ default = ["full-client"]
 ##
 ## Except in WASM where you have to enable `relays`, while `dht` does not do anything.
 __client = [
-  "signed_packet", "dep:dyn-clone", "dep:lru", "dep:sha1_smol", "dep:futures-lite", "dep:async-compat", "dep:tokio",
-  "dep:log", "dep:tracing", "dep:wasm-bindgen-futures", 
+  "signed_packet",
+  "dep:dyn-clone",
+  "dep:lru",
+  "dep:sha1_smol",
+  "dep:futures-lite",
+  "dep:async-compat",
+  "dep:tokio",
+  "dep:log",
+  "dep:tracing",
+  "dep:wasm-bindgen-futures",
 ]
 
 [package.metadata.docs.rs]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "pkarr-relay"
-version = "0.10.0"
-authors = ["Nuh <nuh@nuh.dev>"]
+version = "0.11.0"
+authors = [
+    "Nuh <nuh@nuh.dev>",
+    "SeverinAlexB <severin@synonym.to>",
+    "SHAcollision <shacollision@synonym.to>",
+]
 edition = "2021"
-description = "Pkarr relay (https://pkarr.org/relays)"
+description = "Pkarr relay (https://github.com/pubky/pkarr/blob/main/design/relays.md)"
 license = "MIT"
-homepage = "https://pkarr.org"
-repository = "https://git.pkarr.org"
+homepage = "https://pkdns.net"
+repository = "https://github.com/pubky/pkarr"
 keywords = ["pkarr", "relay", "mainline", "dht"]
 categories = ["network-programming"]
 
@@ -32,7 +36,10 @@ clap = { version = "4.5.28", features = ["derive"] }
 dirs-next = "2.0.0"
 httpdate = "1.0.3"
 url = "2.5.4"
-pkarr = { version = "3.8.0", default-features = false, features = ["dht", "lmdb-cache"] }
+pkarr = { path = "../pkarr", version = "3.9.0", default-features = false, features = [
+    "dht",
+    "lmdb-cache",
+] }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
There are no breaking changes.

## Changes:
- Change of homepage and repo links.
- Added more authors on author list.
- New minor version (no breaking changes). From now on ALL versions published to crates.io SHOULD always have a tag and release in `pubky/pkarr` repository.