### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       commit-message:
           prefix: "deps"
       rebase-strategy: "auto"
+      groups:
+          cargo-dependencies:
+              patterns:
+                  - "*"
 
     # npm dependencies for JS bindings
     - package-ecosystem: "npm"
@@ -20,3 +24,7 @@ updates:
       commit-message:
           prefix: "deps"
       rebase-strategy: "auto"
+      groups:
+          npm-dependencies:
+              patterns:
+                  - "*"


### PR DESCRIPTION
This PR adds `groups` configuration to batch all dependency updates into a single PR per ecosystem (cargo and npm), preserving the existing monthly schedule.

- **Cargo**: Groups all crate updates under `cargo-dependencies`
- **npm**: Groups all JS package updates under `npm-dependencies`