### PR TITLE
feat: Improve multi arch builds for pkarr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM rust:1.86.0-alpine3.20 AS builder
 
 # Build platform argument (x86_64 or aarch64) (default: x86_64)
-ARG TARGETARCH=x86_64
+ARG TARGETARCH
 RUN echo "TARGETARCH: $TARGETARCH"
 
 # Install build dependencies
@@ -15,7 +15,7 @@ RUN apk add --no-cache \
     curl
 
 # Install cross-compiler toolchain only for ARM (Apple Silicon)
-RUN if [ "$TARGETARCH" = "aarch64" ]; then \
+RUN if [ "$TARGETARCH" =~ ".*arm64.*" ]; then \
         wget -qO- https://musl.cc/aarch64-linux-musl-cross.tgz | tar -xz -C /usr/local && \
         echo "/usr/local/aarch64-linux-musl-cross/bin" > /tmp/musl_cross_path; \
     else \
@@ -24,9 +24,6 @@ RUN if [ "$TARGETARCH" = "aarch64" ]; then \
 
 # Set PATH only if we installed the cross compiler (will be empty string for x86)
 ENV PATH="$(cat /tmp/musl_cross_path):$PATH"
-
-# Add the MUSL target for static linking
-RUN rustup target add $TARGETARCH-unknown-linux-musl
 
 # Set the working directory
 WORKDIR /usr/src/app
@@ -38,24 +35,21 @@ COPY Cargo.toml Cargo.lock ./
 COPY . .
 
 # Build only the relay crate in release mode for the MUSL target
-RUN cargo build --release --target $TARGETARCH-unknown-linux-musl -p pkarr-relay
+RUN cargo build --release -p pkarr-relay
 
 # Strip the binary to reduce size
-RUN strip target/$TARGETARCH-unknown-linux-musl/release/pkarr-relay
+RUN strip target/release/pkarr-relay
 
 # ========================
 # Runtime Stage
 # ========================
 FROM alpine:3.20
 
-ARG TARGETARCH=x86_64
-RUN echo "TARGETARCH: $TARGETARCH"
-
 # Install runtime dependencies (only ca-certificates)
 RUN apk add --no-cache ca-certificates
 
 # Copy the compiled binary from the builder stage
-COPY --from=builder /usr/src/app/target/$TARGETARCH-unknown-linux-musl/release/pkarr-relay /usr/local/bin/pkarr-relay
+COPY --from=builder /usr/src/app/target/release/pkarr-relay /usr/local/bin/pkarr-relay
 
 # Set the working directory
 WORKDIR /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,6 @@ RUN apk add --no-cache \
     build-base \
     curl
 
-# Install cross-compiler toolchain only for ARM (Apple Silicon)
-RUN if [ "$TARGETARCH" =~ ".*arm64.*" ]; then \
-        wget -qO- https://musl.cc/aarch64-linux-musl-cross.tgz | tar -xz -C /usr/local && \
-        echo "/usr/local/aarch64-linux-musl-cross/bin" > /tmp/musl_cross_path; \
-    else \
-        echo "" > /tmp/musl_cross_path; \
-    fi
-
 # Set PATH only if we installed the cross compiler (will be empty string for x86)
 ENV PATH="$(cat /tmp/musl_cross_path):$PATH"
 


### PR DESCRIPTION
currently the build arg `TARGETARCH=aarch64` should be provided in order to build image for m1 macs.  
by default the build arg `TARGETARCH` exists, but for m1 macs it's equal `arm64`
I have tested this PR on m1 mac and x86_64 linux machine and it's working. 