### PR TITLE
chore: cargo deny

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -21,7 +21,7 @@ jobs:
       with:
         profile: minimal
         toolchain: stable
-        components: rustfmt, clippy
+        components: rustfmt, clippy, deny
         override: true
 
     - name: Cache cargo registry
@@ -69,6 +69,9 @@ jobs:
 
     - name: Lint with Clippy
       run: cargo clippy --workspace --all-features --bins --tests
+
+    - name: cargo deny
+      run: cargo deny check sources licenses advisories
 
     - name: Build
       if: steps.cargo-build-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -21,8 +21,11 @@ jobs:
       with:
         profile: minimal
         toolchain: stable
-        components: rustfmt, clippy, deny
+        components: rustfmt, clippy
         override: true
+
+    - name: Install cargo-deny
+      run: cargo install cargo-deny
 
     - name: Cache cargo registry
       uses: actions/cache@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,9 +330,12 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cobs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.12",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1688,9 +1691,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "postcard"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
 dependencies = [
  "cobs",
  "embedded-io 0.4.0",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,30 @@
+# Detects dependency and licenses issues
+#
+# https://github.com/EmbarkStudios/cargo-deny
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+# https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.template.toml
+#
+# Install locally: cargo install --locked cargo-deny
+# Run locally: cargo deny check advisories licenses sources
+
+[graph]
+all-features = true
+
+[advisories]
+ignore = [
+    "RUSTSEC-2023-0089" # Tracked here https://github.com/pubky/pkarr/issues/177. No upgrade available yet.
+]
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Zlib",
+    "Unicode-3.0",
+    "ISC",
+    "CDLA-Permissive-2.0",
+    "Unlicense"
+]


### PR DESCRIPTION
Adds [cargo deny](https://github.com/EmbarkStudios/cargo-deny) to the CI.
- Checks if any dependency has a unwanted license.
- Check for security advisories from https://rustsec.org/advisories/ like https://github.com/pubky/pkarr/issues/177