### PR TITLE
fix: tests on MacOS

### DIFF
--- a/pkarr/src/client/tests.rs
+++ b/pkarr/src/client/tests.rs
@@ -1,5 +1,6 @@
 //! Client native tests
 
+use std::net::Ipv4Addr;
 use std::{thread, time::Duration};
 
 use ntimestamp::Timestamp;
@@ -30,7 +31,8 @@ pub(crate) fn builder(
     builder
         .no_default_network()
         // Because of pkarr_relay crate, dht is always enabled.
-        .bootstrap(&testnet.bootstrap);
+        .bootstrap(&testnet.bootstrap)
+        .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST));
 
     if std::env::var("CI").is_ok() {
         builder.request_timeout(Duration::from_millis(1000));
@@ -64,7 +66,7 @@ pub(crate) fn builder(
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn publish_resolve(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let a = builder(&relay, &testnet, networks).build().unwrap();
@@ -94,7 +96,7 @@ async fn publish_resolve(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn client_send(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let a = builder(&relay, &testnet, networks).build().unwrap();
@@ -128,7 +130,7 @@ async fn client_send(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn return_expired_packet_fallback(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let client = builder(&relay, &testnet, networks)
@@ -159,7 +161,7 @@ async fn return_expired_packet_fallback(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn ttl_0_test(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let client = builder(&relay, &testnet, networks)
@@ -192,7 +194,7 @@ async fn ttl_0_test(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn not_found(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
@@ -218,7 +220,7 @@ fn no_network() {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn repeated_publish_query(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
@@ -240,7 +242,7 @@ async fn repeated_publish_query(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn concurrent_resolve(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let a = builder(&relay, &testnet, networks).build().unwrap();
@@ -271,7 +273,7 @@ async fn concurrent_resolve(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn concurrent_publish_same_packet(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
@@ -304,7 +306,7 @@ async fn concurrent_publish_same_packet(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn concurrent_publish_of_different_packets(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
@@ -355,7 +357,7 @@ async fn concurrent_publish_of_different_packets(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn concurrent_publish_different_with_cas(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
 
     let relay = Relay::run_test(&testnet).await.unwrap();
 
@@ -398,7 +400,7 @@ async fn concurrent_publish_different_with_cas(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn conflict_302(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(10).await.unwrap();
+    let testnet = mainline::Testnet::builder(10).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
@@ -440,7 +442,7 @@ async fn conflict_302(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn conflict_301_cas(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
@@ -480,7 +482,7 @@ async fn conflict_301_cas(#[case] networks: Networks) {
 #[test]
 fn blocking(#[case] networks: Networks) {
     let (relay, testnet) = futures_lite::future::block_on(async_compat::Compat::new(async {
-        let testnet = mainline::Testnet::new_async(5).await.unwrap();
+        let testnet = mainline::Testnet::builder(5).build().unwrap();
         let relay = Relay::run_test(&testnet).await.unwrap();
 
         (relay, testnet)
@@ -521,7 +523,7 @@ fn blocking(#[case] networks: Networks) {
 fn no_tokio(#[case] networks: Networks) {
     futures_lite::future::block_on(async {
         let (relay, testnet) = async_compat::Compat::new(async {
-            let testnet = mainline::Testnet::new_async(5).await.unwrap();
+            let testnet = mainline::Testnet::builder(5).build().unwrap();
             let relay = Relay::run_test(&testnet).await.unwrap();
 
             (relay, testnet)
@@ -556,7 +558,7 @@ fn no_tokio(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn zero_cache_size(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let a = builder(&relay, &testnet, networks).build().unwrap();
@@ -581,7 +583,7 @@ async fn zero_cache_size(#[case] networks: Networks) {
 // #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 // #[tokio::test]
 // async fn clear_inflight_requests(#[case] networks: Networks) {
-//     let testnet = mainline::Testnet::new_async(5).await.unwrap();
+//     let testnet = mainline::Testnet::builder(5).build().unwrap();
 //     let relay = Relay::run_test(&testnet).await.unwrap();
 //
 //     let client = builder(&relay, &testnet, networks).build().unwrap();
@@ -611,7 +613,7 @@ async fn zero_cache_size(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn publish_resolve_most_recent_with_no_cache(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let a = builder(&relay, &testnet, networks).build().unwrap();
@@ -640,7 +642,7 @@ async fn publish_resolve_most_recent_with_no_cache(#[case] networks: Networks) {
 #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
 #[tokio::test]
 async fn regression_relay_cas(#[case] networks: Networks) {
-    let testnet = mainline::Testnet::new_async(5).await.unwrap();
+    let testnet = mainline::Testnet::builder(5).build().unwrap();
     let relay = Relay::run_test(&testnet).await.unwrap();
 
     let keypair = Keypair::random();
@@ -671,7 +673,7 @@ async fn regression_relay_cas(#[case] networks: Networks) {
 
 #[tokio::test]
 async fn discard_cache_with_zero_capacity() {
-    let testnet = crate::mainline::Testnet::new_async(2).await.unwrap();
+    let testnet = crate::mainline::Testnet::builder(2).build().unwrap();
 
     // Create relay
     let storage = std::env::temp_dir().join(Timestamp::now().to_string());
@@ -684,6 +686,7 @@ async fn discard_cache_with_zero_capacity() {
         .pkarr(|builder| {
             builder.no_default_network();
             builder.bootstrap(&testnet.bootstrap);
+            builder.dht(|b| b.bind_address(Ipv4Addr::LOCALHOST));
             builder
         });
     let relay = unsafe { builder.run().await.unwrap() };
@@ -695,6 +698,7 @@ async fn discard_cache_with_zero_capacity() {
     let client = Client::builder()
         .no_default_network()
         .bootstrap(&testnet.bootstrap)
+        .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
         .build()
         .unwrap();
 
@@ -783,7 +787,7 @@ mod reqwest_builder {
     #[cfg_attr(feature = "relays", case::relays(Networks::Relays))]
     #[tokio::test]
     async fn reqwest_pkarr_domain(#[case] networks: Networks) {
-        let testnet = mainline::Testnet::new_async(5).await.unwrap();
+        let testnet = mainline::Testnet::builder(5).build().unwrap();
         let relay = Relay::run_test(&testnet).await.unwrap();
 
         let keypair = Keypair::random();

--- a/pkarr/src/extra/endpoints/mod.rs
+++ b/pkarr/src/extra/endpoints/mod.rs
@@ -130,7 +130,7 @@ mod tests {
     use crate::{PublicKey, SignedPacket};
 
     use std::future::Future;
-    use std::net::IpAddr;
+    use std::net::{IpAddr, Ipv4Addr};
     use std::pin::Pin;
     use std::str::FromStr;
     use std::time::Duration;
@@ -208,10 +208,11 @@ mod tests {
 
     #[tokio::test]
     async fn direct_endpoint_resolution() {
-        let testnet = Testnet::new_async(5).await.unwrap();
+        let testnet = Testnet::builder(5).build().unwrap();
         let client = Client::builder()
             .no_default_network()
             .bootstrap(&testnet.bootstrap)
+            .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
             .build()
             .unwrap();
 
@@ -228,10 +229,11 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_endpoints() {
-        let testnet = Testnet::new_async(5).await.unwrap();
+        let testnet = Testnet::builder(5).build().unwrap();
         let client = Client::builder()
             .no_default_network()
             .bootstrap(&testnet.bootstrap)
+            .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
             .request_timeout(Duration::from_millis(200))
             .build()
             .unwrap();
@@ -248,10 +250,11 @@ mod tests {
 
     #[tokio::test]
     async fn empty() {
-        let testnet = Testnet::new_async(5).await.unwrap();
+        let testnet = Testnet::builder(5).build().unwrap();
         let client = Client::builder()
             .no_default_network()
             .bootstrap(&testnet.bootstrap)
+            .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
             .request_timeout(Duration::from_millis(20))
             .build()
             .unwrap();
@@ -265,10 +268,11 @@ mod tests {
 
     #[tokio::test]
     async fn max_recursion_exceeded() {
-        let testnet = Testnet::new_async(5).await.unwrap();
+        let testnet = Testnet::builder(5).build().unwrap();
         let client = Client::builder()
             .no_default_network()
             .bootstrap(&testnet.bootstrap)
+            .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
             .request_timeout(Duration::from_millis(100))
             .max_recursion_depth(3)
             .build()
@@ -283,10 +287,11 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_addresses() {
-        let testnet = Testnet::new_async(5).await.unwrap();
+        let testnet = Testnet::builder(5).build().unwrap();
         let client = Client::builder()
             .no_default_network()
             .bootstrap(&testnet.bootstrap)
+            .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
             .request_timeout(Duration::from_millis(200))
             .build()
             .unwrap();

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -240,7 +240,7 @@ impl Relay {
     /// Homeserver uses LMDB, opening which is marked [unsafe](https://docs.rs/heed/latest/heed/struct.EnvOpenOptions.html#safety-1),
     /// because the possible Undefined Behavior (UB) if the lock file is broken.
     pub async unsafe fn run_testnet() -> anyhow::Result<Self> {
-        let testnet = pkarr::mainline::Testnet::new_async(10).await?;
+        let testnet = pkarr::mainline::Testnet::builder(10).build()?;
 
         // Leaking the testnet to avoid dropping and shutting them down.
         for node in testnet.nodes {

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -205,7 +205,7 @@ impl Relay {
     }
 
     /// Run an ephemeral Pkarr relay on a random port number for testing purposes.
-    ///
+    /// Binds to `127.0.0.1`.
     /// # Arguments
     /// * `testnet` - A reference to a `mainline::Testnet` for bootstrapping the DHT.
     ///
@@ -225,7 +225,11 @@ impl Relay {
             .bootstrap(&testnet.bootstrap)
             .request_timeout(Duration::from_millis(100))
             .bootstrap(&testnet.bootstrap)
-            .dht(|builder| builder.server_mode());
+            .dht(|builder| {
+                builder
+                    .server_mode()
+                    .bind_address(std::net::Ipv4Addr::LOCALHOST)
+            });
 
         Ok(unsafe { Self::run(config).await? })
     }
@@ -236,7 +240,7 @@ impl Relay {
     /// Homeserver uses LMDB, opening which is marked [unsafe](https://docs.rs/heed/latest/heed/struct.EnvOpenOptions.html#safety-1),
     /// because the possible Undefined Behavior (UB) if the lock file is broken.
     pub async unsafe fn run_testnet() -> anyhow::Result<Self> {
-        let testnet = pkarr::mainline::Testnet::new(10)?;
+        let testnet = pkarr::mainline::Testnet::new_async(10).await?;
 
         // Leaking the testnet to avoid dropping and shutting them down.
         for node in testnet.nodes {
@@ -254,7 +258,11 @@ impl Relay {
             .pkarr
             .request_timeout(Duration::from_millis(100))
             .bootstrap(&testnet.bootstrap)
-            .dht(|builder| builder.server_mode());
+            .dht(|builder| {
+                builder
+                    .server_mode()
+                    .bind_address(std::net::Ipv4Addr::LOCALHOST)
+            });
 
         Self::run(config).await
     }


### PR DESCRIPTION
## Summary
- Bind all test DHT nodes and clients to `127.0.0.1` instead of `0.0.0.0` to fix 46 test failures on macOS
- Replace deprecated `Testnet::new_async(N)` / `Testnet::new(N)` with `Testnet::builder(N).build()` (defaults to localhost)
- Add `.bind_address(Ipv4Addr::LOCALHOST)` to all test `DhtBuilder` configs

## Context

On newer macOS, binding UDP sockets to `0.0.0.0` causes DHT nodes to become unreachable — the OS may route UDP responses through a different interface than loopback, resulting in `NoClosestNodes` and `UnexpectedResponses` errors. This caused 46 out of ~96 tests to fail.

Mainline 6.1.1 added `Testnet::builder(N)` which defaults `bind_address` to `127.0.0.1` (vs `0.0.0.0` in the legacy `new()` / `new_async()` constructors). This PR adopts that pattern across all pkarr tests, matching what mainline's own test suite does.

## Changes

- **`pkarr/src/client/tests.rs`**: Replaced all `Testnet::new_async()` calls with `Testnet::builder().build()`, added `.dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))` to the shared `builder()` helper and standalone client builders
- **`pkarr/src/extra/endpoints/mod.rs`**: Same pattern for all 5 endpoint tests
- **`relay/src/lib.rs`**: Added `bind_address(LOCALHOST)` to `run_test()` and `run_testnet()`, replaced `Testnet::new()` with `Testnet::builder().build()`


See https://github.com/pubky/mainline/pull/82
