### PR TITLE
chore: Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     - package-ecosystem: "cargo"
       directory: "/"
       schedule:
-          interval: "weekly"
+          interval: "monthly"
       commit-message:
           prefix: "deps"
       rebase-strategy: "auto"
@@ -16,7 +16,7 @@ updates:
     - package-ecosystem: "npm"
       directory: "/bindings/js/pkg"
       schedule:
-          interval: "weekly"
+          interval: "monthly"
       commit-message:
           prefix: "deps"
       rebase-strategy: "auto"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,15 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
+      commit-message:
+          prefix: "deps"
+      rebase-strategy: "auto"
 
     # npm dependencies for JS bindings
     - package-ecosystem: "npm"
       directory: "/bindings/js/pkg"
       schedule:
           interval: "weekly"
+      commit-message:
+          prefix: "deps"
+      rebase-strategy: "auto"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+    # Cargo dependencies for all workspace members
+    - package-ecosystem: "cargo"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+
+    # npm dependencies for JS bindings
+    - package-ecosystem: "npm"
+      directory: "/bindings/js/pkg"
+      schedule:
+          interval: "weekly"


### PR DESCRIPTION
This PR adds a `dependabot` config.

This tells the bot to open dependency update PRs for Cargo and the JS dependencies. These PRs are bundled into one per week.