### PR TITLE
feat!: Bump `simple-dns` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,9 +2300,9 @@ checksum = "fc280a6ff65c79fbd6622f64d7127f32b85563bca8c53cd2e9141d6744a9056d"
 
 [[package]]
 name = "simple-dns"
-version = "0.9.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
+checksum = "df350943049174c4ae8ced56c604e28270258faec12a6a48637a7655287c9ce0"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ name = "pkarr"
 [workspace.dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
-simple-dns = "0.9.3"
+simple-dns = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ name = "pkarr"
 [workspace.dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+simple-dns = "0.9.3"

--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -26,7 +26,7 @@ console_error_panic_hook = "0.1.7"
 wasm-bindgen-futures = "0.4.50"
 
 # Dependencies needed by the WASM bindings
-simple-dns = { version = "0.9.3" }
+simple-dns = { workspace = true }
 ntimestamp = { version = "1.0.0", features = ["full"] }
 thiserror = "2.0.11"
 url = { version = "2.5.4" }

--- a/bindings/js/src/dns/svcb/input.rs
+++ b/bindings/js/src/dns/svcb/input.rs
@@ -89,19 +89,17 @@ fn set_alpn_protocols(svcb: &mut SVCB, protocol_strings: Vec<String>) -> Result<
         }
     }
 
-    // Then convert to CharacterString and set on SVCB
-    let protocols: Result<Vec<simple_dns::CharacterString>, _> = protocol_strings
-        .iter()
-        .map(|s| s.as_str().try_into())
-        .collect();
+    // Then convert to owned CharacterStrings using TryFrom<String>
+    let protocols: Result<Vec<simple_dns::CharacterString>, _> =
+        protocol_strings.into_iter().map(|s| s.try_into()).collect();
 
     match protocols {
-        Ok(alpn_list) => svcb
-            .set_alpn(alpn_list)
-            .map_err(|e| JsValue::from_str(&format!("Failed to set ALPN parameter: {}", e))),
+        Ok(alpn_list) => {
+            svcb.set_alpn(&alpn_list);
+            Ok(())
+        }
         Err(e) => Err(JsValue::from_str(&format!(
-            "Invalid ALPN protocol format: {}",
-            e
+            "Invalid ALPN protocol format: {e}"
         ))),
     }
 }
@@ -148,8 +146,8 @@ fn set_ipv4hint_from_js(svcb: &mut SVCB, value_js: &JsValue) -> Result<(), JsVal
         },
     )?;
 
-    svcb.set_ipv4hint(addrs)
-        .map_err(|e| JsValue::from_str(&format!("Failed to set IPv4hint parameter: {}", e)))
+    svcb.set_ipv4hint(&addrs);
+    Ok(())
 }
 
 /// Set IPv6 address hints from JavaScript value (string, array, or Uint8Array)
@@ -167,8 +165,8 @@ fn set_ipv6hint_from_js(svcb: &mut SVCB, value_js: &JsValue) -> Result<(), JsVal
         },
     )?;
 
-    svcb.set_ipv6hint(addrs)
-        .map_err(|e| JsValue::from_str(&format!("Failed to set IPv6hint parameter: {}", e)))
+    svcb.set_ipv6hint(&addrs);
+    Ok(())
 }
 
 /// Generic helper function for parsing IP address hints (IPv4 or IPv6)

