### PR TITLE
chore: v6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkarr"
-version = "5.0.5"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr"
-version = "5.0.5"
+version = "6.0.0"
 rust-version = "1.85"
 authors = [
   "Nuh <nuh@nuh.dev>",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr-relay"
-version = "0.11.6"
+version = "0.11.7"
 rust-version = "1.85"
 authors = [
     "Nuh <nuh@nuh.dev>",
@@ -34,7 +34,7 @@ toml = "0.9.11"
 clap = { version = "4.5.57", features = ["derive"] }
 httpdate = "1.0.3"
 url = "2.5.8"
-pkarr = { path = "../pkarr", version = "5.0", default-features = false, features = [
+pkarr = { path = "../pkarr", version = "6.0", default-features = false, features = [
     "dht",
     "lmdb-cache",
 ] }

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr-relay"
-version = "0.11.7"
+version = "0.12.0"
 rust-version = "1.85"
 authors = [
     "Nuh <nuh@nuh.dev>",


### PR DESCRIPTION
Version 6.0.0 which replaces v5.0.5 due to #241 .