### PR TITLE
refactor(dht)!: hide mainline client behind wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,12 +1480,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mainline"
-version = "6.1.2"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578beb3b6dcbe6f3f60a89547a13b34d36bda41dc056540bac5f4e4340ebf25c"
+checksum = "25fd96e1eb0cff23f7048801d1561336c2e3c9f2b468d0271f27ad3463f583bf"
 dependencies = [
  "crc",
- "digest",
  "document-features",
  "dyn-clone",
  "ed25519-dalek",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -64,7 +64,7 @@ getrandom = { version = "0.4.1", default-features = false }
 tracing = { version = "0.1.44", optional = true }
 
 # feat: dht dependencies
-mainline = { version = "6.1.2", default-features = false, features = ["async"], optional = true }
+mainline = { version = "6.2.0", default-features = false, features = ["async"], optional = true }
 
 # feat: relay dependencies
 reqwest = { workspace = true, optional = true }

--- a/pkarr/src/client.rs
+++ b/pkarr/src/client.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 use std::{hash::Hash, num::NonZeroUsize};
 
 #[cfg(dht)]
-use mainline::{errors::PutMutableError, Dht};
+use crate::dht::DhtClient;
 
 use builder::{ClientBuilder, Config};
 
@@ -49,7 +49,7 @@ pub(crate) struct Inner {
     maximum_ttl: u32,
     cache: Option<Arc<dyn Cache>>,
     #[cfg(dht)]
-    dht: Option<Dht>,
+    dht: Option<DhtClient>,
     #[cfg(relays)]
     relays: Option<RelaysClient>,
     #[cfg(feature = "endpoints")]
@@ -87,8 +87,8 @@ impl Client {
         cross_debug!("Starting Pkarr Client {:?}", config);
 
         #[cfg(dht)]
-        let dht = if let Some(builder) = config.dht {
-            Some(builder.build().map_err(BuildError::DhtBuildError)?)
+        let dht = if let Some(config) = config.dht {
+            Some(DhtClient::build(config).map_err(BuildError::DhtBuildError)?)
         } else {
             None
         };
@@ -145,14 +145,10 @@ impl Client {
         self.0.cache.as_deref()
     }
 
-    /// Returns a reference to the internal [mainline::Dht] node.
-    ///
-    /// Gives you access to methods like [mainline::Dht::info],
-    /// [mainline::Dht::bootstrapped], and [mainline::Dht::to_bootstrap]
-    /// among the rest of the API.
+    /// Returns a reference to the internal DHT client.
     #[cfg(dht)]
-    pub fn dht(&self) -> Option<mainline::Dht> {
-        self.0.dht.as_ref().cloned()
+    pub fn dht(&self) -> Option<&DhtClient> {
+        self.0.dht.as_ref()
     }
 
     // === Publish ===
@@ -325,11 +321,8 @@ impl Client {
         #[cfg(dht)]
         let dht_future = {
             let signed_packet = signed_packet.clone();
-            self.dht().map(|node| async move {
-                node.as_async()
-                    .put_mutable((&signed_packet).into(), cas.map(|t| t.as_u64() as i64))
-                    .await
-                    .map(|_| Ok(()))?
+            self.dht().cloned().map(|dht| async move {
+                dht.publish(&signed_packet, cas).await.map_err(Into::into)
             })
         };
 
@@ -462,14 +455,10 @@ impl Client {
         use futures::select_stream;
 
         #[cfg(dht)]
-        let dht_stream = match self.dht() {
-            Some(node) => map_dht_stream(node.as_async().get_mutable(
-                public_key.as_bytes(),
-                None,
-                more_recent_than.map(|t| t.as_u64() as i64),
-            )),
-            None => None,
-        };
+        let dht_stream = self.dht().cloned().map(|dht| {
+            let public_key = public_key.clone();
+            dht.resolve(&public_key, more_recent_than).boxed()
+        });
 
         #[cfg(relays)]
         let relays_stream = self
@@ -525,25 +514,6 @@ fn filter_incoming_signed_packet(
     } else {
         None
     }
-}
-
-#[cfg(dht)]
-fn map_dht_stream(
-    stream: mainline::async_dht::GetStream<mainline::MutableItem>,
-) -> Option<Pin<Box<dyn Stream<Item = SignedPacket> + Send>>> {
-    Some(
-        stream
-            .filter_map(
-                move |mutable_item| match SignedPacket::try_from(mutable_item) {
-                    Ok(signed_packet) => Some(signed_packet),
-                    Err(error) => {
-                        cross_debug!("Got an invalid signed packet from the DHT. Error: {error}");
-                        None
-                    }
-                },
-            )
-            .boxed(),
-    )
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -624,23 +594,25 @@ pub enum ConcurrencyError {
 }
 
 #[cfg(dht)]
-impl From<PutMutableError> for PublishError {
-    fn from(value: PutMutableError) -> Self {
+impl From<crate::dht::PublishError> for PublishError {
+    fn from(value: crate::dht::PublishError) -> Self {
         match value {
-            PutMutableError::Query(error) => PublishError::Query(match error {
-                mainline::errors::PutQueryError::Timeout => QueryError::Timeout,
-                mainline::errors::PutQueryError::NoClosestNodes => QueryError::NoClosestNodes,
-                mainline::errors::PutQueryError::ErrorResponse(error) => {
-                    QueryError::DhtErrorResponse(error.code, error.description)
-                }
-            }),
-            PutMutableError::Concurrency(error) => PublishError::Concurrency(match error {
-                mainline::errors::ConcurrencyError::ConflictRisk => ConcurrencyError::ConflictRisk,
-                mainline::errors::ConcurrencyError::NotMostRecent => {
-                    ConcurrencyError::NotMostRecent
-                }
-                mainline::errors::ConcurrencyError::CasFailed => ConcurrencyError::CasFailed,
-            }),
+            crate::dht::PublishError::Timeout => PublishError::Query(QueryError::Timeout),
+            crate::dht::PublishError::NoClosestNodes => {
+                PublishError::Query(QueryError::NoClosestNodes)
+            }
+            crate::dht::PublishError::ErrorResponse { code, description } => {
+                PublishError::Query(QueryError::DhtErrorResponse(code, description))
+            }
+            crate::dht::PublishError::ConflictRisk => {
+                PublishError::Concurrency(ConcurrencyError::ConflictRisk)
+            }
+            crate::dht::PublishError::NotMostRecent => {
+                PublishError::Concurrency(ConcurrencyError::NotMostRecent)
+            }
+            crate::dht::PublishError::CasFailed => {
+                PublishError::Concurrency(ConcurrencyError::CasFailed)
+            }
         }
     }
 }

--- a/pkarr/src/client/blocking.rs
+++ b/pkarr/src/client/blocking.rs
@@ -23,16 +23,6 @@ impl ClientBlocking {
         self.0.cache()
     }
 
-    /// Returns a reference to the internal [mainline::Dht] node.
-    ///
-    /// Gives you access to methods like [mainline::Dht::info],
-    /// [mainline::Dht::bootstrapped], and [mainline::Dht::to_bootstrap]
-    /// among the rest of the API.
-    #[cfg(dht)]
-    pub fn dht(&self) -> Option<mainline::Dht> {
-        self.0.dht()
-    }
-
     // === Publish ===
 
     /// Publishes a [SignedPacket] to the [mainline] Dht and or [Relays](https://github.com/pubky/pkarr/blob/main/design/relays.md).

--- a/pkarr/src/client/builder.rs
+++ b/pkarr/src/client/builder.rs
@@ -1,5 +1,5 @@
 #[cfg(dht)]
-use std::net::ToSocketAddrs;
+use std::net::{SocketAddr, SocketAddrV4, ToSocketAddrs};
 use std::{sync::Arc, time::Duration};
 
 #[cfg(feature = "relays")]
@@ -36,7 +36,7 @@ pub(crate) struct Config {
     pub cache: Option<Arc<dyn Cache>>,
 
     #[cfg(dht)]
-    pub dht: Option<mainline::DhtBuilder>,
+    pub dht: Option<mainline::Config>,
 
     /// Pkarr [Relays](https://github.com/pubky/pkarr/blob/main/design/relays.md) Urls
     #[cfg(feature = "relays")]
@@ -62,7 +62,7 @@ impl Default for Config {
             cache: None,
 
             #[cfg(dht)]
-            dht: Some(mainline::Dht::builder()),
+            dht: Some(mainline::Config::default()),
 
             #[cfg(feature = "relays")]
             relays: Some(
@@ -138,10 +138,10 @@ impl ClientBuilder {
     }
 
     #[cfg(dht)]
-    /// Create a [mainline::DhtBuilder] if `None`, and allows mutating it with a callback function.
+    /// Create a [mainline::Config] if `None`, and allows mutating it with a callback function.
     pub fn dht<F>(&mut self, f: F) -> &mut Self
     where
-        F: FnOnce(&mut mainline::DhtBuilder) -> &mut mainline::DhtBuilder,
+        F: FnOnce(&mut mainline::Config) -> &mut mainline::Config,
     {
         if self.0.dht.is_none() {
             self.0.dht = Some(Default::default());
@@ -158,11 +158,14 @@ impl ClientBuilder {
     ///
     /// You can start a separate Dht network by setting this to an empty array.
     ///
-    /// If you want to extend [bootstrap][mainline::DhtBuilder::bootstrap] nodes with more nodes, you can
+    /// If you want to extend bootstrap nodes with more nodes, you can
     /// use [Self::extra_bootstrap].
     #[cfg(dht)]
     pub fn bootstrap<T: ToSocketAddrs>(&mut self, bootstrap: &[T]) -> &mut Self {
-        self.dht(|b| b.bootstrap(bootstrap));
+        self.dht(|config| {
+            config.bootstrap = Some(to_socket_address_v4(bootstrap));
+            config
+        });
 
         self
     }
@@ -173,7 +176,12 @@ impl ClientBuilder {
     /// If you want to set (override) the DHT bootstrapping nodes,
     /// use [Self::bootstrap] directly.
     pub fn extra_bootstrap<T: ToSocketAddrs>(&mut self, bootstrap: &[T]) -> &mut Self {
-        self.dht(|b| b.extra_bootstrap(bootstrap));
+        self.dht(|config| {
+            let mut existing = config.bootstrap.clone().unwrap_or_default();
+            existing.extend(to_socket_address_v4(bootstrap));
+            config.bootstrap = Some(existing);
+            config
+        });
 
         self
     }
@@ -263,7 +271,9 @@ impl ClientBuilder {
     pub fn request_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.0.request_timeout = timeout;
         #[cfg(dht)]
-        self.0.dht.as_mut().map(|b| b.request_timeout(timeout));
+        if let Some(config) = self.0.dht.as_mut() {
+            config.request_timeout = timeout;
+        }
 
         self
     }
@@ -284,6 +294,24 @@ impl ClientBuilder {
     pub fn build(&self) -> Result<Client, BuildError> {
         Client::new(self.0.clone())
     }
+}
+
+#[cfg(dht)]
+fn to_socket_address_v4<T: ToSocketAddrs>(bootstrap: &[T]) -> Vec<SocketAddrV4> {
+    bootstrap
+        .iter()
+        .flat_map(|s| {
+            s.to_socket_addrs().map(|addrs| {
+                addrs
+                    .filter_map(|addr| match addr {
+                        SocketAddr::V4(addr_v4) => Some(addr_v4),
+                        _ => None,
+                    })
+                    .collect::<Box<[_]>>()
+            })
+        })
+        .flatten()
+        .collect()
 }
 
 #[cfg(relays)]

--- a/pkarr/src/client/tests.rs
+++ b/pkarr/src/client/tests.rs
@@ -32,7 +32,10 @@ pub(crate) fn builder(
         .no_default_network()
         // Because of pkarr_relay crate, dht is always enabled.
         .bootstrap(&testnet.bootstrap)
-        .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST));
+        .dht(|config| {
+            config.bind_address = Some(Ipv4Addr::LOCALHOST);
+            config
+        });
 
     if std::env::var("CI").is_ok() {
         builder.request_timeout(Duration::from_millis(1000));
@@ -686,7 +689,10 @@ async fn discard_cache_with_zero_capacity() {
         .pkarr(|builder| {
             builder.no_default_network();
             builder.bootstrap(&testnet.bootstrap);
-            builder.dht(|b| b.bind_address(Ipv4Addr::LOCALHOST));
+            builder.dht(|config| {
+                config.bind_address = Some(Ipv4Addr::LOCALHOST);
+                config
+            });
             builder
         });
     let relay = unsafe { builder.run().await.unwrap() };
@@ -698,7 +704,10 @@ async fn discard_cache_with_zero_capacity() {
     let client = Client::builder()
         .no_default_network()
         .bootstrap(&testnet.bootstrap)
-        .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
+        .dht(|config| {
+            config.bind_address = Some(Ipv4Addr::LOCALHOST);
+            config
+        })
         .build()
         .unwrap();
 

--- a/pkarr/src/dht/client.rs
+++ b/pkarr/src/dht/client.rs
@@ -1,8 +1,63 @@
 use ed25519_dalek::Signature;
-use mainline::MutableItem;
+use futures_lite::{Stream, StreamExt};
+use mainline::{async_dht::AsyncDht, Config, Dht, MutableItem};
 use ntimestamp::Timestamp;
 
 use crate::{PublicKey, SignedPacket};
+
+use super::{DhtInfo, PublishError};
+
+/// Pkarr DHT client.
+#[derive(Clone, Debug)]
+pub struct DhtClient {
+    inner: AsyncDht,
+}
+
+impl DhtClient {
+    /// Build a DHT client from a Mainline configuration.
+    pub fn build(config: Config) -> Result<Self, std::io::Error> {
+        let dht = Dht::new(config)?;
+        Ok(Self {
+            inner: dht.as_async(),
+        })
+    }
+
+    /// Publish a signed packet to the DHT.
+    pub async fn publish(
+        &self,
+        signed_packet: &SignedPacket,
+        cas: Option<Timestamp>,
+    ) -> Result<(), PublishError> {
+        let cas = cas.map(|timestamp| timestamp.as_u64() as i64);
+        self.inner.put_mutable(signed_packet.into(), cas).await?;
+        Ok(())
+    }
+
+    /// Resolve signed packets newer than the given timestamp.
+    pub fn resolve(
+        &self,
+        public_key: &PublicKey,
+        more_recent_than: Option<Timestamp>,
+    ) -> impl Stream<Item = SignedPacket> + Send {
+        let more_recent_than = more_recent_than.map(|timestamp| timestamp.as_u64() as i64);
+
+        self.inner
+            .get_mutable(public_key.as_bytes(), None, more_recent_than)
+            .filter_map(|item| SignedPacket::try_from(item).ok())
+    }
+
+    /// Return information about the underlying DHT node.
+    pub async fn info(&self) -> DhtInfo {
+        let info = self.inner.info().await;
+
+        DhtInfo::new(
+            info.local_addr(),
+            info.public_address(),
+            info.firewalled(),
+            info.dht_size_estimate(),
+        )
+    }
+}
 
 impl From<&SignedPacket> for MutableItem {
     fn from(s: &SignedPacket) -> Self {

--- a/pkarr/src/dht/error.rs
+++ b/pkarr/src/dht/error.rs
@@ -1,0 +1,56 @@
+use mainline::errors::PutMutableError;
+
+/// DHT publish error.
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PublishError {
+    /// DHT query timed out.
+    #[error("DHT query timed out")]
+    Timeout,
+
+    /// DHT query found no closest nodes.
+    #[error("DHT query found no closest nodes")]
+    NoClosestNodes,
+
+    /// DHT query returned an error response.
+    #[error("DHT query returned error response code: {code}, description: {description}")]
+    ErrorResponse {
+        /// Error response code.
+        code: i32,
+        /// Error response description.
+        description: String,
+    },
+
+    /// Publishing risks a write conflict.
+    #[error("publishing risks a write conflict")]
+    ConflictRisk,
+
+    /// Packet is not the most recent.
+    #[error("packet is not the most recent")]
+    NotMostRecent,
+
+    /// Compare-and-swap failed.
+    #[error("compare-and-swap failed")]
+    CasFailed,
+}
+
+impl From<PutMutableError> for PublishError {
+    fn from(value: PutMutableError) -> Self {
+        match value {
+            PutMutableError::Query(error) => match error {
+                mainline::errors::PutQueryError::Timeout => PublishError::Timeout,
+                mainline::errors::PutQueryError::NoClosestNodes => PublishError::NoClosestNodes,
+                mainline::errors::PutQueryError::ErrorResponse(error) => {
+                    PublishError::ErrorResponse {
+                        code: error.code,
+                        description: error.description,
+                    }
+                }
+            },
+            PutMutableError::Concurrency(error) => match error {
+                mainline::errors::ConcurrencyError::ConflictRisk => PublishError::ConflictRisk,
+                mainline::errors::ConcurrencyError::NotMostRecent => PublishError::NotMostRecent,
+                mainline::errors::ConcurrencyError::CasFailed => PublishError::CasFailed,
+            },
+        }
+    }
+}

--- a/pkarr/src/dht/info.rs
+++ b/pkarr/src/dht/info.rs
@@ -1,0 +1,46 @@
+use std::net::SocketAddrV4;
+
+/// Information about the DHT node.
+#[derive(Clone, Copy, Debug)]
+pub struct DhtInfo {
+    local_addr: SocketAddrV4,
+    public_address: Option<SocketAddrV4>,
+    firewalled: bool,
+    dht_size_estimate: (usize, f64),
+}
+
+impl DhtInfo {
+    pub(crate) fn new(
+        local_addr: SocketAddrV4,
+        public_address: Option<SocketAddrV4>,
+        firewalled: bool,
+        dht_size_estimate: (usize, f64),
+    ) -> Self {
+        Self {
+            local_addr,
+            public_address,
+            firewalled,
+            dht_size_estimate,
+        }
+    }
+
+    /// Local UDP IPv4 socket address that this node is listening on.
+    pub fn local_addr(&self) -> SocketAddrV4 {
+        self.local_addr
+    }
+
+    /// Returns the best guess for this node's public address.
+    pub fn public_address(&self) -> Option<SocketAddrV4> {
+        self.public_address
+    }
+
+    /// Returns true if this node is likely firewalled.
+    pub fn firewalled(&self) -> bool {
+        self.firewalled
+    }
+
+    /// Returns the DHT size estimate and confidence value.
+    pub fn dht_size_estimate(&self) -> (usize, f64) {
+        self.dht_size_estimate
+    }
+}

--- a/pkarr/src/dht/mod.rs
+++ b/pkarr/src/dht/mod.rs
@@ -1,1 +1,9 @@
-pub mod client;
+//! Mainline DHT integration.
+
+mod client;
+mod error;
+mod info;
+
+pub use client::DhtClient;
+pub use error::PublishError;
+pub use info::DhtInfo;

--- a/pkarr/src/extra/endpoints/mod.rs
+++ b/pkarr/src/extra/endpoints/mod.rs
@@ -212,7 +212,10 @@ mod tests {
         let client = Client::builder()
             .no_default_network()
             .bootstrap(&testnet.bootstrap)
-            .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
+            .dht(|config| {
+                config.bind_address = Some(Ipv4Addr::LOCALHOST);
+                config
+            })
             .build()
             .unwrap();
 
@@ -233,7 +236,10 @@ mod tests {
         let client = Client::builder()
             .no_default_network()
             .bootstrap(&testnet.bootstrap)
-            .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
+            .dht(|config| {
+                config.bind_address = Some(Ipv4Addr::LOCALHOST);
+                config
+            })
             .request_timeout(Duration::from_millis(200))
             .build()
             .unwrap();
@@ -254,7 +260,10 @@ mod tests {
         let client = Client::builder()
             .no_default_network()
             .bootstrap(&testnet.bootstrap)
-            .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
+            .dht(|config| {
+                config.bind_address = Some(Ipv4Addr::LOCALHOST);
+                config
+            })
             .request_timeout(Duration::from_millis(20))
             .build()
             .unwrap();
@@ -272,7 +281,10 @@ mod tests {
         let client = Client::builder()
             .no_default_network()
             .bootstrap(&testnet.bootstrap)
-            .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
+            .dht(|config| {
+                config.bind_address = Some(Ipv4Addr::LOCALHOST);
+                config
+            })
             .request_timeout(Duration::from_millis(100))
             .max_recursion_depth(3)
             .build()
@@ -291,7 +303,10 @@ mod tests {
         let client = Client::builder()
             .no_default_network()
             .bootstrap(&testnet.bootstrap)
-            .dht(|b| b.bind_address(Ipv4Addr::LOCALHOST))
+            .dht(|config| {
+                config.bind_address = Some(Ipv4Addr::LOCALHOST);
+                config
+            })
             .request_timeout(Duration::from_millis(200))
             .build()
             .unwrap();

--- a/pkarr/src/lib.rs
+++ b/pkarr/src/lib.rs
@@ -11,7 +11,7 @@
 #[cfg(client)]
 mod client;
 #[cfg(dht)]
-mod dht;
+pub mod dht;
 #[cfg(client)]
 pub mod extra;
 pub mod types;

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -129,7 +129,10 @@ impl Config {
         }
 
         if let Some(port) = config_toml.mainline.and_then(|m| m.port) {
-            config.pkarr.dht(|builder| builder.port(port));
+            config.pkarr.dht(|dht| {
+                dht.port = Some(port);
+                dht
+            });
         }
 
         if let Some(HttpConfig { port: Some(port) }) = config_toml.http {

--- a/relay/src/error.rs
+++ b/relay/src/error.rs
@@ -5,7 +5,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use pkarr::mainline::errors::{ConcurrencyError, PutMutableError};
+use pkarr::dht;
 
 #[derive(Debug, Clone)]
 pub struct Error {
@@ -68,19 +68,19 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<PutMutableError> for Error {
-    fn from(error: PutMutableError) -> Self {
+impl From<dht::PublishError> for Error {
+    fn from(error: dht::PublishError) -> Self {
         match error {
-            PutMutableError::Query(_) => Self::new(StatusCode::INTERNAL_SERVER_ERROR, Some(error)),
-            PutMutableError::Concurrency(ConcurrencyError::CasFailed) => {
-                Self::new(StatusCode::PRECONDITION_FAILED, Some(error))
+            dht::PublishError::Timeout
+            | dht::PublishError::NoClosestNodes
+            | dht::PublishError::ErrorResponse { .. } => {
+                Self::new(StatusCode::INTERNAL_SERVER_ERROR, Some(error))
             }
-            PutMutableError::Concurrency(ConcurrencyError::ConflictRisk) => {
+            dht::PublishError::CasFailed => Self::new(StatusCode::PRECONDITION_FAILED, Some(error)),
+            dht::PublishError::ConflictRisk => {
                 Self::new(StatusCode::PRECONDITION_REQUIRED, Some(error))
             }
-            PutMutableError::Concurrency(ConcurrencyError::NotMostRecent) => {
-                Self::new(StatusCode::CONFLICT, Some(error))
-            }
+            dht::PublishError::NotMostRecent => Self::new(StatusCode::CONFLICT, Some(error)),
         }
     }
 }

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -4,9 +4,8 @@ use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
 use futures_lite::StreamExt;
 use http::StatusCode;
-use pkarr::mainline::async_dht::AsyncDht;
 use pkarr::mainline::errors::ConcurrencyError;
-use pkarr::{Cache, CacheKey, PublicKey, ResolvePolicy, SignedPacket, Timestamp};
+use pkarr::{Cache, CacheKey, ResolvePolicy, SignedPacket, Timestamp};
 use serde::Deserialize;
 
 use crate::error::Error;
@@ -37,8 +36,7 @@ pub async fn put(
 
     enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
 
-    let cas = cas.map(|t| t.as_u64() as i64);
-    state.dht.put_mutable((&signed_packet).into(), cas).await?;
+    state.dht.publish(&signed_packet, cas).await?;
     update_cache_if_needed(&state, &key, &signed_packet);
 
     Ok(StatusCode::NO_CONTENT)
@@ -55,49 +53,43 @@ pub async fn get(
 
     let policy = query.policy.unwrap_or(ResolvePolicy::CacheFirst);
     let cached_packet = state.cache.get_read_only(&key);
-    let signed_packet = match policy {
+    let more_recent_than = cached_packet
+        .as_ref()
+        .map(SignedPacket::timestamp)
+        .and_then(decrement);
+
+    let packet = match policy {
         ResolvePolicy::LocalOrRelayCacheOnly => cached_packet,
         ResolvePolicy::CacheFirst => match cached_packet {
             Some(packet) if !packet.is_expired(state.minimum_ttl, state.maximum_ttl) => {
                 Some(packet)
             }
-            Some(packet) => {
+            _ => {
                 enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-                resolve(
-                    &state.dht,
-                    &public_key,
-                    Mode::First,
-                    Some(packet.timestamp()),
-                )
-                .await
-            }
-            None => {
-                enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-                resolve(&state.dht, &public_key, Mode::First, None).await
+                let mut stream = state.dht.resolve(&public_key, more_recent_than);
+                let packet = stream.next().await;
+                let state = state.clone();
+                // Do not waste late responses with potentially newer packets.
+                tokio::spawn(async move {
+                    if let Some(packet) = stream.fold(None, most_recent_packet).await {
+                        update_cache_if_needed(&state, &key, &packet);
+                    }
+                });
+                packet
             }
         },
         ResolvePolicy::DhtNetworkOnly => {
             enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-            let at_least_that_recent = cached_packet.as_ref().map(SignedPacket::timestamp);
-            resolve(
-                &state.dht,
-                &public_key,
-                Mode::MostRecent,
-                at_least_that_recent,
-            )
-            .await
+            let stream = state.dht.resolve(&public_key, more_recent_than);
+            stream.fold(None, most_recent_packet).await
         }
     };
 
-    if let Some(signed_packet) = signed_packet {
-        update_cache_if_needed(&state, &key, &signed_packet);
+    if let Some(packet) = packet {
+        update_cache_if_needed(&state, &key, &packet);
 
-        let ttl = signed_packet.ttl(state.minimum_ttl, state.maximum_ttl);
-        Ok(SignedPacketResponse::new(
-            signed_packet,
-            ttl,
-            if_modified_since,
-        ))
+        let ttl = packet.ttl(state.minimum_ttl, state.maximum_ttl);
+        Ok(SignedPacketResponse::new(packet, ttl, if_modified_since))
     } else {
         Err(Error::with_status(StatusCode::NOT_FOUND))
     }
@@ -205,38 +197,6 @@ fn format_number(num: usize) -> String {
     result
 }
 
-enum Mode {
-    First,
-    MostRecent,
-}
-
-async fn resolve(
-    dht: &AsyncDht,
-    public_key: &PublicKey,
-    mode: Mode,
-    at_least_that_recent: Option<Timestamp>,
-) -> Option<SignedPacket> {
-    // TODO: Ratelimit.
-    let key = public_key.as_bytes();
-    // It is safe to subtract 1, because even the very first item has a timestamp
-    // greater than 0.
-    let more_recent_than = at_least_that_recent
-        .map(|timestamp| timestamp.as_u64() as i64 - 1)
-        .unwrap_or_default();
-    let item = match mode {
-        Mode::First => {
-            dht.get_mutable(key, None, Some(more_recent_than))
-                .next()
-                .await
-        }
-        Mode::MostRecent => dht
-            .get_mutable_most_recent(key, None)
-            .await
-            .filter(|item| more_recent_than < item.seq()),
-    };
-    item.map(SignedPacket::try_from).transpose().ok().flatten()
-}
-
 fn update_cache_if_needed(state: &AppState, key: &CacheKey, signed_packet: &SignedPacket) {
     let _lock = state
         .cache_write_lock
@@ -258,6 +218,10 @@ fn update_cache_if_needed(state: &AppState, key: &CacheKey, signed_packet: &Sign
     }
 }
 
+fn decrement(timestamp: Timestamp) -> Option<Timestamp> {
+    timestamp.as_u64().checked_sub(1).map(Timestamp::from)
+}
+
 fn enforce_user_dht_rate_limit(
     state: &AppState,
     real_ip: Option<&Extension<RealIp>>,
@@ -273,4 +237,118 @@ fn enforce_user_dht_rate_limit(
     }
 
     Ok(())
+}
+
+fn most_recent_packet(
+    most_recent: Option<SignedPacket>,
+    packet: SignedPacket,
+) -> Option<SignedPacket> {
+    match most_recent {
+        Some(mr) if mr.more_recent_than(&packet) => Some(mr),
+        _ => Some(packet),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decrement, most_recent_packet};
+    use pkarr::{Keypair, SignedPacket, Timestamp};
+
+    fn signed_packet(timestamp: u64, text: &str) -> SignedPacket {
+        signed_packet_for_key(&Keypair::random(), timestamp, text)
+    }
+
+    fn signed_packet_for_key(keypair: &Keypair, timestamp: u64, text: &str) -> SignedPacket {
+        SignedPacket::builder()
+            .timestamp(Timestamp::from(timestamp))
+            .txt("test".try_into().unwrap(), text.try_into().unwrap(), 30)
+            .sign(keypair)
+            .unwrap()
+    }
+
+    #[test]
+    fn most_recent_packet_selects_newest_packet() {
+        let packet = signed_packet(1, "first");
+
+        assert_eq!(
+            most_recent_packet(None, packet.clone()).unwrap().as_bytes(),
+            packet.as_bytes()
+        );
+
+        let existing = signed_packet(2, "existing");
+        let packet = signed_packet(1, "packet");
+
+        assert_eq!(
+            most_recent_packet(Some(existing.clone()), packet)
+                .unwrap()
+                .as_bytes(),
+            existing.as_bytes()
+        );
+
+        let existing = signed_packet(1, "existing");
+        let packet = signed_packet(2, "packet");
+
+        assert_eq!(
+            most_recent_packet(Some(existing), packet.clone())
+                .unwrap()
+                .as_bytes(),
+            packet.as_bytes()
+        );
+
+        let keypair = Keypair::random();
+        let a = signed_packet_for_key(&keypair, 1, "a");
+        let b = signed_packet_for_key(&keypair, 1, "b");
+        let (smaller, larger) = if a.encoded_packet() < b.encoded_packet() {
+            (a, b)
+        } else {
+            (b, a)
+        };
+
+        assert_eq!(
+            most_recent_packet(Some(larger.clone()), smaller.clone())
+                .unwrap()
+                .as_bytes(),
+            larger.as_bytes()
+        );
+
+        assert_eq!(
+            most_recent_packet(Some(smaller), larger.clone())
+                .unwrap()
+                .as_bytes(),
+            larger.as_bytes()
+        );
+    }
+
+    #[test]
+    fn most_recent_packet_uses_value_tie_breaker_for_same_timestamp() {
+        let keypair = Keypair::random();
+        let (smaller_value, larger_value) = (0..1000)
+            .find_map(|i| {
+                let a = signed_packet_for_key(&keypair, 1, &format!("a{i}"));
+                let b = signed_packet_for_key(&keypair, 1, &format!("b{i}"));
+
+                (a.encoded_packet().cmp(&b.encoded_packet()) != a.as_bytes().cmp(b.as_bytes()))
+                    .then(|| {
+                        if a.more_recent_than(&b) {
+                            (b, a)
+                        } else {
+                            (a, b)
+                        }
+                    })
+            })
+            .expect("test packet pair with conflicting signature and DNS value ordering");
+
+        assert_eq!(
+            most_recent_packet(Some(smaller_value), larger_value.clone())
+                .unwrap()
+                .encoded_packet(),
+            larger_value.encoded_packet()
+        );
+    }
+
+    #[test]
+    fn zero_timestamp_has_no_dht_lower_bound() {
+        assert_eq!(decrement(Timestamp::from(0)), None);
+        assert_eq!(decrement(Timestamp::from(1)), Some(Timestamp::from(0)));
+    }
 }

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -30,7 +30,7 @@ use axum_server::Handle;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 use tracing::info;
 
-use pkarr::{extra::lmdb_cache::LmdbCache, mainline::async_dht::AsyncDht, Timestamp};
+use pkarr::{dht::DhtClient, extra::lmdb_cache::LmdbCache, Timestamp};
 use url::Url;
 
 use config::{Config, CACHE_DIR};
@@ -157,11 +157,12 @@ impl Relay {
                     rate_limiting::UserDhtRateLimiter::new(rate_limiter_config)
                         .await
                         .map_err(|e| anyhow!("Failed to build UserDhtRateLimiter: {e}"))?;
-                config.pkarr.dht(|builder| {
-                    builder.server_settings(pkarr::mainline::ServerSettings {
+                config.pkarr.dht(|config| {
+                    config.server_settings = pkarr::mainline::ServerSettings {
                         filter: Box::new(rate_limiter.clone()),
                         ..Default::default()
-                    })
+                    };
+                    config
                 });
                 (Some(rate_limiter), Some(user_dht_rate_limiter))
             }
@@ -175,7 +176,7 @@ impl Relay {
         // See open issue https://github.com/programatik29/axum-server/issues/181
         listener.set_nonblocking(true)?;
 
-        let dht = client.dht().expect("dht network is enabled").as_async();
+        let dht = client.dht().expect("dht network is enabled").clone();
         let node_address = dht.info().await.local_addr();
         let relay_address = listener.local_addr()?;
 
@@ -244,10 +245,10 @@ impl Relay {
             .bootstrap(&testnet.bootstrap)
             .request_timeout(Duration::from_millis(100))
             .bootstrap(&testnet.bootstrap)
-            .dht(|builder| {
-                builder
-                    .server_mode()
-                    .bind_address(std::net::Ipv4Addr::LOCALHOST)
+            .dht(|config| {
+                config.server_mode = true;
+                config.bind_address = Some(std::net::Ipv4Addr::LOCALHOST);
+                config
             });
 
         Ok(unsafe { Self::run(config).await? })
@@ -277,10 +278,10 @@ impl Relay {
             .pkarr
             .request_timeout(Duration::from_millis(100))
             .bootstrap(&testnet.bootstrap)
-            .dht(|builder| {
-                builder
-                    .server_mode()
-                    .bind_address(std::net::Ipv4Addr::LOCALHOST)
+            .dht(|config| {
+                config.server_mode = true;
+                config.bind_address = Some(std::net::Ipv4Addr::LOCALHOST);
+                config
             });
 
         Self::run(config).await
@@ -337,7 +338,7 @@ struct AppState {
     cache_write_lock: Arc<Mutex<()>>,
     // Rate limiter for DHT operations initiated by HTTP user requests.
     user_dht_rate_limiter: Option<rate_limiting::UserDhtRateLimiter>,
-    dht: AsyncDht,
+    dht: DhtClient,
 }
 
 #[cfg(test)]
@@ -424,7 +425,10 @@ mod tests {
                     .no_default_network()
                     .bootstrap(&testnet.bootstrap)
                     .request_timeout(Duration::from_millis(100))
-                    .dht(|builder| builder.bind_address(Ipv4Addr::LOCALHOST))
+                    .dht(|config| {
+                        config.bind_address = Some(Ipv4Addr::LOCALHOST);
+                        config
+                    })
             });
 
         unsafe { builder.run().await.unwrap() }


### PR DESCRIPTION
BREAKING CHANGE: `ClientBuilder::dht` now configures `mainline::Config`
instead of `mainline::DhtBuilder`, `Client::dht` returns `DhtClient` instead
of `mainline::Dht`, and `ClientBlocking::dht` has been removed.

Introduce `DhtClient` as the internal DHT abstraction and move direct mainline Dht/AsyncDht usage behind `pkarr::dht`. The wrapper owns the AsyncDht, exposes publish, resolve, and info operations, and maps mainline publish failures into `pkarr::dht::PublishError`.

Switch client and relay configuration to pass `mainline::Config` instead of exposing `mainline::DhtBuilder` or `mainline::Dht`. This keeps pkarr's public DHT surface focused on pkarr types while still allowing callers to configure the underlying node.

Update relay GET handling to consume DHT response streams through the wrapper, return the first packet for cache-first reads, and continue processing later DHT responses in the background so newer packets can refresh the cache. Add tests for most-recent packet selection.