--- a/bindings/js/src/dns/svcb/output.rs
+++ b/bindings/js/src/dns/svcb/output.rs
@@ -54,10 +54,7 @@ fn parse_param_value_from_param(param: &SVCParam) -> String {
         SVCParam::Port(port) => port.to_string(),
         SVCParam::Ipv4Hint(ips) => ips
             .iter()
-            .map(|&ip| {
-                let bytes = ip.to_be_bytes();
-                format!("{}.{}.{}.{}", bytes[0], bytes[1], bytes[2], bytes[3])
-            })
+            .map(|&ip| std::net::Ipv4Addr::from(ip).to_string())
             .collect::<Vec<_>>()
             .join(","),
         SVCParam::Ipv6Hint(ips) => ips

--- a/bindings/js/src/dns/svcb/output.rs
+++ b/bindings/js/src/dns/svcb/output.rs
@@ -2,17 +2,18 @@
 
 use super::constants::*;
 use super::utils::bytes_to_hex;
-use simple_dns::rdata::SVCB;
+use simple_dns::rdata::{SVCParam, SVCB};
 use wasm_bindgen::JsValue;
 
 /// Convert SVCB parameters to JavaScript object with descriptive keys and parsed values
 pub fn to_js_object(svcb: &SVCB) -> Result<js_sys::Object, JsValue> {
     let params_obj = js_sys::Object::new();
 
-    for (key, value) in svcb.iter_params() {
+    for param in svcb.iter_params() {
+        let key = param.key_code();
         if is_known_param(key) {
             let key_name = param_key_to_name(key);
-            let parsed_value = parse_param_value(key, value);
+            let parsed_value = parse_param_value_from_param(param);
             js_sys::Reflect::set(
                 &params_obj,
                 &JsValue::from_str(key_name),
@@ -21,7 +22,10 @@ pub fn to_js_object(svcb: &SVCB) -> Result<js_sys::Object, JsValue> {
         } else {
             // For unknown parameters, use the format "param{number}" with hex values
             let unknown_key = format!("param{}", key);
-            let hex_value = bytes_to_hex(value);
+            let hex_value = match param {
+                SVCParam::Unknown(_, data) => bytes_to_hex(data.as_ref()),
+                _ => bytes_to_hex(&[]), // This shouldn't happen for truly unknown params
+            };
             js_sys::Reflect::set(
                 &params_obj,
                 &JsValue::from_str(&unknown_key),
@@ -33,73 +37,36 @@ pub fn to_js_object(svcb: &SVCB) -> Result<js_sys::Object, JsValue> {
     Ok(params_obj)
 }
 
-/// Parse parameter value based on its type
-fn parse_param_value(key: u16, value: &[u8]) -> String {
-    match key {
-        PARAM_ALPN => parse_alpn_param(value),
-        PARAM_PORT => parse_port_param(value),
-        PARAM_IPV4HINT => parse_ip_hint_param(value, 4, "ipv4hint", |chunk| {
-            format!("{}.{}.{}.{}", chunk[0], chunk[1], chunk[2], chunk[3])
-        }),
-        PARAM_IPV6HINT => parse_ip_hint_param(value, 16, "ipv6hint", |chunk| {
-            let mut addr_bytes = [0u8; 16];
-            addr_bytes.copy_from_slice(chunk);
-            std::net::Ipv6Addr::from(addr_bytes).to_string()
-        }),
-        _ => bytes_to_hex(value),
+/// Parse parameter value from SVCParam
+fn parse_param_value_from_param(param: &SVCParam) -> String {
+    match param {
+        SVCParam::Alpn(alpns) => alpns
+            .iter()
+            .map(|cs| cs.to_string())
+            .collect::<Vec<_>>()
+            .join(","),
+        SVCParam::Port(port) => port.to_string(),
+        SVCParam::Ipv4Hint(ips) => ips
+            .iter()
+            .map(|&ip| {
+                let bytes = ip.to_be_bytes();
+                format!("{}.{}.{}.{}", bytes[0], bytes[1], bytes[2], bytes[3])
+            })
+            .collect::<Vec<_>>()
+            .join(","),
+        SVCParam::Ipv6Hint(ips) => ips
+            .iter()
+            .map(|&ip| std::net::Ipv6Addr::from(ip).to_string())
+            .collect::<Vec<_>>()
+            .join(","),
+        SVCParam::NoDefaultAlpn => String::new(),
+        SVCParam::Ech(data) => bytes_to_hex(data.as_ref()),
+        SVCParam::Mandatory(keys) => keys
+            .iter()
+            .map(|k| k.to_string())
+            .collect::<Vec<_>>()
+            .join(","),
+        SVCParam::Unknown(_, data) => bytes_to_hex(data.as_ref()),
+        SVCParam::InvalidKey => String::from("invalid_key"),
     }
-}
-
-/// Parse ALPN parameter to comma-separated protocol list
-/// Format: [length1][protocol1_bytes][length2][protocol2_bytes]...
-fn parse_alpn_param(value: &[u8]) -> String {
-    let mut protocols = Vec::new();
-    let mut offset = 0;
-
-    while offset < value.len() {
-        if let Some(&len) = value.get(offset) {
-            offset += 1;
-            if offset + len as usize <= value.len() {
-                // Convert bytes to string
-                let protocol_bytes = &value[offset..offset + len as usize];
-                let protocol = String::from_utf8_lossy(protocol_bytes);
-                protocols.push(protocol.to_string());
-                offset += len as usize;
-            } else {
-                break;
-            }
-        } else {
-            break;
-        }
-    }
-
-    protocols.join(",")
-}
-
-/// Parse PORT parameter to port number string
-fn parse_port_param(value: &[u8]) -> String {
-    if value.len() == 2 {
-        let port = u16::from_be_bytes([value[0], value[1]]);
-        port.to_string()
-    } else {
-        format!("invalid_port_({}_bytes)", value.len())
-    }
-}
-
-/// Generic function to parse IP address hints (IPv4 or IPv6)
-fn parse_ip_hint_param(
-    value: &[u8],
-    bytes_per_addr: usize,
-    hint_type: &str,
-    format_addr: impl Fn(&[u8]) -> String,
-) -> String {
-    if value.len() % bytes_per_addr != 0 {
-        return format!("invalid_{}_({}_bytes)", hint_type, value.len());
-    }
-
-    value
-        .chunks(bytes_per_addr)
-        .map(format_addr)
-        .collect::<Vec<_>>()
-        .join(",")
 }

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.217", features = ["derive"] }
 document-features = "0.2.10"
 
 #feat: signed_packet dependencies
-simple-dns = { version = "0.9.3", optional = true }
+simple-dns = { workspace = true, optional = true }
 bytes = { version = "1.10.0", optional = true }
 self_cell = { version = "1.1.0", optional = true }
 ntimestamp = { version = "1.0.0", features = ["full"], optional = true }

--- a/pkarr/src/extra/endpoints/endpoint.rs
+++ b/pkarr/src/extra/endpoints/endpoint.rs
@@ -12,27 +12,23 @@ use std::{
 
 #[derive(Debug, Clone)]
 /// An alternative Endpoint for a `qname`, from either [RData::SVCB] or [RData::HTTPS] dns records
-pub struct Endpoint<'a> {
+pub struct Endpoint {
     target: String,
     public_key: PublicKey,
     port: u16,
     /// SocketAddrs from the [SignedPacket]
     addrs: Vec<IpAddr>,
-    params: BTreeMap<u16, SVCParam<'a>>,
+    params: BTreeMap<u16, SVCParam<'static>>,
 }
 
-impl<'a> Endpoint<'a> {
+impl Endpoint {
     /// Returns a stack of endpoints from a SignedPacket
     ///
     /// 1. Find the SVCB or HTTPS records
     /// 2. Sort them by priority (reverse)
     /// 3. Shuffle records within each priority
     /// 3. If the target is `.`, keep track of A and AAAA records see [rfc9460](https://www.rfc-editor.org/rfc/rfc9460#name-special-handling-of-in-targ)
-    pub(crate) fn parse(
-        signed_packet: &SignedPacket,
-        target: &str,
-        https: bool,
-    ) -> Vec<Endpoint<'a>> {
+    pub(crate) fn parse(signed_packet: &SignedPacket, target: &str, https: bool) -> Vec<Endpoint> {
         let mut records = signed_packet
             .resource_records(target)
             .filter_map(|record| get_svcb(record, https))

--- a/pkarr/src/extra/endpoints/endpoint.rs
+++ b/pkarr/src/extra/endpoints/endpoint.rs
@@ -1,6 +1,6 @@
 use crate::{
     dns::{
-        rdata::{RData, SVCB},
+        rdata::{RData, SVCParam, SVCB},
         ResourceRecord,
     },
     PublicKey, SignedPacket,
@@ -65,13 +65,10 @@ impl Endpoint {
                 };
 
                 let port = s
-                    .get_param(SVCB::PORT)
-                    .map(|bytes| {
-                        let mut arr = [0_u8; 2];
-                        arr[0] = bytes[0];
-                        arr[1] = bytes[1];
-
-                        u16::from_be_bytes(arr)
+                    .iter_params()
+                    .find_map(|p| match p {
+                        SVCParam::Port(port) => Some(*port),
+                        _ => None,
                     })
                     .unwrap_or_default();
 

--- a/pkarr/src/extra/endpoints/mod.rs
+++ b/pkarr/src/extra/endpoints/mod.rs
@@ -15,7 +15,7 @@ impl crate::Client {
     pub fn resolve_https_endpoints<'a>(
         &'a self,
         qname: &'a str,
-    ) -> impl Stream<Item = Endpoint> + 'a {
+    ) -> impl Stream<Item = Endpoint<'a>> {
         self.resolve_endpoints(qname, true)
     }
 
@@ -23,15 +23,15 @@ impl crate::Client {
     pub fn resolve_svcb_endpoints<'a>(
         &'a self,
         qname: &'a str,
-    ) -> impl Stream<Item = Endpoint> + 'a {
+    ) -> impl Stream<Item = Endpoint<'a>> {
         self.resolve_endpoints(qname, false)
     }
 
     /// Helper method that returns the first [HTTPS][crate::dns::rdata::RData::HTTPS] [Endpoint] in the Async stream from [Self::resolve_https_endpoints]
-    pub async fn resolve_https_endpoint(
-        &self,
-        qname: &str,
-    ) -> Result<Endpoint, CouldNotResolveEndpoint> {
+    pub async fn resolve_https_endpoint<'a>(
+        &'a self,
+        qname: &'a str,
+    ) -> Result<Endpoint<'a>, CouldNotResolveEndpoint> {
         let stream = self.resolve_https_endpoints(qname);
 
         pin!(stream);
@@ -50,10 +50,10 @@ impl crate::Client {
     }
 
     /// Helper method that returns the first [SVCB][crate::dns::rdata::RData::SVCB] [Endpoint] in the Async stream from [Self::resolve_svcb_endpoints]
-    pub async fn resolve_svcb_endpoint(
-        &self,
-        qname: &str,
-    ) -> Result<Endpoint, CouldNotResolveEndpoint> {
+    pub async fn resolve_svcb_endpoint<'a>(
+        &'a self,
+        qname: &'a str,
+    ) -> Result<Endpoint<'a>, CouldNotResolveEndpoint> {
         let stream = self.resolve_https_endpoints(qname);
 
         pin!(stream);
@@ -69,7 +69,7 @@ impl crate::Client {
         &'a self,
         qname: &'a str,
         https: bool,
-    ) -> impl Stream<Item = Endpoint> + 'a {
+    ) -> impl Stream<Item = Endpoint<'a>> {
         Gen::new(|co| async move {
             let mut depth = 0;
             let mut stack: Vec<Endpoint> = Vec::new();
@@ -217,10 +217,8 @@ mod tests {
 
         let tld = generate(&client, 1, 1, Some("example.com".to_string()), vec![], None).await;
 
-        let endpoint = client
-            .resolve_https_endpoint(&tld.to_string())
-            .await
-            .unwrap();
+        let qname = tld.to_string();
+        let endpoint = client.resolve_https_endpoint(&qname).await.unwrap();
 
         assert_eq!(endpoint.domain(), Some("example.com"));
         assert_eq!(endpoint.public_key(), &tld);
@@ -238,10 +236,8 @@ mod tests {
 
         let tld = generate(&client, 3, 3, Some("example.com".to_string()), vec![], None).await;
 
-        let endpoint = client
-            .resolve_https_endpoint(&tld.to_string())
-            .await
-            .unwrap();
+        let qname = tld.to_string();
+        let endpoint = client.resolve_https_endpoint(&qname).await.unwrap();
 
         assert_eq!(endpoint.domain(), Some("example.com"));
     }
@@ -258,7 +254,8 @@ mod tests {
 
         let public_key = Keypair::random().public_key();
 
-        let endpoint = client.resolve_https_endpoint(&public_key.to_string()).await;
+        let qname = public_key.to_string();
+        let endpoint = client.resolve_https_endpoint(&qname).await;
 
         assert!(endpoint.is_err());
     }
@@ -276,7 +273,8 @@ mod tests {
 
         let tld = generate(&client, 4, 3, Some("example.com".to_string()), vec![], None).await;
 
-        let endpoint = client.resolve_https_endpoint(&tld.to_string()).await;
+        let qname = tld.to_string();
+        let endpoint = client.resolve_https_endpoint(&qname).await;
 
         assert!(endpoint.is_err());
     }
@@ -301,10 +299,8 @@ mod tests {
         )
         .await;
 
-        let endpoint = client
-            .resolve_https_endpoint(&tld.to_string())
-            .await
-            .unwrap();
+        let qname = tld.to_string();
+        let endpoint = client.resolve_https_endpoint(&qname).await.unwrap();
 
         assert_eq!(endpoint.target(), ".");
         assert_eq!(endpoint.domain(), None);


### PR DESCRIPTION
This PR updates the `simple-dns` dependency from `0.9.3` (~1y old) to the latest `0.11.2`.

The changelog is available here: https://github.com/balliegojr/simple-dns/blob/main/simple-dns/CHANGELOG.md

There were some breaking changes in the new `simple-dns`, like the use of parsed `SVCParam`s as an enum. The `pkarr` loops and callers were updated to reflect that.

A trickier part was the `Endpoint` behind the `extra` feature flag. It used to keep a copy of all params as

```diff
-    params: BTreeMap<u16, Box<[u8]>>,
+    params: BTreeMap<u16, SVCParam<'a>>,
```

but the newer `simple-dns` 1) doesn't expose the underlying bytes for the params anymore, and 2) instead exposes the params as parsed `SVCParam<'a>`.