### PR TITLE
fix: unmantained rustls-pemfile deny CI failure. patch version bump.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,12 +178,13 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http",
  "http-body",
@@ -191,7 +192,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -582,6 +582,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedded-io"
@@ -1009,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1049,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
@@ -2071,15 +2077,6 @@ dependencies = [
  "rustls-webpki 0.103.6",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -93,7 +93,7 @@ mainline = "6.0.1"
 tempfile = "3.20"
 tokio-rustls = { version = "0.26.1", default-features = false }
 axum = "0.8.1"
-axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
+axum-server = { version = "0.8", features = ["tls-rustls-no-provider"] }
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 
 [target.wasm32-unknown-unknown.dev-dependencies]

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "pkarr"
-version = "5.0.1"
+version = "5.0.2"
 authors = [
   "Nuh <nuh@nuh.dev>",
   "SeverinAlexB <severin@synonym.to>",
   "SHAcollision <shacollision@synonym.to>",
-  "dzdidi <denys@synonym.to>"
+  "dzdidi <denys@synonym.to>",
 ]
 edition = "2021"
 description = "Public-Key Addressable Resource Records (Pkarr); publish and resolve DNS records over Mainline DHT"
@@ -70,7 +70,9 @@ rustls = { workspace = true, optional = true }
 webpki = { package = "rustls-webpki", version = "0.102", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.3", default-features = false, features = ["wasm_js"] }
+getrandom = { version = "0.3", default-features = false, features = [
+  "wasm_js",
+] }
 
 #feat: client dependencies
 log = { version = "0.4.25", optional = true }

--- a/pkarr/examples/http-get.rs
+++ b/pkarr/examples/http-get.rs
@@ -2,7 +2,6 @@
 
 use reqwest::Method;
 use tracing::Level;
-use tracing_subscriber;
 
 use clap::Parser;
 

--- a/pkarr/examples/http-serve.rs
+++ b/pkarr/examples/http-serve.rs
@@ -54,7 +54,7 @@ async fn main() -> anyhow::Result<()> {
     let server = axum_server::bind_rustls(
         addr,
         RustlsConfig::from_config(Arc::new(keypair.to_rpk_rustls_server_config())),
-    );
+    )?;
 
     let app = Router::new().route("/", get(|| async { "Hello, world!" }));
     server.serve(app.into_make_service()).await?;

--- a/pkarr/examples/http-serve.rs
+++ b/pkarr/examples/http-serve.rs
@@ -3,11 +3,9 @@
 //! This server will _not_ be accessible from other networks
 //! unless the provided IP is public and the port number is forwarded.
 
-use tracing::Level;
-use tracing_subscriber;
-
 use axum::{routing::get, Router};
 use axum_server::tls_rustls::RustlsConfig;
+use tracing::Level;
 
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
@@ -54,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
     let server = axum_server::bind_rustls(
         addr,
         RustlsConfig::from_config(Arc::new(keypair.to_rpk_rustls_server_config())),
-    )?;
+    );
 
     let app = Router::new().route("/", get(|| async { "Hello, world!" }));
     server.serve(app.into_make_service()).await?;
@@ -73,7 +71,7 @@ async fn publish_server_pkarr(
     let signed_packet = SignedPacket::builder()
         .https(".".try_into().unwrap(), svcb, 60 * 60)
         .address(".".try_into().unwrap(), socket_addr.ip(), 60 * 60)
-        .sign(&keypair)?;
+        .sign(keypair)?;
 
     client.publish(&signed_packet, None).await?;
 

--- a/pkarr/examples/publish.rs
+++ b/pkarr/examples/publish.rs
@@ -7,10 +7,9 @@
 //!     $ cargo run --example publish
 
 use clap::{Parser, ValueEnum};
+use pkarr::{Client, Keypair, SignedPacket};
 use std::time::Instant;
 use tracing_subscriber;
-
-use pkarr::{Client, Keypair, SignedPacket};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/pkarr/examples/publish.rs
+++ b/pkarr/examples/publish.rs
@@ -9,7 +9,6 @@
 use clap::{Parser, ValueEnum};
 use pkarr::{Client, Keypair, SignedPacket};
 use std::time::Instant;
-use tracing_subscriber;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/pkarr/examples/resolve.rs
+++ b/pkarr/examples/resolve.rs
@@ -4,10 +4,9 @@
 //!     $ cargo run --example resolve <zbase32 encoded key>
 
 use clap::{Parser, ValueEnum};
+use pkarr::{Client, PublicKey};
 use std::time::Instant;
 use tracing_subscriber;
-
-use pkarr::{Client, PublicKey};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/pkarr/examples/resolve.rs
+++ b/pkarr/examples/resolve.rs
@@ -6,7 +6,6 @@
 use clap::{Parser, ValueEnum};
 use pkarr::{Client, PublicKey};
 use std::time::Instant;
-use tracing_subscriber;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/pkarr/src/client/tests.rs
+++ b/pkarr/src/client/tests.rs
@@ -792,6 +792,7 @@ mod reqwest_builder {
             // Run a server on Pkarr
             let app = Router::new().route("/", get(|| async { "Hello, world!" }));
             let listener = TcpListener::bind("127.0.0.1:0").unwrap(); // Bind to any available port
+            listener.set_nonblocking(true).unwrap();
             let address = listener.local_addr().unwrap();
 
             let client = builder(&relay, &testnet, networks).build().unwrap();

--- a/pkarr/src/client/tests.rs
+++ b/pkarr/src/client/tests.rs
@@ -802,7 +802,8 @@ mod reqwest_builder {
             let server = axum_server::from_tcp_rustls(
                 listener,
                 RustlsConfig::from_config(Arc::new((&keypair).into())),
-            );
+            )
+            .unwrap();
 
             tokio::spawn(server.serve(app.into_make_service()));
         }

--- a/pkarr/src/extra/lmdb_cache.rs
+++ b/pkarr/src/extra/lmdb_cache.rs
@@ -36,7 +36,7 @@ pub struct CacheKeyCodec;
 impl BytesEncode<'_> for CacheKeyCodec {
     type EItem = CacheKey;
 
-    fn bytes_encode(key: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
+    fn bytes_encode(key: &Self::EItem) -> Result<Cow<'_, [u8]>, BoxedError> {
         Ok(Cow::Owned(key.to_vec()))
     }
 }
@@ -53,7 +53,7 @@ impl<'a> BytesDecode<'a> for CacheKeyCodec {
 impl BytesEncode<'_> for SignedPacket {
     type EItem = SignedPacket;
 
-    fn bytes_encode(signed_packet: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
+    fn bytes_encode(signed_packet: &Self::EItem) -> Result<Cow<'_, [u8]>, BoxedError> {
         Ok(Cow::Owned(signed_packet.serialize().to_vec()))
     }
 }

--- a/pkarr/src/signed_packet.rs
+++ b/pkarr/src/signed_packet.rs
@@ -381,7 +381,7 @@ impl SignedPacket {
     }
 
     /// Return the DNS [Packet].
-    pub(crate) fn packet(&self) -> &Packet {
+    pub(crate) fn packet(&self) -> &Packet<'_> {
         self.inner.borrow_dependent()
     }
 
@@ -431,7 +431,7 @@ impl SignedPacket {
     /// You can use `@` to filter the resource records at the Apex (the public key).
     ///
     /// Wildcards are also supported, so `*.foo.<key>` will match `bar.foo.<key>`.
-    pub fn resource_records(&self, name: &str) -> impl Iterator<Item = &ResourceRecord> {
+    pub fn resource_records(&self, name: &str) -> impl Iterator<Item = &ResourceRecord<'_>> {
         let origin = self.public_key().to_z32();
         let normalized_name = normalize_name(&origin, name.to_string());
         let is_wildcard = normalized_name.starts_with('*');
@@ -451,13 +451,13 @@ impl SignedPacket {
 
     /// Similar to [resource_records](SignedPacket::resource_records), but filters out
     /// expired records, according the the [Self::last_seen] value and each record's `ttl`.
-    pub fn fresh_resource_records(&self, name: &str) -> impl Iterator<Item = &ResourceRecord> {
+    pub fn fresh_resource_records(&self, name: &str) -> impl Iterator<Item = &ResourceRecord<'_>> {
         self.resource_records(name)
             .filter(move |rr| rr.ttl > self.elapsed())
     }
 
     /// Returns all resource records in this packet
-    pub fn all_resource_records(&self) -> impl Iterator<Item = &ResourceRecord> {
+    pub fn all_resource_records(&self) -> impl Iterator<Item = &ResourceRecord<'_>> {
         self.packet().answers.iter()
     }
 

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.43.0", features = ["full"] }
 tower-http = { version = "0.6.2", features = ["cors", "trace"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
+axum-server = { version = "0.8", features = ["tls-rustls-no-provider"] }
 rustls = { workspace = true }
 http = "1.2.0"
 thiserror = "2.0.11"

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr-relay"
-version = "0.11.2"
+version = "0.11.3"
 authors = [
     "Nuh <nuh@nuh.dev>",
     "SeverinAlexB <severin@synonym.to>",

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -157,6 +157,8 @@ impl Relay {
         let client = config.pkarr.build()?;
 
         let listener = TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], config.http_port)))?;
+        // On axum-server 0.8.0 the `.set_nonblocking(true)` call does not take place internally anymore
+        // See open issue https://github.com/programatik29/axum-server/issues/181
         listener.set_nonblocking(true)?;
 
         let node_address = client

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -107,7 +107,7 @@ impl RelayBuilder {
 /// This struct represents a running relay server and provides methods to interact with it,
 /// such as retrieving the server's address or shutting it down.
 pub struct Relay {
-    handle: Handle,
+    handle: Handle<SocketAddr>,
     relay_address: SocketAddr,
 }
 
@@ -157,6 +157,7 @@ impl Relay {
         let client = config.pkarr.build()?;
 
         let listener = TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], config.http_port)))?;
+        listener.set_nonblocking(true)?;
 
         let node_address = client
             .dht()
@@ -173,7 +174,7 @@ impl Relay {
 
         let handle = Handle::new();
 
-        let task = axum_server::from_tcp(listener)
+        let task = axum_server::from_tcp(listener)?
             .handle(handle.clone())
             .serve(app.into_make_service_with_connect_info::<SocketAddr>());
 


### PR DESCRIPTION
**WIP**
- Upgraded `axum-server` to 0.8 in the relay crate and pkarr dev-dependencies to drop the unmaintained `rustls-pemfile` chain.
- Updated for the new server behavior.
- Bumped `pkarr` and `pkarr-relay` patch versions for a new release.