### PR TITLE
chore: release v5.0.5 / js v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkarr"
-version = "5.0.4"
+version = "5.0.5"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/bindings/js/pkg/package.json
+++ b/bindings/js/pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/pkarr",
   "description": "Public-Key Addressable Resource Records (Pkarr); publish and resolve DNS records over Mainline DHT",
-  "version": "0.1.5",
+  "version": "0.1.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/bindings/js/pkg/package.json
+++ b/bindings/js/pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/pkarr",
   "description": "Public-Key Addressable Resource Records (Pkarr); publish and resolve DNS records over Mainline DHT",
-  "version": "0.1.4-rc.3",
+  "version": "0.1.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr"
-version = "5.0.4"
+version = "5.0.5"
 rust-version = "1.85"
 authors = [
   "Nuh <nuh@nuh.dev>",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr-relay"
-version = "0.11.5"
+version = "0.11.6"
 rust-version = "1.85"
 authors = [
     "Nuh <nuh@nuh.dev>",


### PR DESCRIPTION
- New rust pkarr version that includes the newest mainline dependency.
- Also bump the javascript lib because the current published version is still a release candidate.