### PR TITLE
fix: Dockerfile build pkarr-relay without js bindings

### DIFF
--- a/.github/workflows/js-binding.yaml
+++ b/.github/workflows/js-binding.yaml
@@ -31,6 +31,9 @@ jobs:
       with:
         node-version: '22.13.0'
 
+    - name: Update dependencies
+      run: cargo update
+
     - name: Build server
       run: cargo build
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -73,6 +73,9 @@ jobs:
     - name: Lint with Clippy
       run: cargo clippy --workspace --all-features --bins --tests
 
+    - name: Update dependencies
+      run: cargo update
+
     - name: cargo deny
       run: cargo deny check sources licenses advisories
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ COPY Cargo.toml Cargo.lock ./
 # Copy over all the source code
 COPY . .
 
-# Build the project in release mode for the MUSL target
-RUN cargo build --release --target $TARGETARCH-unknown-linux-musl
+# Build only the relay crate in release mode for the MUSL target
+RUN cargo build --release --target $TARGETARCH-unknown-linux-musl -p pkarr-relay
 
 # Strip the binary to reduce size
 RUN strip target/$TARGETARCH-unknown-linux-musl/release/pkarr-relay


### PR DESCRIPTION
The Dockerfile is currently failing to build on Silicon Macs with error 
> ...not produce cdylib for `pkarr-js v3.8.0 (/usr/src/app/bindings/js)` as the target `aarch64-unknown-linux-musl`  does not support these crate types

This change ensures only the pkarr-relay is built for Docker image.