### PR TITLE
chore(release): bump to v3.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,7 +1577,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "3.9.1"
+version = "3.10.0"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr"
-version = "3.9.1"
+version = "3.10.0"
 authors = [
   "Nuh <nuh@nuh.dev>",
   "SeverinAlexB <severin@synonym.to>",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -36,7 +36,7 @@ clap = { version = "4.5.28", features = ["derive"] }
 dirs-next = "2.0.0"
 httpdate = "1.0.3"
 url = "2.5.4"
-pkarr = { path = "../pkarr", version = "3.9.1", default-features = false, features = [
+pkarr = { path = "../pkarr", version = "3.10.0", default-features = false, features = [
     "dht",
     "lmdb-cache",
 ] }


### PR DESCRIPTION
New release with FS functionality in use in PRs https://github.com/pubky/pubky-core/pull/196 and https://github.com/pubky/pubky-nexus/pull/503