### PR TITLE
chore: release v6.0.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,7 +1749,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "5.0.3"
+version = "6.0.0-rc.0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "0.11.4"
+version = "0.11.5-rc.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr"
-version = "5.0.3"
+version = "6.0.0-rc.0"
 rust-version = "1.85"
 authors = [
   "Nuh <nuh@nuh.dev>",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr-relay"
-version = "0.11.4"
+version = "0.11.5-rc.0"
 rust-version = "1.85"
 authors = [
     "Nuh <nuh@nuh.dev>",
@@ -37,7 +37,7 @@ clap = { version = "4.5.57", features = ["derive"] }
 dirs-next = "2.0.0"
 httpdate = "1.0.3"
 url = "2.5.8"
-pkarr = { path = "../pkarr", version = "5.0.0", default-features = false, features = [
+pkarr = { path = "../pkarr", version = "6.0.0-rc.0", default-features = false, features = [
     "dht",
     "lmdb-cache",
 ] }


### PR DESCRIPTION
This is a release candidate with the breaking changes from #207. This is to test if everything is still compatible or if we will see unexpected changes.

Compared to v5.0.3, #207 is the only change.