### PR TITLE
feat(relay)!: rate limit user DHT operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,7 @@ dependencies = [
  "http",
  "httpdate",
  "pkarr",
+ "reqwest",
  "serde",
  "tokio",
  "toml",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -40,5 +40,8 @@ pkarr = { path = "../pkarr", version = "6.0", default-features = false, features
 ] }
 futures-lite = "2.6.1"
 
+[dev-dependencies]
+reqwest = { workspace = true }
+
 [package.metadata.docs.rs]
 all-features = true

--- a/relay/src/config.example.toml
+++ b/relay/src/config.example.toml
@@ -37,11 +37,11 @@ maximum_ttl =  86400
 # Ip rate limiting by setting the trusted headers to 
 # a random IP address on every request.
 behind_proxy = false
-# Maximum number of requests per second.
-burst_size = 10
-# Number of seconds after which one request of the quota is replenished.
-per_second = 2
-# Maximum number of DHT operations (initiated by user's request) per second.
-user_dht_burst_size = 5
-# Number of seconds after which one user DHT operation quota is replenished.
-user_dht_per_second = 2
+# HTTP request quota per IP address.
+quota = "2r/s"
+# Optional HTTP request burst size. Defaults to the quota rate when omitted.
+burst = 10
+# DHT operation quota per IP address for operations initiated by user's request.
+user_dht_quota = "2r/s"
+# Optional user DHT operation burst size. Defaults to the quota rate when omitted.
+user_dht_burst = 10

--- a/relay/src/config.example.toml
+++ b/relay/src/config.example.toml
@@ -38,10 +38,17 @@ maximum_ttl =  86400
 # a random IP address on every request.
 behind_proxy = false
 # HTTP request quota per IP address.
+# Always applied before request handling to every HTTP request.
+# This includes GET, PUT, the index route, cache hits, and cache-only requests.
 quota = "2r/s"
 # Optional HTTP request burst size. Defaults to the quota rate when omitted.
 burst = 10
-# DHT operation quota per IP address for operations initiated by user's request.
+# User-initiated DHT operation quota per IP address.
+# This is separate from the HTTP quota above and is consumed only when a
+# request makes the relay contact the DHT: PUT publishes, GET cache misses,
+# expired CacheFirst entries, and DhtNetworkOnly requests. Cache hits and
+# LocalOrRelayCacheOnly requests do not consume this quota.
 user_dht_quota = "2r/s"
-# Optional user DHT operation burst size. Defaults to the quota rate when omitted.
+# Optional user-initiated DHT operation burst size.
+# Defaults to the DHT quota rate when omitted.
 user_dht_burst = 10

--- a/relay/src/config.example.toml
+++ b/relay/src/config.example.toml
@@ -41,3 +41,7 @@ behind_proxy = false
 burst_size = 10
 # Number of seconds after which one request of the quota is replenished.
 per_second = 2
+# Maximum number of DHT operations (initiated by user's request) per second.
+user_dht_burst_size = 5
+# Number of seconds after which one user DHT operation quota is replenished.
+user_dht_per_second = 2

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -1,4 +1,4 @@
-use axum::extract::{Path, Query};
+use axum::extract::{Extension, Path, Query};
 use axum::response::Html;
 use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
@@ -11,6 +11,7 @@ use serde::Deserialize;
 
 use crate::error::Error;
 use crate::extractors::{IfMatch, IfModifiedSince, PublicKeyParam};
+use crate::real_ip::RealIp;
 use crate::response::SignedPacketResponse;
 use crate::AppState;
 
@@ -18,6 +19,7 @@ pub async fn put(
     State(state): State<AppState>,
     Path(PublicKeyParam(public_key)): Path<PublicKeyParam>,
     IfMatch(cas): IfMatch,
+    real_ip: Option<Extension<RealIp>>,
     body: Bytes,
 ) -> Result<impl IntoResponse, Error> {
     let signed_packet = pkarr::SignedPacket::from_relay_payload(&public_key, &body)
@@ -33,8 +35,9 @@ pub async fn put(
         }
     }
 
+    enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
+
     let cas = cas.map(|t| t.as_u64() as i64);
-    // TODO: Ratelimit.
     state.dht.put_mutable((&signed_packet).into(), cas).await?;
     update_cache_if_needed(&state, &key, &signed_packet);
 
