### PR TITLE
feat(pkarr): add publish_with_info exposing stored_at from DHT       

### DIFF
--- a/pkarr/src/lib.rs
+++ b/pkarr/src/lib.rs
@@ -33,7 +33,7 @@ pub use client::blocking::ClientBlocking;
 #[cfg(client)]
 pub use client::cache::{Cache, CacheKey, InMemoryCache};
 #[cfg(client)]
-pub use client::{builder::ClientBuilder, Client};
+pub use client::{builder::ClientBuilder, Client, PublishResult};
 #[cfg(feature = "keys")]
 pub use keys::{Keypair, PublicKey};
 #[cfg(feature = "signed_packet")]


### PR DESCRIPTION
Adds `PublishResult` with a `stored_at: Option<u8>` field and a `publish_with_info` method that returns it. This lets callers know how many DHT nodes acknowledged storing a packet without a separate verification query. Relay-only publishes return `None` since relays don't report node counts.