### PR TITLE
fix: remove cargo update step

### DIFF
--- a/.github/workflows/js-binding.yaml
+++ b/.github/workflows/js-binding.yaml
@@ -31,9 +31,6 @@ jobs:
       with:
         node-version: '22.13.0'
 
-    - name: Update dependencies
-      run: cargo update
-
     - name: Build server
       run: cargo build
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -61,7 +61,7 @@ jobs:
     - name: Install Nextest if not cached
       run: |
         if [ ! -f ~/.cargo/bin/cargo-nextest ]; then
-          cargo install cargo-nextest
+          cargo install cargo-nextest@0.9.111
         fi
 
     - name: Check no default features
@@ -72,9 +72,6 @@ jobs:
 
     - name: Lint with Clippy
       run: cargo clippy --workspace --all-features --bins --tests
-
-    - name: Update dependencies
-      run: cargo update
 
     - name: cargo deny
       run: cargo deny check sources licenses advisories


### PR DESCRIPTION
The pipeline failed for https://github.com/pubky/pkarr/commit/887a20d1e5bd7e8f21dea5f3381942a30335ba7c
The changes haven't affected any code
the PRs pipelines were successful https://github.com/pubky/pkarr/pull/195

The deletion of `cargo update` fixes the build stage. Also pinned the version for `cargo-nextest`