@@ -45,6 +48,7 @@ pub async fn get(
     State(state): State<AppState>,
     Path(PublicKeyParam(public_key)): Path<PublicKeyParam>,
     Query(query): Query<GetQuery>,
+    real_ip: Option<Extension<RealIp>>,
     IfModifiedSince(if_modified_since): IfModifiedSince,
 ) -> Result<SignedPacketResponse, Error> {
     let key = CacheKey::from(&public_key);
@@ -58,6 +62,7 @@ pub async fn get(
                 Some(packet)
             }
             Some(packet) => {
+                enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
                 resolve(
                     &state.dht,
                     &public_key,
@@ -66,9 +71,13 @@ pub async fn get(
                 )
                 .await
             }
-            None => resolve(&state.dht, &public_key, Mode::First, None).await,
+            None => {
+                enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
+                resolve(&state.dht, &public_key, Mode::First, None).await
+            }
         },
         ResolvePolicy::DhtNetworkOnly => {
+            enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
             let at_least_that_recent = cached_packet.as_ref().map(SignedPacket::timestamp);
             resolve(
                 &state.dht,
@@ -247,4 +256,21 @@ fn update_cache_if_needed(state: &AppState, key: &CacheKey, signed_packet: &Sign
     if should_update {
         state.cache.put(key, signed_packet);
     }
+}
+
+fn enforce_user_dht_rate_limit(
+    state: &AppState,
+    real_ip: Option<&Extension<RealIp>>,
+) -> Result<(), Error> {
+    if let (Some(rate_limiter), Some(Extension(real_ip))) = (&state.user_dht_rate_limiter, real_ip)
+    {
+        if rate_limiter.is_limited(&real_ip.0) {
+            return Err(Error::new(
+                StatusCode::TOO_MANY_REQUESTS,
+                Some("Too many requests to DHT nodes"),
+            ));
+        }
+    }
+
+    Ok(())
 }

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -11,6 +11,7 @@ mod config;
 mod error;
 mod extractors;
 mod handlers;
+mod quota_config;
 mod rate_limiting;
 mod real_ip;
 mod response;
@@ -22,6 +23,7 @@ use std::{
     time::Duration,
 };
 
+use anyhow::anyhow;
 use axum::{extract::DefaultBodyLimit, Router};
 use axum_server::Handle;
 
@@ -33,6 +35,7 @@ use url::Url;
 
 use config::{Config, CACHE_DIR};
 
+pub use quota_config::{RequestCountQuota, TimeUnit};
 pub use rate_limiting::RateLimiterConfig;
 
 /// A builder for Pkarr [Relay]
@@ -147,9 +150,13 @@ impl Relay {
 
         let (rate_limiter, user_dht_rate_limiter) = match config.rate_limiter.as_ref() {
             Some(rate_limiter_config) => {
-                let rate_limiter = rate_limiting::IpRateLimiter::new(rate_limiter_config).await;
+                let rate_limiter = rate_limiting::IpRateLimiter::new(rate_limiter_config)
+                    .await
+                    .map_err(|e| anyhow!("Failed to build IpRateLimiter: {e}"))?;
                 let user_dht_rate_limiter =
-                    rate_limiting::UserDhtRateLimiter::new(rate_limiter_config).await;
+                    rate_limiting::UserDhtRateLimiter::new(rate_limiter_config)
+                        .await
+                        .map_err(|e| anyhow!("Failed to build UserDhtRateLimiter: {e}"))?;
                 config.pkarr.dht(|builder| {
                     builder.server_settings(pkarr::mainline::ServerSettings {
                         filter: Box::new(rate_limiter.clone()),
@@ -335,12 +342,12 @@ struct AppState {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::Ipv4Addr, time::Duration};
+    use std::{net::Ipv4Addr, num::NonZeroU32, time::Duration};
 
     use http::StatusCode;
     use pkarr::{Keypair, SignedPacket, Timestamp};
 
-    use super::{RateLimiterConfig, Relay};
+    use super::{RateLimiterConfig, Relay, RequestCountQuota};
 
     #[tokio::test]
     async fn user_dht_rate_limit_only_blocks_dht_operations() {
@@ -407,10 +414,10 @@ mod tests {
             .storage(storage)
             .rate_limiter_config(RateLimiterConfig {
                 behind_proxy: false,
-                per_second: 60,
-                burst_size: 100,
-                user_dht_per_second: 60,
-                user_dht_burst_size: 1,
+                quota: "60r/s".parse::<RequestCountQuota>().unwrap(),
+                burst: NonZeroU32::new(100),
+                user_dht_quota: "1r/h".parse::<RequestCountQuota>().unwrap(),
+                user_dht_burst: NonZeroU32::new(1),
             })
             .pkarr(|builder| {
                 builder

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -144,18 +144,22 @@ impl Relay {
             .as_ref()
             .map(|rate_limiter| rate_limiter.behind_proxy)
             .unwrap_or(false);
-        let rate_limiter = config
-            .rate_limiter
-            .map(|rate_limiter| rate_limiting::IpRateLimiter::new(&rate_limiter));
 
-        if let Some(ref rate_limiter) = rate_limiter {
-            config.pkarr.dht(|builder| {
-                builder.server_settings(pkarr::mainline::ServerSettings {
-                    filter: Box::new(rate_limiter.clone()),
-                    ..Default::default()
-                })
-            });
-        }
+        let (rate_limiter, user_dht_rate_limiter) = match config.rate_limiter.as_ref() {
+            Some(rate_limiter_config) => {
+                let rate_limiter = rate_limiting::IpRateLimiter::new(rate_limiter_config).await;
+                let user_dht_rate_limiter =
+                    rate_limiting::UserDhtRateLimiter::new(rate_limiter_config).await;
+                config.pkarr.dht(|builder| {
+                    builder.server_settings(pkarr::mainline::ServerSettings {
+                        filter: Box::new(rate_limiter.clone()),
+                        ..Default::default()
+                    })
+                });
+                (Some(rate_limiter), Some(user_dht_rate_limiter))
+            }
+            None => (None, None),
+        };
 
         let client = config.pkarr.build()?;
 
@@ -177,6 +181,7 @@ impl Relay {
             maximum_ttl: config.maximum_ttl,
             cache,
             cache_write_lock: Arc::new(Mutex::new(())),
+            user_dht_rate_limiter,
             dht,
         };
         let app = create_app(state, rate_limiter, behind_proxy);
@@ -323,5 +328,109 @@ struct AppState {
     cache: Arc<LmdbCache>,
     // Synchronous mutex is fine here; handlers only hold it across cache reads/writes, never await points.
     cache_write_lock: Arc<Mutex<()>>,
+    // Rate limiter for DHT operations initiated by HTTP user requests.
+    user_dht_rate_limiter: Option<rate_limiting::UserDhtRateLimiter>,
     dht: AsyncDht,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::Ipv4Addr, time::Duration};
+
+    use http::StatusCode;
+    use pkarr::{Keypair, SignedPacket, Timestamp};
+
+    use super::{RateLimiterConfig, Relay};
+
+    #[tokio::test]
+    async fn user_dht_rate_limit_only_blocks_dht_operations() {
+        let testnet = pkarr::mainline::Testnet::builder(2).build().unwrap();
+        let relay = run_rate_limited_relay(&testnet).await;
+        let http = reqwest::Client::new();
+        let keypair = Keypair::random();
+        let signed_packet = signed_packet(&keypair);
+        let relay_url = relay.local_url();
+
+        let put_response = http
+            .put(relay_url.join(&keypair.public_key().to_string()).unwrap())
+            .body(signed_packet.to_relay_payload())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(put_response.status(), StatusCode::NO_CONTENT);
+
+        let local_cache_response = http
+            .get(
+                relay_url
+                    .join(&format!(
+                        "{}?policy=LocalOrRelayCacheOnly",
+                        keypair.public_key()
+                    ))
+                    .unwrap(),
+            )
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(local_cache_response.status(), StatusCode::OK);
+
+        let cache_first_response = http
+            .get(
+                relay_url
+                    .join(&format!("{}?policy=CacheFirst", keypair.public_key()))
+                    .unwrap(),
+            )
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(cache_first_response.status(), StatusCode::OK);
+
+        let dht_response = http
+            .get(
+                relay_url
+                    .join(&format!("{}?policy=DhtNetworkOnly", keypair.public_key()))
+                    .unwrap(),
+            )
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(dht_response.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        relay.shutdown();
+    }
+
+    async fn run_rate_limited_relay(testnet: &pkarr::mainline::Testnet) -> Relay {
+        let storage = std::env::temp_dir().join(format!("pkarr-relay-{}", Timestamp::now()));
+        let mut builder = Relay::builder();
+        builder
+            .cache_size(10)
+            .http_port(0)
+            .storage(storage)
+            .rate_limiter_config(RateLimiterConfig {
+                behind_proxy: false,
+                per_second: 60,
+                burst_size: 100,
+                user_dht_per_second: 60,
+                user_dht_burst_size: 1,
+            })
+            .pkarr(|builder| {
+                builder
+                    .no_default_network()
+                    .bootstrap(&testnet.bootstrap)
+                    .request_timeout(Duration::from_millis(100))
+                    .dht(|builder| builder.bind_address(Ipv4Addr::LOCALHOST))
+            });
+
+        unsafe { builder.run().await.unwrap() }
+    }
+
+    fn signed_packet(keypair: &Keypair) -> SignedPacket {
+        SignedPacket::builder()
+            .txt(
+                "example.com".try_into().unwrap(),
+                "rate-limited".try_into().unwrap(),
+                300,
+            )
+            .sign(keypair)
+            .unwrap()
+    }
 }

--- a/relay/src/quota_config/mod.rs
+++ b/relay/src/quota_config/mod.rs
@@ -1,0 +1,5 @@
+mod request_count_quota;
+mod time_unit;
+
+pub use request_count_quota::RequestCountQuota;
+pub use time_unit::TimeUnit;

--- a/relay/src/quota_config/request_count_quota.rs
+++ b/relay/src/quota_config/request_count_quota.rs
@@ -1,0 +1,141 @@
+use std::fmt;
+use std::num::NonZeroU32;
+use std::str::FromStr;
+use std::time::Duration;
+
+use super::TimeUnit;
+
+/// A request-count quota — limits how many requests are allowed per time window.
+///
+/// Examples: `"5r/s"`, `"10r/m"`, `"100r/h"`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RequestCountQuota {
+    /// Number of requests allowed per time window.
+    pub rate: NonZeroU32,
+    /// The time window.
+    pub time_unit: TimeUnit,
+}
+
+impl RequestCountQuota {
+    /// Convert to a `governor::Quota`, optionally overriding the burst.
+    pub fn to_governor_quota(&self, burst: Option<NonZeroU32>) -> Result<governor::Quota, String> {
+        let period = Duration::from(self.time_unit) / self.rate.get();
+        let burst = burst.unwrap_or(self.rate);
+        let quota = governor::Quota::with_period(period)
+            .ok_or_else(|| format!("Request-count quota rate '{}' is too high", self.rate.get()))?
+            .allow_burst(burst);
+        Ok(quota)
+    }
+}
+
+impl fmt::Display for RequestCountQuota {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}r/{}", self.rate, self.time_unit)
+    }
+}
+
+impl FromStr for RequestCountQuota {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (rate_with_unit, time_unit) = s.split_once('/').ok_or_else(|| {
+            format!("Invalid request-count quota format: '{s}', expected {{count}}r/{{time}}")
+        })?;
+        let rate = rate_with_unit
+            .strip_suffix('r')
+            .ok_or_else(|| format!("Request-count quota must end with 'r': '{rate_with_unit}'"))?
+            .parse::<NonZeroU32>()
+            .map_err(|_| format!("Failed to parse rate from '{s}'"))?;
+
+        let time_unit = TimeUnit::from_str(time_unit)?;
+
+        Ok(RequestCountQuota { rate, time_unit })
+    }
+}
+
+impl serde::Serialize for RequestCountQuota {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for RequestCountQuota {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        RequestCountQuota::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_and_display() {
+        let q: RequestCountQuota = "5r/s".parse().unwrap();
+        assert_eq!(q.rate, NonZeroU32::new(5).unwrap());
+        assert_eq!(q.time_unit, TimeUnit::Second);
+        assert_eq!(q.to_string(), "5r/s");
+
+        let q: RequestCountQuota = "100r/m".parse().unwrap();
+        assert_eq!(q.rate, NonZeroU32::new(100).unwrap());
+        assert_eq!(q.time_unit, TimeUnit::Minute);
+        assert_eq!(q.to_string(), "100r/m");
+    }
+
+    #[test]
+    fn test_converts_to_governor_quota() {
+        let q: RequestCountQuota = "5r/s".parse().unwrap();
+        assert_eq!(
+            q.to_governor_quota(None).unwrap(),
+            governor::Quota::per_second(NonZeroU32::new(5).unwrap())
+        );
+
+        let q: RequestCountQuota = "5r/m".parse().unwrap();
+        assert_eq!(
+            q.to_governor_quota(None).unwrap(),
+            governor::Quota::per_minute(NonZeroU32::new(5).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_rejects_rate_that_would_create_zero_replenish_period() {
+        let q = RequestCountQuota::from_str("4294967295r/s").unwrap();
+        let err = q.to_governor_quota(None).unwrap_err();
+        assert!(err.contains("too high"), "error: {err}");
+    }
+
+    #[test]
+    fn test_rejects_bandwidth_units() {
+        assert!(RequestCountQuota::from_str("5mb/s").is_err());
+        assert!(RequestCountQuota::from_str("5kb/m").is_err());
+    }
+
+    #[test]
+    fn test_rejects_invalid_formats() {
+        assert!(RequestCountQuota::from_str("5rs").is_err()); // missing /
+        assert!(RequestCountQuota::from_str("r/s").is_err()); // missing count
+        assert!(RequestCountQuota::from_str("5r/x").is_err()); // invalid time unit
+        assert!(RequestCountQuota::from_str("0r/s").is_err()); // zero rate
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Wrapper {
+            quota: RequestCountQuota,
+        }
+
+        let q: RequestCountQuota = "10r/m".parse().unwrap();
+        let toml = toml::to_string(&Wrapper { quota: q.clone() }).unwrap();
+        assert_eq!(toml, "quota = \"10r/m\"\n");
+        let wrapper: Wrapper = toml::from_str(&toml).unwrap();
+        assert_eq!(q, wrapper.quota);
+    }
+}

--- a/relay/src/quota_config/time_unit.rs
+++ b/relay/src/quota_config/time_unit.rs
@@ -1,0 +1,57 @@
+use std::time::Duration;
+
+/// The time unit of the quota.
+///
+/// Examples:
+/// - "s" -> second
+/// - "m" -> minute
+/// - "h" -> hour
+/// - "d" -> day
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TimeUnit {
+    /// Second
+    Second,
+    /// Minute
+    Minute,
+    /// Hour
+    Hour,
+    /// Day
+    Day,
+}
+
+impl std::fmt::Display for TimeUnit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let unit = match self {
+            TimeUnit::Second => "s",
+            TimeUnit::Minute => "m",
+            TimeUnit::Hour => "h",
+            TimeUnit::Day => "d",
+        };
+        write!(f, "{unit}")
+    }
+}
+
+impl std::str::FromStr for TimeUnit {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "s" => Ok(TimeUnit::Second),
+            "m" => Ok(TimeUnit::Minute),
+            "h" => Ok(TimeUnit::Hour),
+            "d" => Ok(TimeUnit::Day),
+            _ => Err(format!("Invalid time unit: {s}")),
+        }
+    }
+}
+
+impl From<TimeUnit> for Duration {
+    fn from(time_unit: TimeUnit) -> Self {
+        match time_unit {
+            TimeUnit::Second => Duration::from_secs(1),
+            TimeUnit::Minute => Duration::from_secs(60),
+            TimeUnit::Hour => Duration::from_secs(60 * 60),
+            TimeUnit::Day => Duration::from_secs(24 * 60 * 60),
+        }
+    }
+}

--- a/relay/src/rate_limiting.rs
+++ b/relay/src/rate_limiting.rs
@@ -2,12 +2,12 @@ use std::{net::IpAddr, sync::Arc, time::Duration};
 
 use crate::real_ip::RealIpKeyExtractor;
 use axum::Router;
-use governor::middleware::StateInformationMiddleware;
-use serde::{Deserialize, Serialize};
+use governor::middleware::{NoOpMiddleware, StateInformationMiddleware};
+use serde::{Deserialize, Deserializer, Serialize};
 use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
 pub use tower_governor::GovernorLayer;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Debug)]
 /// Configurations for rate limitng.
 pub struct RateLimiterConfig {
     /// Enable rate limit based on headers commonly used by reverse proxies.
@@ -26,6 +26,47 @@ pub struct RateLimiterConfig {
     ///
     /// **The burst_size must not be zero.**
     pub burst_size: u32,
+    /// Set the interval after which one user-initiated DHT operation quota item
+    /// is replenished in seconds.
+    ///
+    /// When omitted from configuration, this defaults to [`Self::per_second`].
+    ///
+    /// **The interval must not be zero.**
+    pub user_dht_per_second: u64,
+    /// Set quota size for DHT operations initiated by HTTP user requests.
+    ///
+    /// When omitted from configuration, this defaults to [`Self::burst_size`].
+    ///
+    /// **The burst_size must not be zero.**
+    pub user_dht_burst_size: u32,
+}
+
+#[derive(Deserialize)]
+struct RateLimiterConfigToml {
+    behind_proxy: bool,
+    per_second: u64,
+    burst_size: u32,
+    #[serde(default)]
+    user_dht_per_second: Option<u64>,
+    #[serde(default)]
+    user_dht_burst_size: Option<u32>,
+}
+
+impl<'de> Deserialize<'de> for RateLimiterConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let config = RateLimiterConfigToml::deserialize(deserializer)?;
+
+        Ok(Self {
+            behind_proxy: config.behind_proxy,
+            per_second: config.per_second,
+            burst_size: config.burst_size,
+            user_dht_per_second: config.user_dht_per_second.unwrap_or(config.per_second),
+            user_dht_burst_size: config.user_dht_burst_size.unwrap_or(config.burst_size),
+        })
+    }
 }
 
 impl Default for RateLimiterConfig {
@@ -34,6 +75,8 @@ impl Default for RateLimiterConfig {
             behind_proxy: false,
             per_second: 2,
             burst_size: 10,
+            user_dht_per_second: 2,
+            user_dht_burst_size: 10,
         }
     }
 }
@@ -47,8 +90,8 @@ pub struct IpRateLimiter {
 impl IpRateLimiter {
     /// Create an [IpRateLimiter]
     ///
-    /// This spawns a background thread to clean up the rate limiting cache.
-    pub fn new(config: &RateLimiterConfig) -> Self {
+    /// This spawns a background task to clean up the rate limiting cache.
+    pub async fn new(config: &RateLimiterConfig) -> Self {
         let governor_middleware = Arc::new(
             GovernorConfigBuilder::default()
                 .use_headers()
@@ -63,10 +106,12 @@ impl IpRateLimiter {
         let gc_interval = Duration::from_secs(60);
 
         let governor_limiter = governor_middleware.limiter().clone();
-        std::thread::spawn(move || loop {
-            std::thread::sleep(gc_interval);
-            tracing::debug!("rate limiting storage size: {}", governor_limiter.len());
-            governor_limiter.retain_recent();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(gc_interval).await;
+                tracing::debug!("rate limiting storage size: {}", governor_limiter.len());
+                governor_limiter.retain_recent();
+            }
         });
 
         Self {
@@ -85,6 +130,51 @@ impl IpRateLimiter {
     }
 }
 
+#[derive(Debug, Clone)]
+/// A rate limiter for user-initiated DHT operations keyed by normalized real IP.
+pub struct UserDhtRateLimiter {
+    governor_middleware: Arc<GovernorConfig<RealIpKeyExtractor, NoOpMiddleware>>,
+}
+
+impl UserDhtRateLimiter {
+    /// Create a [UserDhtRateLimiter].
+    ///
+    /// This spawns a background task to clean up the rate limiting cache.
+    pub async fn new(config: &RateLimiterConfig) -> Self {
+        let governor_middleware = Arc::new(
+            GovernorConfigBuilder::default()
+                .per_second(config.user_dht_per_second)
+                .burst_size(config.user_dht_burst_size)
+                .key_extractor(RealIpKeyExtractor)
+                .finish()
+                .expect("failed to build user DHT rate-limiting governor"),
+        );
+
+        let gc_interval = Duration::from_secs(60);
+
+        let governor_limiter = governor_middleware.limiter().clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(gc_interval).await;
+                tracing::debug!(
+                    "user DHT rate limiting storage size: {}",
+                    governor_limiter.len()
+                );
+                governor_limiter.retain_recent();
+            }
+        });
+
+        Self {
+            governor_middleware,
+        }
+    }
+
+    /// Check if the IP is allowed to initiate more DHT operations.
+    pub fn is_limited(&self, ip: &IpAddr) -> bool {
+        self.governor_middleware.limiter().check_key(ip).is_err()
+    }
+}
+
 impl pkarr::mainline::RequestFilter for IpRateLimiter {
     fn allow_request(
         &self,
@@ -92,5 +182,41 @@ impl pkarr::mainline::RequestFilter for IpRateLimiter {
         from: std::net::SocketAddrV4,
     ) -> bool {
         !self.is_limited(&IpAddr::from(*from.ip()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::{RateLimiterConfig, UserDhtRateLimiter};
+
+    #[tokio::test]
+    async fn user_dht_limiter_uses_configured_quota() {
+        let config = RateLimiterConfig {
+            user_dht_per_second: 60,
+            user_dht_burst_size: 1,
+            ..Default::default()
+        };
+        let limiter = UserDhtRateLimiter::new(&config).await;
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+
+        assert!(!limiter.is_limited(&ip));
+        assert!(limiter.is_limited(&ip));
+    }
+
+    #[test]
+    fn user_dht_limits_default_when_missing_from_toml() {
+        let config: RateLimiterConfig = toml::from_str(
+            r#"
+behind_proxy = false
+per_second = 7
+burst_size = 13
+"#,
+        )
+        .expect("legacy rate limiter config should deserialize");
+
+        assert_eq!(config.user_dht_per_second, 7);
+        assert_eq!(config.user_dht_burst_size, 13);
     }
 }

--- a/relay/src/rate_limiting.rs
+++ b/relay/src/rate_limiting.rs
@@ -24,6 +24,9 @@ pub struct RateLimiterConfig {
     pub behind_proxy: bool,
 
     /// HTTP request quota applied per normalized real IP.
+    ///
+    /// This is always applied before request handling to every HTTP request,
+    /// including GET, PUT, the index route, cache hits, and cache-only requests.
     pub quota: RequestCountQuota,
     /// Optional HTTP request burst size.
     ///
@@ -32,6 +35,11 @@ pub struct RateLimiterConfig {
     pub burst: Option<NonZeroU32>,
 
     /// User-initiated DHT operation quota applied per normalized real IP.
+    ///
+    /// This is separate from [`Self::quota`] and is consumed only when a request
+    /// makes the relay contact the DHT: PUT publishes, GET cache misses, expired
+    /// `CacheFirst` entries, and `DhtNetworkOnly` requests. Cache hits and
+    /// `LocalOrRelayCacheOnly` requests do not consume this quota.
     pub user_dht_quota: RequestCountQuota,
     /// Optional user-initiated DHT operation burst size.
     ///

--- a/relay/src/rate_limiting.rs
+++ b/relay/src/rate_limiting.rs
@@ -1,13 +1,19 @@
-use std::{net::IpAddr, sync::Arc, time::Duration};
+use std::{net::IpAddr, num::NonZeroU32, sync::Arc, time::Duration};
 
+use crate::quota_config::{RequestCountQuota, TimeUnit};
 use crate::real_ip::RealIpKeyExtractor;
 use axum::Router;
-use governor::middleware::{NoOpMiddleware, StateInformationMiddleware};
-use serde::{Deserialize, Deserializer, Serialize};
+use governor::{
+    clock::QuantaInstant,
+    middleware::{NoOpMiddleware, RateLimitingMiddleware, StateInformationMiddleware},
+};
+use serde::{Deserialize, Serialize};
 use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
+use tower_governor::key_extractor::KeyExtractor;
 pub use tower_governor::GovernorLayer;
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 /// Configurations for rate limitng.
 pub struct RateLimiterConfig {
     /// Enable rate limit based on headers commonly used by reverse proxies.
@@ -16,67 +22,38 @@ pub struct RateLimiterConfig {
     /// falling back to the connection's peer IP address.
     /// <https://docs.rs/tower_governor/latest/tower_governor/key_extractor/struct.SmartIpKeyExtractor.html>
     pub behind_proxy: bool,
-    /// Set the interval after which one element of the quota is replenished in seconds.
-    ///
-    /// **The interval must not be zero.**
-    pub per_second: u64,
-    /// Set quota size that defines how many requests can occur
-    /// before the governor middleware starts blocking requests from an IP address and
-    /// clients have to wait until the elements of the quota are replenished.
-    ///
-    /// **The burst_size must not be zero.**
-    pub burst_size: u32,
-    /// Set the interval after which one user-initiated DHT operation quota item
-    /// is replenished in seconds.
-    ///
-    /// When omitted from configuration, this defaults to [`Self::per_second`].
-    ///
-    /// **The interval must not be zero.**
-    pub user_dht_per_second: u64,
-    /// Set quota size for DHT operations initiated by HTTP user requests.
-    ///
-    /// When omitted from configuration, this defaults to [`Self::burst_size`].
-    ///
-    /// **The burst_size must not be zero.**
-    pub user_dht_burst_size: u32,
-}
 
-#[derive(Deserialize)]
-struct RateLimiterConfigToml {
-    behind_proxy: bool,
-    per_second: u64,
-    burst_size: u32,
+    /// HTTP request quota applied per normalized real IP.
+    pub quota: RequestCountQuota,
+    /// Optional HTTP request burst size.
+    ///
+    /// When omitted, this defaults to the rate configured in [`Self::quota`].
     #[serde(default)]
-    user_dht_per_second: Option<u64>,
+    pub burst: Option<NonZeroU32>,
+
+    /// User-initiated DHT operation quota applied per normalized real IP.
+    pub user_dht_quota: RequestCountQuota,
+    /// Optional user-initiated DHT operation burst size.
+    ///
+    /// When omitted, this defaults to the rate configured in [`Self::user_dht_quota`].
     #[serde(default)]
-    user_dht_burst_size: Option<u32>,
-}
-
-impl<'de> Deserialize<'de> for RateLimiterConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let config = RateLimiterConfigToml::deserialize(deserializer)?;
-
-        Ok(Self {
-            behind_proxy: config.behind_proxy,
-            per_second: config.per_second,
-            burst_size: config.burst_size,
-            user_dht_per_second: config.user_dht_per_second.unwrap_or(config.per_second),
-            user_dht_burst_size: config.user_dht_burst_size.unwrap_or(config.burst_size),
-        })
-    }
+    pub user_dht_burst: Option<NonZeroU32>,
 }
 
 impl Default for RateLimiterConfig {
     fn default() -> Self {
         Self {
             behind_proxy: false,
-            per_second: 2,
-            burst_size: 10,
-            user_dht_per_second: 2,
-            user_dht_burst_size: 10,
+            quota: RequestCountQuota {
+                rate: NonZeroU32::new(2).unwrap_or(NonZeroU32::MIN),
+                time_unit: TimeUnit::Second,
+            },
+            burst: NonZeroU32::new(10),
+            user_dht_quota: RequestCountQuota {
+                rate: NonZeroU32::new(2).unwrap_or(NonZeroU32::MIN),
+                time_unit: TimeUnit::Second,
+            },
+            user_dht_burst: NonZeroU32::new(10),
         }
     }
 }
@@ -91,16 +68,13 @@ impl IpRateLimiter {
     /// Create an [IpRateLimiter]
     ///
     /// This spawns a background task to clean up the rate limiting cache.
-    pub async fn new(config: &RateLimiterConfig) -> Self {
-        let governor_middleware = Arc::new(
-            GovernorConfigBuilder::default()
-                .use_headers()
-                .per_second(config.per_second)
-                .burst_size(config.burst_size)
-                .key_extractor(RealIpKeyExtractor)
-                .finish()
-                .expect("failed to build rate-limiting governor"),
-        );
+    pub async fn new(config: &RateLimiterConfig) -> Result<Self, String> {
+        let quota = config.quota.to_governor_quota(config.burst)?;
+        let builder = GovernorConfigBuilder::default()
+            .use_headers()
+            .key_extractor(RealIpKeyExtractor);
+        let governor_middleware = build_with_quota(builder, &quota);
+        let governor_middleware = Arc::new(governor_middleware);
 
         // The governor needs a background task for garbage collection (to clear expired records)
         let gc_interval = Duration::from_secs(60);
@@ -114,9 +88,9 @@ impl IpRateLimiter {
             }
         });
 
-        Self {
+        Ok(Self {
             governor_middleware,
-        }
+        })
     }
 
     /// Check if the Ip is allowed to make more requests
@@ -140,15 +114,13 @@ impl UserDhtRateLimiter {
     /// Create a [UserDhtRateLimiter].
     ///
     /// This spawns a background task to clean up the rate limiting cache.
-    pub async fn new(config: &RateLimiterConfig) -> Self {
-        let governor_middleware = Arc::new(
-            GovernorConfigBuilder::default()
-                .per_second(config.user_dht_per_second)
-                .burst_size(config.user_dht_burst_size)
-                .key_extractor(RealIpKeyExtractor)
-                .finish()
-                .expect("failed to build user DHT rate-limiting governor"),
-        );
+    pub async fn new(config: &RateLimiterConfig) -> Result<Self, String> {
+        let quota = config
+            .user_dht_quota
+            .to_governor_quota(config.user_dht_burst)?;
+        let builder = GovernorConfigBuilder::default().key_extractor(RealIpKeyExtractor);
+        let governor_middleware = build_with_quota(builder, &quota);
+        let governor_middleware = Arc::new(governor_middleware);
 
         let gc_interval = Duration::from_secs(60);
 
@@ -164,9 +136,9 @@ impl UserDhtRateLimiter {
             }
         });
 
-        Self {
+        Ok(Self {
             governor_middleware,
-        }
+        })
     }
 
     /// Check if the IP is allowed to initiate more DHT operations.
@@ -185,20 +157,39 @@ impl pkarr::mainline::RequestFilter for IpRateLimiter {
     }
 }
 
+fn build_with_quota<K, M>(
+    mut builder: GovernorConfigBuilder<K, M>,
+    quota: &governor::Quota,
+) -> GovernorConfig<K, M>
+where
+    K: KeyExtractor,
+    M: RateLimitingMiddleware<QuantaInstant>,
+{
+    builder
+        .period(quota.replenish_interval())
+        .burst_size(quota.burst_size().get())
+        .finish()
+        .expect("failed to build GovernorConfig from governor::Quota")
+}
+
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        num::NonZeroU32,
+    };
 
     use super::{RateLimiterConfig, UserDhtRateLimiter};
+    use crate::quota_config::RequestCountQuota;
 
     #[tokio::test]
     async fn user_dht_limiter_uses_configured_quota() {
         let config = RateLimiterConfig {
-            user_dht_per_second: 60,
-            user_dht_burst_size: 1,
+            user_dht_quota: "60r/s".parse::<RequestCountQuota>().unwrap(),
+            user_dht_burst: NonZeroU32::new(1),
             ..Default::default()
         };
-        let limiter = UserDhtRateLimiter::new(&config).await;
+        let limiter = UserDhtRateLimiter::new(&config).await.unwrap();
         let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
 
         assert!(!limiter.is_limited(&ip));
@@ -206,17 +197,79 @@ mod tests {
     }
 
     #[test]
-    fn user_dht_limits_default_when_missing_from_toml() {
+    fn rate_limiter_config_deserializes_new_quota_fields() {
         let config: RateLimiterConfig = toml::from_str(
+            r#"
+behind_proxy = false
+quota = "7r/s"
+burst = 13
+user_dht_quota = "3r/m"
+user_dht_burst = 5
+"#,
+        )
+        .expect("rate limiter config should deserialize");
+
+        assert_eq!(config.quota.to_string(), "7r/s");
+        assert_eq!(config.burst, NonZeroU32::new(13));
+        assert_eq!(config.user_dht_quota.to_string(), "3r/m");
+        assert_eq!(config.user_dht_burst, NonZeroU32::new(5));
+    }
+
+    #[test]
+    fn omitted_bursts_default_to_quota_rate() {
+        let config: RateLimiterConfig = toml::from_str(
+            r#"
+behind_proxy = false
+quota = "7r/s"
+user_dht_quota = "3r/m"
+"#,
+        )
+        .expect("rate limiter config should deserialize");
+
+        assert_eq!(
+            config
+                .quota
+                .to_governor_quota(config.burst)
+                .unwrap()
+                .burst_size(),
+            NonZeroU32::new(7).unwrap()
+        );
+        assert_eq!(
+            config
+                .user_dht_quota
+                .to_governor_quota(config.user_dht_burst)
+                .unwrap()
+                .burst_size(),
+            NonZeroU32::new(3).unwrap()
+        );
+    }
+
+    #[test]
+    fn zero_burst_is_rejected() {
+        let err = toml::from_str::<RateLimiterConfig>(
+            r#"
+behind_proxy = false
+quota = "7r/s"
+burst = 0
+user_dht_quota = "3r/m"
+"#,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("invalid value"));
+    }
+
+    #[test]
+    fn legacy_rate_limiter_fields_are_rejected() {
+        let err = toml::from_str::<RateLimiterConfig>(
             r#"
 behind_proxy = false
 per_second = 7
 burst_size = 13
 "#,
         )
-        .expect("legacy rate limiter config should deserialize");
+        .unwrap_err();
 
-        assert_eq!(config.user_dht_per_second, 7);
-        assert_eq!(config.user_dht_burst_size, 13);
+        assert!(err.to_string().contains("unknown field"));
     }
 }


### PR DESCRIPTION
Add a separate user-initiated DHT rate limiter for relay HTTP
PUT requests and GET requests that query the DHT. Preserve cache-only
and fresh CacheFirst reads without consuming that quota.

BREAKING CHANGE: RateLimiterConfig now requires user_dht_per_second
and user_dht_burst_size fields when constructed with a Rust struct
literal.
