### PR TITLE
refactor(relay): split client IP normalization and rate limiting

### DIFF
--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -11,6 +11,7 @@ mod config;
 mod error;
 mod handlers;
 mod rate_limiting;
+mod real_ip;
 
 use std::{
     net::{SocketAddr, TcpListener},
@@ -139,6 +140,11 @@ impl Relay {
 
         let cache = Arc::new(LmdbCache::open(&cache_path, config.cache_size)?);
 
+        let behind_proxy = config
+            .rate_limiter
+            .as_ref()
+            .map(|rate_limiter| rate_limiter.behind_proxy)
+            .unwrap_or(false);
         let rate_limiter = config
             .rate_limiter
             .map(|rate_limiter| rate_limiting::IpRateLimiter::new(&rate_limiter));
@@ -172,7 +178,7 @@ impl Relay {
         info!("Running as a DHT node on {node_address}");
         info!("Running as a relay on TCP socket {relay_address}");
 
-        let app = create_app(AppState { client }, rate_limiter);
+        let app = create_app(AppState { client }, rate_limiter, behind_proxy);
 
         let handle = Handle::new();
 
@@ -284,7 +290,11 @@ impl Relay {
     }
 }
 
-fn create_app(state: AppState, rate_limiter: Option<rate_limiting::IpRateLimiter>) -> Router {
+fn create_app(
+    state: AppState,
+    rate_limiter: Option<rate_limiting::IpRateLimiter>,
+    behind_proxy: bool,
+) -> Router {
     let mut router = Router::new()
         .route(
             "/{key}",
@@ -297,7 +307,9 @@ fn create_app(state: AppState, rate_limiter: Option<rate_limiting::IpRateLimiter
         .layer(TraceLayer::new_for_http());
 
     if let Some(rate_limiter) = rate_limiter {
-        router = rate_limiter.layer(router);
+        router = rate_limiter
+            .layer(router)
+            .layer(real_ip::middleware(behind_proxy));
     }
 
     router

--- a/relay/src/rate_limiting.rs
+++ b/relay/src/rate_limiting.rs
@@ -1,14 +1,10 @@
 use std::{net::IpAddr, sync::Arc, time::Duration};
 
+use crate::real_ip::RealIpKeyExtractor;
 use axum::Router;
 use governor::middleware::StateInformationMiddleware;
 use serde::{Deserialize, Serialize};
-
-use tower_governor::{
-    governor::{GovernorConfig, GovernorConfigBuilder},
-    key_extractor::{PeerIpKeyExtractor, SmartIpKeyExtractor},
-};
-
+use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
 pub use tower_governor::GovernorLayer;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -43,10 +39,9 @@ impl Default for RateLimiterConfig {
 }
 
 #[derive(Debug, Clone)]
-/// A rate limiter that works for direct connections (Peer) or behind reverse-proxy (Proxy)
-pub enum IpRateLimiter {
-    Peer(Arc<GovernorConfig<PeerIpKeyExtractor, StateInformationMiddleware>>),
-    Proxy(Arc<GovernorConfig<SmartIpKeyExtractor, StateInformationMiddleware>>),
+/// A rate limiter keyed by the request's normalized real IP.
+pub struct IpRateLimiter {
+    governor_middleware: Arc<GovernorConfig<RealIpKeyExtractor, StateInformationMiddleware>>,
 }
 
 impl IpRateLimiter {
@@ -54,69 +49,39 @@ impl IpRateLimiter {
     ///
     /// This spawns a background thread to clean up the rate limiting cache.
     pub fn new(config: &RateLimiterConfig) -> Self {
-        match config.behind_proxy {
-            true => {
-                let config = Arc::new(
-                    GovernorConfigBuilder::default()
-                        .use_headers()
-                        .per_second(config.per_second)
-                        .burst_size(config.burst_size)
-                        .key_extractor(SmartIpKeyExtractor)
-                        .finish()
-                        .expect("failed to build rate-limiting governor"),
-                );
+        let governor_middleware = Arc::new(
+            GovernorConfigBuilder::default()
+                .use_headers()
+                .per_second(config.per_second)
+                .burst_size(config.burst_size)
+                .key_extractor(RealIpKeyExtractor)
+                .finish()
+                .expect("failed to build rate-limiting governor"),
+        );
 
-                // The governor needs a background task for garbage collection (to clear expired records)
-                let gc_interval = Duration::from_secs(60);
+        // The governor needs a background task for garbage collection (to clear expired records)
+        let gc_interval = Duration::from_secs(60);
 
-                let governor_limiter = config.limiter().clone();
-                std::thread::spawn(move || loop {
-                    std::thread::sleep(gc_interval);
-                    tracing::debug!("rate limiting storage size: {}", governor_limiter.len());
-                    governor_limiter.retain_recent();
-                });
+        let governor_limiter = governor_middleware.limiter().clone();
+        std::thread::spawn(move || loop {
+            std::thread::sleep(gc_interval);
+            tracing::debug!("rate limiting storage size: {}", governor_limiter.len());
+            governor_limiter.retain_recent();
+        });
 
-                Self::Proxy(config)
-            }
-            false => {
-                let config = Arc::new(
-                    GovernorConfigBuilder::default()
-                        .use_headers()
-                        .per_second(config.per_second)
-                        .burst_size(config.burst_size)
-                        .finish()
-                        .expect("failed to build rate-limiting governor"),
-                );
-
-                // The governor needs a background task for garbage collection (to clear expired records)
-                let gc_interval = Duration::from_secs(60);
-
-                let governor_limiter = config.limiter().clone();
-                std::thread::spawn(move || loop {
-                    std::thread::sleep(gc_interval);
-                    tracing::debug!("rate limiting storage size: {}", governor_limiter.len());
-                    governor_limiter.retain_recent();
-                });
-
-                Self::Peer(config)
-            }
+        Self {
+            governor_middleware,
         }
     }
 
     /// Check if the Ip is allowed to make more requests
     pub fn is_limited(&self, ip: &IpAddr) -> bool {
-        match self {
-            IpRateLimiter::Peer(config) => config.limiter().check_key(ip).is_err(),
-            IpRateLimiter::Proxy(config) => config.limiter().check_key(ip).is_err(),
-        }
+        self.governor_middleware.limiter().check_key(ip).is_err()
     }
 
     /// Add a [GovernorLayer] on the provided [Router]
-    pub fn layer(&self, router: Router) -> Router {
-        match self {
-            IpRateLimiter::Peer(config) => router.layer(GovernorLayer::new(config.clone())),
-            IpRateLimiter::Proxy(config) => router.layer(GovernorLayer::new(config.clone())),
-        }
+    pub fn layer(self, router: Router) -> Router {
+        router.layer(GovernorLayer::new(self.governor_middleware))
     }
 }
 

--- a/relay/src/real_ip.rs
+++ b/relay/src/real_ip.rs
@@ -1,0 +1,122 @@
+use std::{future::Future, net::IpAddr, pin::Pin};
+
+use axum::{
+    extract::Request,
+    middleware::{from_fn, FromFnLayer, Next},
+    response::Response,
+};
+use http::request;
+use tower_governor::{
+    errors::GovernorError,
+    key_extractor::{KeyExtractor, PeerIpKeyExtractor, SmartIpKeyExtractor},
+};
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RealIp(pub(crate) IpAddr);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Extracts a request's normalized real IP from extensions.
+pub struct RealIpKeyExtractor;
+
+impl KeyExtractor for RealIpKeyExtractor {
+    type Key = IpAddr;
+
+    fn extract<T>(&self, req: &request::Request<T>) -> Result<Self::Key, GovernorError> {
+        req.extensions()
+            .get::<RealIp>()
+            .map(|real_ip| real_ip.0)
+            .ok_or(GovernorError::UnableToExtractKey)
+    }
+}
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn middleware(
+    behind_proxy: bool,
+) -> FromFnLayer<
+    impl Fn(Request, Next) -> Pin<Box<dyn Future<Output = Response> + Send>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    (),
+    (Request,),
+> {
+    from_fn(move |request, next| {
+        let future: Pin<Box<dyn Future<Output = Response> + Send>> =
+            Box::pin(handle_request(request, next, behind_proxy));
+
+        future
+    })
+}
+
+async fn handle_request(mut request: Request, next: Next, behind_proxy: bool) -> Response {
+    if let Some(real_ip) = extract_real_ip(&request, behind_proxy) {
+        request.extensions_mut().insert(RealIp(real_ip));
+    }
+
+    next.run(request).await
+}
+
+fn extract_real_ip(request: &Request, behind_proxy: bool) -> Option<IpAddr> {
+    let extracted_ip = if behind_proxy {
+        SmartIpKeyExtractor.extract(request)
+    } else {
+        PeerIpKeyExtractor.extract(request)
+    };
+
+    extracted_ip.ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use axum::{body::Body, extract::ConnectInfo};
+    use http::Request;
+    use tower_governor::key_extractor::KeyExtractor;
+
+    use super::{extract_real_ip, RealIp, RealIpKeyExtractor};
+
+    fn request_with_peer(peer_ip: Ipv4Addr) -> Request<Body> {
+        let mut request = Request::new(Body::empty());
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from((peer_ip, 8080))));
+        request
+    }
+
+    #[test]
+    fn real_ip_uses_peer_ip_without_proxy_mode() {
+        let mut request = request_with_peer(Ipv4Addr::new(192, 0, 2, 1));
+        request
+            .headers_mut()
+            .insert("x-forwarded-for", "198.51.100.1".parse().unwrap());
+
+        assert_eq!(
+            extract_real_ip(&request, false),
+            Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)))
+        );
+    }
+
+    #[test]
+    fn real_ip_uses_forwarded_ip_with_proxy_mode() {
+        let mut request = request_with_peer(Ipv4Addr::new(192, 0, 2, 1));
+        request
+            .headers_mut()
+            .insert("x-forwarded-for", "198.51.100.1".parse().unwrap());
+
+        assert_eq!(
+            extract_real_ip(&request, true),
+            Some(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)))
+        );
+    }
+
+    #[test]
+    fn real_ip_key_extractor_reads_extension() {
+        let mut request = Request::new(Body::empty());
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1));
+        request.extensions_mut().insert(RealIp(ip));
+
+        assert_eq!(RealIpKeyExtractor.extract(&request).unwrap(), ip);
+    }
+}


### PR DESCRIPTION
Prepare outbound DHT request rate limiting to reuse the same
real-IP extraction path as HTTP rate limiting.
