### PR TITLE
feat(relays): expose single-relay client

### DIFF
--- a/pkarr/src/client.rs
+++ b/pkarr/src/client.rs
@@ -102,7 +102,8 @@ impl Client {
             }
 
             let relays_client =
-                RelaysClient::new(relays.clone().into_boxed_slice(), config.request_timeout);
+                RelaysClient::new(relays.clone().into_boxed_slice(), config.request_timeout)
+                    .map_err(BuildError::RelayBuildError)?;
 
             Some(relays_client)
         } else {
@@ -526,6 +527,11 @@ pub enum BuildError {
     #[error("Failed to build the Dht client {0}")]
     /// Failed to build the Dht client.
     DhtBuildError(std::io::Error),
+
+    #[cfg(relays)]
+    #[error("Failed to build the relays client {0}")]
+    /// Failed to build the relays client.
+    RelayBuildError(crate::relay_client::RelayError),
 
     #[error("Passed an empty list of relays")]
     /// Passed an empty list of relays

--- a/pkarr/src/client/relays.rs
+++ b/pkarr/src/client/relays.rs
@@ -5,28 +5,20 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use bytes::Bytes;
 use futures_buffered::FuturesUnorderedBounded;
 #[cfg(not(wasm_browser))]
 use futures_lite::Stream;
 use futures_lite::StreamExt;
 use ntimestamp::Timestamp;
-use reqwest::Method;
 use url::Url;
 
-use reqwest::{
-    header::{self, HeaderValue},
-    Client, StatusCode,
-};
-
 use super::{ConcurrencyError, PublishError, QueryError};
+use crate::relay_client::{RelayClient, RelayError};
 use crate::{PublicKey, SignedPacket};
 
 #[derive(Clone)]
 pub struct RelaysClient {
-    relays: Box<[Url]>,
-    http_client: Client,
-    timeout: Duration,
+    relays: Box<[RelayClient]>,
     pub(crate) inflight_publish: InflightPublishRequests,
 }
 
@@ -40,7 +32,7 @@ impl Debug for RelaysClient {
                 .relays
                 .as_ref()
                 .iter()
-                .map(|url| url.as_str())
+                .map(|relay| relay.base_url().as_str())
                 .collect::<Vec<_>>(),
         );
 
@@ -51,14 +43,16 @@ impl Debug for RelaysClient {
 impl RelaysClient {
     pub fn new(relays: Box<[Url]>, timeout: Duration) -> Self {
         let inflight_publish = InflightPublishRequests::new(relays.len());
+        let relays = relays
+            .into_vec()
+            .into_iter()
+            .map(|url| {
+                RelayClient::new(url, timeout).expect("Client building should be infallible")
+            })
+            .collect();
 
         Self {
             relays,
-            http_client: Client::builder()
-                .build()
-                .expect("Client building should be infallible"),
-
-            timeout,
             inflight_publish,
         }
     }
@@ -75,25 +69,17 @@ impl RelaysClient {
 
         let mut futures = futures_buffered::FuturesUnorderedBounded::new(self.relays.len());
 
-        let body = signed_packet.to_relay_payload();
-        let cas = cas.map(|timestamp| timestamp.as_u64().to_string());
-
         for relay in &self.relays {
-            let http_client = self.http_client.clone();
-            let timeout = self.timeout;
-
-            let cas = cas.clone();
-            let body = body.clone();
-
-            let public_key = public_key.clone();
             let relay = relay.clone();
-
+            let signed_packet = signed_packet.clone();
+            let public_key = public_key.clone();
             let mut inflight = self.inflight_publish.clone();
 
             futures.push(async move {
-                let result = publish_to_relay(http_client, relay, &public_key, body, cas, timeout)
+                let result = relay
+                    .publish(&signed_packet, cas)
                     .await
-                    .map_err(map_reqwest_error);
+                    .map_err(map_relay_error);
 
                 inflight.add_result(&public_key, result)
             });
@@ -135,22 +121,26 @@ impl RelaysClient {
     ) -> FuturesUnorderedBounded<impl futures_lite::Future<Output = Option<SignedPacket>>> {
         let mut futures = FuturesUnorderedBounded::new(self.relays.len());
 
-        let if_modified_since = more_recent_than.map(|t| t.format_http_date());
-
         self.relays.iter().for_each(|relay| {
-            let http_client = self.http_client.clone();
             let relay = relay.clone();
             let public_key = public_key.clone();
-            let if_modified_since = if_modified_since.clone();
-            let timeout = self.timeout;
 
-            futures.push(resolve_from_relay(
-                http_client,
-                relay,
-                public_key,
-                if_modified_since,
-                timeout,
-            ));
+            futures.push(async move {
+                match relay
+                    .resolve(
+                        &public_key,
+                        crate::ResolvePolicy::CacheFirst,
+                        more_recent_than,
+                    )
+                    .await
+                {
+                    Ok(signed_packet) => signed_packet,
+                    Err(error) => {
+                        cross_debug!("GET {} {:?}", relay.base_url(), error);
+                        None
+                    }
+                }
+            });
         });
 
         futures
@@ -312,200 +302,23 @@ impl InflightPublishRequests {
     }
 }
 
-pub async fn publish_to_relay(
-    http_client: reqwest::Client,
-    relay: Url,
-    public_key: &PublicKey,
-    body: Bytes,
-    cas: Option<String>,
-    timeout: Duration,
-) -> Result<(), reqwest::Error> {
-    let url = format_url(&relay, public_key);
-
-    let mut request = http_client.put(url.clone());
-
-    request = request
-        // Publish combines the http latency with the PUT query to the dht
-        // on the relay side, so we should be as generous as possible
-        .timeout(timeout * 3);
-
-    if let Some(cas) = cas {
-        request = request.header(header::IF_MATCH, cas);
-    }
-
-    let response = request.body(body).send().await.inspect_err(|error| {
-        cross_debug!("PUT {:?}", error);
-    })?;
-
-    let status = response.status();
-
-    if let Err(error) = response.error_for_status_ref() {
-        let text = response.text().await.unwrap_or("".to_string());
-
-        cross_debug!("Got error response for PUT {url} {status} {text}");
-
-        return Err(error);
-    };
-
-    if status.is_success() {
-        cross_debug!("Successfully published to {url}");
-    } else {
-        cross_debug!("Got neither 2xx nor >=400 status code {status} for PUT {url}",);
-    }
-
-    Ok(())
-}
-
-fn map_reqwest_error(error: reqwest::Error) -> PublishError {
-    if error.is_timeout() {
-        PublishError::Query(QueryError::Timeout)
-    } else if error.is_status() {
-        match error
-            .status()
-            .expect("previously verified that it is a status error")
-        {
-            StatusCode::BAD_REQUEST => {
-                // This should be very unlikely unless relays are misbehaving, still worth
-                // returning to the user to know that relays are misbehaving, and not just a
-                // network issue.
-                PublishError::Query(QueryError::BadRequest)
-            }
-            StatusCode::CONFLICT => PublishError::Concurrency(ConcurrencyError::NotMostRecent),
-            StatusCode::PRECONDITION_FAILED => {
-                PublishError::Concurrency(ConcurrencyError::CasFailed)
-            }
-            StatusCode::PRECONDITION_REQUIRED => {
-                PublishError::Concurrency(ConcurrencyError::ConflictRisk)
-            }
-            _ => PublishError::UnexpectedResponses,
+fn map_relay_error(error: RelayError) -> PublishError {
+    match error {
+        RelayError::Timeout => PublishError::Query(QueryError::Timeout),
+        RelayError::BadRequest => {
+            // This should be very unlikely unless relays are misbehaving, still worth
+            // returning to the user to know that relays are misbehaving, and not just a
+            // network issue.
+            PublishError::Query(QueryError::BadRequest)
         }
-    } else {
-        PublishError::UnexpectedResponses
+        RelayError::NotMostRecent => PublishError::Concurrency(ConcurrencyError::NotMostRecent),
+        RelayError::CasFailed => PublishError::Concurrency(ConcurrencyError::CasFailed),
+        RelayError::ConflictRisk => PublishError::Concurrency(ConcurrencyError::ConflictRisk),
+        RelayError::Build(_)
+        | RelayError::Request(_)
+        | RelayError::BodyTooLarge { .. }
+        | RelayError::InvalidSignedPacket(_)
+        | RelayError::InvalidHeader(_)
+        | RelayError::UnexpectedStatus(_) => PublishError::UnexpectedResponses,
     }
-}
-
-pub fn format_url(relay: &Url, public_key: &PublicKey) -> Url {
-    let mut url = relay.clone();
-
-    let mut segments = url
-        .path_segments_mut()
-        .expect("Relay url cannot be base, is it http(s)?");
-
-    segments.push(&public_key.to_string());
-
-    drop(segments);
-
-    url
-}
-
-pub async fn resolve_from_relay(
-    http_client: reqwest::Client,
-    relay: Url,
-    public_key: PublicKey,
-    if_modified_since: Option<String>,
-    timeout: Duration,
-) -> Option<SignedPacket> {
-    let url = format_url(&relay, &public_key);
-
-    let mut request = reqwest::Request::new(Method::GET, url.clone());
-
-    *request.timeout_mut() = Some(timeout);
-
-    if let Some(ref httpdate) = if_modified_since {
-        request.headers_mut().insert(
-            header::IF_MODIFIED_SINCE,
-            HeaderValue::from_str(httpdate).expect("httpdate to be valid header value"),
-        );
-    }
-
-    let response = loop {
-        let response = match http_client
-            .execute(request.try_clone().expect("infallible"))
-            .await
-        {
-            Ok(response) => response,
-            Err(error) => {
-                cross_debug!("GET {:?}", error);
-
-                return None;
-            }
-        };
-
-        let status = response.status();
-
-        if response.error_for_status_ref().is_err() {
-            let text = response.text().await.unwrap_or("".to_string());
-
-            cross_debug!("Got error response for GET {url} {status} {text}");
-
-            return None;
-        };
-
-        if should_retry_with_cache_disabled(
-            &mut request,
-            &if_modified_since,
-            &status,
-            response.content_length(),
-        ) {
-            continue;
-        } else {
-            break response;
-        }
-    };
-
-    if response.content_length().unwrap_or_default() > SignedPacket::MAX_BYTES {
-        cross_debug!("Response too large for GET {url}");
-
-        return None;
-    }
-
-    let payload = match response.bytes().await {
-        Ok(payload) => payload,
-        Err(error) => {
-            cross_debug!("Failed to read relay response from GET {url} {error}");
-
-            return None;
-        }
-    };
-
-    match SignedPacket::from_relay_payload(&public_key, &payload) {
-        Ok(signed_packet) => Some(signed_packet),
-        Err(error) => {
-            cross_debug!("Invalid signed_packet {url}:{error}");
-
-            None
-        }
-    }
-}
-
-fn should_retry_with_cache_disabled(
-    request: &mut reqwest::Request,
-    if_modified_since: &Option<String>,
-    status: &StatusCode,
-    content_length: Option<u64>,
-) -> bool {
-    // We got a 304 not modified, even though we don't have any packet in cache.
-    let unexpected_not_modified =
-        (*status == StatusCode::NOT_MODIFIED) && if_modified_since.is_none();
-
-    // We got a success response, but the packet is empty.
-    let broken_cache = status.is_success() && (content_length.unwrap_or_default() == 0);
-
-    let needs_retry_with_cache_disabled = unexpected_not_modified || broken_cache;
-
-    let havent_retried_with_cache_disabled_already =
-        request.headers().get(header::CACHE_CONTROL).is_none();
-
-    if needs_retry_with_cache_disabled && havent_retried_with_cache_disabled_already {
-        request.headers_mut().insert(
-            header::CACHE_CONTROL,
-            "no-cache, no-store, must-revalidate"
-                .try_into()
-                .expect("cache control is valid http header value"),
-        );
-
-        return true;
-    }
-
-    false
 }

--- a/pkarr/src/client/relays.rs
+++ b/pkarr/src/client/relays.rs
@@ -41,20 +41,24 @@ impl Debug for RelaysClient {
 }
 
 impl RelaysClient {
-    pub fn new(relays: Box<[Url]>, timeout: Duration) -> Self {
+    pub fn new(relays: Box<[Url]>, timeout: Duration) -> Result<Self, RelayError> {
         let inflight_publish = InflightPublishRequests::new(relays.len());
+        let resolve_timeout = timeout;
+        // Publish combines HTTP latency with the relay-side DHT PUT query.
+        let publish_timeout = resolve_timeout
+            .checked_mul(3)
+            .ok_or_else(|| RelayError::Build("publish timeout overflow".to_string()))?;
         let relays = relays
             .into_vec()
             .into_iter()
-            .map(|url| {
-                RelayClient::new(url, timeout).expect("Client building should be infallible")
-            })
-            .collect();
+            .map(|url| RelayClient::new(url, resolve_timeout, publish_timeout))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_boxed_slice();
 
-        Self {
+        Ok(Self {
             relays,
             inflight_publish,
-        }
+        })
     }
 
     pub async fn publish(

--- a/pkarr/src/lib.rs
+++ b/pkarr/src/lib.rs
@@ -14,6 +14,8 @@ mod client;
 pub mod dht;
 #[cfg(client)]
 pub mod extra;
+#[cfg(relays)]
+pub mod relay_client;
 pub mod types;
 
 /// Default minimum TTL: 5 minutes.

--- a/pkarr/src/relay_client.rs
+++ b/pkarr/src/relay_client.rs
@@ -28,7 +28,8 @@ macro_rules! debug {
 pub struct RelayClient {
     base_url: Url,
     client: Client,
-    timeout: Duration,
+    resolve_timeout: Duration,
+    publish_timeout: Duration,
 }
 
 impl RelayClient {
@@ -37,13 +38,25 @@ impl RelayClient {
     /// # Errors
     ///
     /// Returns an error if the underlying HTTP client cannot be built.
-    pub fn new(base_url: Url, timeout: Duration) -> Result<Self, RelayError> {
-        let client = Client::builder().build().map_err(RelayError::Build)?;
+    pub fn new(
+        base_url: Url,
+        resolve_timeout: Duration,
+        publish_timeout: Duration,
+    ) -> Result<Self, RelayError> {
+        let client = Client::builder()
+            .build()
+            .map_err(|e| RelayError::Build(e.to_string()))?;
+        if base_url.cannot_be_a_base() {
+            return Err(RelayError::Build(format!(
+                "Invalid base url of a relay: `{base_url}`"
+            )));
+        }
 
         Ok(Self {
             base_url,
             client,
-            timeout,
+            resolve_timeout,
+            publish_timeout,
         })
     }
 
@@ -68,8 +81,7 @@ impl RelayClient {
         let mut request = self
             .client
             .put(url.clone())
-            // Publish combines HTTP latency with the relay-side DHT PUT query.
-            .timeout(self.timeout * 3)
+            .timeout(self.publish_timeout)
             .body(packet.to_relay_payload());
 
         if let Some(cas) = cas {
@@ -128,7 +140,7 @@ impl RelayClient {
             return Err(RelayError::from_status(status));
         }
 
-        let last_seen = memento_datetime(&response);
+        let last_seen = extract_memento_datetime(&response);
         let payload = read_body_with_limit(response, SignedPacket::MAX_BYTES as usize).await?;
 
         let mut signed_packet = SignedPacket::from_relay_payload(key, &payload)
@@ -147,7 +159,7 @@ impl RelayClient {
         newer_than: Option<&Timestamp>,
         bypass_cache: bool,
     ) -> Result<Response, RelayError> {
-        let mut request = self.client.get(url.clone()).timeout(self.timeout);
+        let mut request = self.client.get(url.clone()).timeout(self.resolve_timeout);
 
         if let Some(newer_than) = newer_than {
             let newer_than = newer_than.format_http_date();
@@ -186,9 +198,9 @@ impl RelayClient {
 /// Relay-client error.
 #[derive(thiserror::Error, Debug)]
 pub enum RelayError {
-    /// Failed to build the HTTP client.
-    #[error("failed to build relay HTTP client: {0}")]
-    Build(reqwest::Error),
+    /// Failed to build the relay client.
+    #[error("failed to build relay client: {0}")]
+    Build(String),
 
     /// Relay request timed out.
     #[error("relay request timed out")]
@@ -256,7 +268,7 @@ impl RelayError {
     }
 }
 
-fn memento_datetime(response: &Response) -> Option<Timestamp> {
+fn extract_memento_datetime(response: &Response) -> Option<Timestamp> {
     response
         .headers()
         .get(MEMENTO_DATETIME)
@@ -323,6 +335,8 @@ mod tests {
     use super::*;
     use crate::Keypair;
 
+    const TIMEOUT: Duration = Duration::from_secs(1);
+
     #[tokio::test]
     async fn resolve_returns_none_on_not_found() {
         let keypair = Keypair::random();
@@ -330,7 +344,7 @@ mod tests {
             &format!("/{}", keypair.public_key()),
             get(|| async { HttpStatusCode::NOT_FOUND }),
         );
-        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
 
         let resolved = client
             .resolve(
@@ -351,7 +365,7 @@ mod tests {
             &format!("/{}", keypair.public_key()),
             get(|| async { HttpStatusCode::NOT_MODIFIED }),
         );
-        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
 
         let resolved = client
             .resolve(
@@ -389,7 +403,7 @@ mod tests {
                 }
             }),
         );
-        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
 
         let resolved = client
             .resolve(
@@ -428,7 +442,7 @@ mod tests {
                 }
             }),
         );
-        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
 
         let resolved = client
             .resolve(
@@ -450,7 +464,7 @@ mod tests {
             &format!("/{}", keypair.public_key()),
             get(|| async { vec![0; SignedPacket::MAX_BYTES as usize + 1] }),
         );
-        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
 
         let error = client
             .resolve(
@@ -478,7 +492,7 @@ mod tests {
             &format!("/{}", keypair.public_key()),
             get(|| async { vec![0; 1] }),
         );
-        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
 
         let error = client
             .resolve(
@@ -515,7 +529,7 @@ mod tests {
 
         let base_url = serve(app).await;
 
-        let client = RelayClient::new(base_url, Duration::from_secs(1)).unwrap();
+        let client = RelayClient::new(base_url, TIMEOUT, TIMEOUT).unwrap();
         let resolved = client
             .resolve(
                 &keypair.public_key(),
@@ -546,7 +560,7 @@ mod tests {
                 }
             }),
         );
-        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
 
         let resolved = client
             .resolve(
@@ -585,7 +599,7 @@ mod tests {
                 }
             }),
         );
-        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
 
         let resolved = client
             .resolve(
@@ -617,7 +631,7 @@ mod tests {
                 }
             }),
         );
-        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
 
         let resolved = client
             .resolve(

--- a/pkarr/src/relay_client.rs
+++ b/pkarr/src/relay_client.rs
@@ -1,0 +1,647 @@
+//! Single-relay HTTP client.
+
+use bytes::Bytes;
+use ntimestamp::Timestamp;
+use reqwest::{
+    header::{self, HeaderValue},
+    Client, Response, StatusCode,
+};
+use std::time::Duration;
+use url::Url;
+
+use crate::{PublicKey, ResolvePolicy, SignedPacket};
+
+const MEMENTO_DATETIME: &str = "memento-datetime";
+const CACHE_BYPASS: &str = "no-cache, no-store, must-revalidate";
+
+macro_rules! debug {
+    ($($arg:tt)*) => {
+        #[cfg(target_arch = "wasm32")]
+        log::debug!($($arg)*);
+        #[cfg(not(target_arch = "wasm32"))]
+        tracing::debug!($($arg)*);
+    };
+}
+
+/// Single-relay HTTP client.
+#[derive(Clone, Debug)]
+pub struct RelayClient {
+    base_url: Url,
+    client: Client,
+    timeout: Duration,
+}
+
+impl RelayClient {
+    /// Build a client for one relay endpoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying HTTP client cannot be built.
+    pub fn new(base_url: Url, timeout: Duration) -> Result<Self, RelayError> {
+        let client = Client::builder().build().map_err(RelayError::Build)?;
+
+        Ok(Self {
+            base_url,
+            client,
+            timeout,
+        })
+    }
+
+    /// Return this client's relay base URL.
+    pub fn base_url(&self) -> &Url {
+        &self.base_url
+    }
+
+    /// Publish a [`SignedPacket`] to this relay.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the relay request fails, the relay returns a
+    /// non-success status, or the request times out.
+    pub async fn publish(
+        &self,
+        packet: &SignedPacket,
+        cas: Option<Timestamp>,
+    ) -> Result<(), RelayError> {
+        let url = self.build_url(&packet.public_key(), None);
+
+        let mut request = self
+            .client
+            .put(url.clone())
+            // Publish combines HTTP latency with the relay-side DHT PUT query.
+            .timeout(self.timeout * 3)
+            .body(packet.to_relay_payload());
+
+        if let Some(cas) = cas {
+            request = request.header(header::IF_MATCH, cas.as_u64().to_string());
+        }
+
+        let response = request.send().await.map_err(RelayError::from_reqwest)?;
+        let status = response.status();
+
+        if status.is_success() {
+            debug!("Successfully published to {url}");
+            return Ok(());
+        }
+
+        let text = response.text().await.unwrap_or_default();
+        debug!("Got error response for PUT {url} {status} {text}");
+
+        Err(RelayError::from_status(status))
+    }
+
+    /// Resolve a [`SignedPacket`] from this relay.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the relay request fails, the response body is too
+    /// large, or the returned relay payload does not verify.
+    pub async fn resolve(
+        &self,
+        key: &PublicKey,
+        policy: ResolvePolicy,
+        newer_than: Option<Timestamp>,
+    ) -> Result<Option<SignedPacket>, RelayError> {
+        let url = self.build_url(key, Some(policy));
+
+        let mut response = self
+            .send_resolve_request(&url, newer_than.as_ref(), false)
+            .await?;
+
+        // A stale HTTP cache can produce impossible 304 responses or empty
+        // successful responses. Retry once with cache bypass headers.
+        if should_retry_with_cache_bypass(&response, newer_than.as_ref()) {
+            response = self
+                .send_resolve_request(&url, newer_than.as_ref(), true)
+                .await?;
+        }
+
+        let status = response.status();
+        if status == StatusCode::NOT_MODIFIED || status == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        if status.is_client_error() || status.is_server_error() {
+            let text = response.text().await.unwrap_or_default();
+            debug!("Got error response for GET {url} {status} {text}");
+
+            return Err(RelayError::from_status(status));
+        }
+
+        let last_seen = memento_datetime(&response);
+        let payload = read_body_with_limit(response, SignedPacket::MAX_BYTES as usize).await?;
+
+        let mut signed_packet = SignedPacket::from_relay_payload(key, &payload)
+            .map_err(RelayError::InvalidSignedPacket)?;
+
+        if let Some(last_seen) = last_seen {
+            signed_packet.set_last_seen(&last_seen);
+        }
+
+        Ok(Some(signed_packet))
+    }
+
+    async fn send_resolve_request(
+        &self,
+        url: &Url,
+        newer_than: Option<&Timestamp>,
+        bypass_cache: bool,
+    ) -> Result<Response, RelayError> {
+        let mut request = self.client.get(url.clone()).timeout(self.timeout);
+
+        if let Some(newer_than) = newer_than {
+            let newer_than = newer_than.format_http_date();
+            request = request.header(
+                header::IF_MODIFIED_SINCE,
+                HeaderValue::from_str(&newer_than).map_err(RelayError::InvalidHeader)?,
+            );
+        }
+
+        if bypass_cache {
+            request = request.header(header::CACHE_CONTROL, CACHE_BYPASS);
+        }
+
+        request.send().await.map_err(RelayError::from_reqwest)
+    }
+
+    fn build_url(&self, public_key: &PublicKey, policy: Option<ResolvePolicy>) -> Url {
+        let mut url = self.base_url.clone();
+
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .expect("relay URL cannot be a base URL");
+
+            segments.push(&public_key.to_string());
+        }
+
+        if let Some(policy) = policy {
+            url.query_pairs_mut().append_pair("policy", policy.as_str());
+        }
+
+        url
+    }
+}
+
+/// Relay-client error.
+#[derive(thiserror::Error, Debug)]
+pub enum RelayError {
+    /// Failed to build the HTTP client.
+    #[error("failed to build relay HTTP client: {0}")]
+    Build(reqwest::Error),
+
+    /// Relay request timed out.
+    #[error("relay request timed out")]
+    Timeout,
+
+    /// Relay request failed.
+    #[error("relay request failed: {0}")]
+    Request(reqwest::Error),
+
+    /// Relay response body exceeded the maximum accepted size.
+    #[error("relay response body is larger than {limit} bytes")]
+    BodyTooLarge {
+        /// Maximum accepted size.
+        limit: usize,
+    },
+
+    /// Relay returned a malformed signed packet payload.
+    #[error("relay returned an invalid signed packet: {0}")]
+    InvalidSignedPacket(crate::errors::SignedPacketVerifyError),
+
+    /// Relay request contained an invalid header.
+    #[error("relay request contained an invalid header: {0}")]
+    InvalidHeader(header::InvalidHeaderValue),
+
+    /// Relay returned bad request.
+    #[error("relay returned bad request")]
+    BadRequest,
+
+    /// Relay has a more recent signed packet.
+    #[error("relay has a more recent signed packet")]
+    NotMostRecent,
+
+    /// Relay compare-and-swap failed.
+    #[error("relay compare-and-swap failed")]
+    CasFailed,
+
+    /// Relay requires compare-and-swap.
+    #[error("relay requires compare-and-swap")]
+    ConflictRisk,
+
+    /// Relay returned an unexpected status code.
+    #[error("relay returned unexpected status code {0}")]
+    UnexpectedStatus(StatusCode),
+}
+
+impl RelayError {
+    fn from_reqwest(error: reqwest::Error) -> Self {
+        if error.is_timeout() {
+            Self::Timeout
+        } else if let Some(status) = error.status() {
+            Self::from_status(status)
+        } else {
+            Self::Request(error)
+        }
+    }
+
+    fn from_status(status: StatusCode) -> Self {
+        match status {
+            StatusCode::BAD_REQUEST => Self::BadRequest,
+            StatusCode::CONFLICT => Self::NotMostRecent,
+            StatusCode::PRECONDITION_FAILED => Self::CasFailed,
+            StatusCode::PRECONDITION_REQUIRED => Self::ConflictRisk,
+            status => Self::UnexpectedStatus(status),
+        }
+    }
+}
+
+fn memento_datetime(response: &Response) -> Option<Timestamp> {
+    response
+        .headers()
+        .get(MEMENTO_DATETIME)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| Timestamp::parse_http_date(value).ok())
+        .filter(|timestamp| timestamp <= &Timestamp::now())
+}
+
+fn should_retry_with_cache_bypass(response: &Response, newer_than: Option<&Timestamp>) -> bool {
+    let status = response.status();
+    let unexpected_not_modified = status == StatusCode::NOT_MODIFIED && newer_than.is_none();
+    let empty_success = status.is_success() && response.content_length().unwrap_or_default() == 0;
+
+    unexpected_not_modified || empty_success
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn read_body_with_limit(mut response: Response, limit: usize) -> Result<Bytes, RelayError> {
+    reject_known_too_large(response.content_length(), limit)?;
+
+    let mut payload = bytes::BytesMut::with_capacity(limit);
+
+    while let Some(chunk) = response.chunk().await.map_err(RelayError::from_reqwest)? {
+        if payload.len() + chunk.len() > limit {
+            return Err(RelayError::BodyTooLarge { limit });
+        }
+
+        payload.extend_from_slice(&chunk);
+    }
+
+    Ok(payload.freeze())
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn read_body_with_limit(response: Response, limit: usize) -> Result<Bytes, RelayError> {
+    reject_known_too_large(response.content_length(), limit)?;
+
+    let payload = response.bytes().await.map_err(RelayError::from_reqwest)?;
+
+    if payload.len() > limit {
+        return Err(RelayError::BodyTooLarge { limit });
+    }
+    Ok(payload)
+}
+
+fn reject_known_too_large(content_length: Option<u64>, limit: usize) -> Result<(), RelayError> {
+    match content_length {
+        Some(length) if length > limit as u64 => Err(RelayError::BodyTooLarge { limit }),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use axum::{
+        http::{HeaderMap, StatusCode as HttpStatusCode},
+        routing::get,
+        Router,
+    };
+    use ntimestamp::Timestamp;
+    use tokio::net::TcpListener;
+    use url::Url;
+
+    use super::*;
+    use crate::Keypair;
+
+    #[tokio::test]
+    async fn resolve_returns_none_on_not_found() {
+        let keypair = Keypair::random();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get(|| async { HttpStatusCode::NOT_FOUND }),
+        );
+        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+
+        let resolved = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_none_on_not_modified() {
+        let keypair = Keypair::random();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get(|| async { HttpStatusCode::NOT_MODIFIED }),
+        );
+        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+
+        let resolved = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                Some(Timestamp::now()),
+            )
+            .await
+            .unwrap();
+
+        assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_retries_unexpected_not_modified_with_cache_bypass() {
+        let keypair = Keypair::random();
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get({
+                let payload = signed_packet.to_relay_payload();
+
+                move |headers: HeaderMap| {
+                    let payload = payload.clone();
+
+                    async move {
+                        match headers
+                            .get(header::CACHE_CONTROL)
+                            .and_then(|v| v.to_str().ok())
+                        {
+                            Some(CACHE_BYPASS) => (HttpStatusCode::OK, payload),
+                            _ => (HttpStatusCode::NOT_MODIFIED, Bytes::new()),
+                        }
+                    }
+                }
+            }),
+        );
+        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+
+        let resolved = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn resolve_retries_empty_success_with_cache_bypass() {
+        let keypair = Keypair::random();
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get({
+                let payload = signed_packet.to_relay_payload();
+
+                move |headers: HeaderMap| {
+                    let payload = payload.clone();
+
+                    async move {
+                        match headers
+                            .get(header::CACHE_CONTROL)
+                            .and_then(|v| v.to_str().ok())
+                        {
+                            Some(CACHE_BYPASS) => payload,
+                            _ => Bytes::new(),
+                        }
+                    }
+                }
+            }),
+        );
+        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+
+        let resolved = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_response_body_larger_than_signed_packet_limit() {
+        let keypair = Keypair::random();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get(|| async { vec![0; SignedPacket::MAX_BYTES as usize + 1] }),
+        );
+        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+
+        let error = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RelayError::BodyTooLarge { .. }));
+    }
+
+    #[test]
+    fn rejects_known_too_large_content_length_before_buffering() {
+        assert!(reject_known_too_large(Some(101), 100).is_err());
+        assert!(reject_known_too_large(Some(100), 100).is_ok());
+        assert!(reject_known_too_large(None, 100).is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_invalid_signed_packet_payload() {
+        let keypair = Keypair::random();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get(|| async { vec![0; 1] }),
+        );
+        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+
+        let error = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RelayError::InvalidSignedPacket(_)));
+    }
+
+    #[tokio::test]
+    async fn resolve_sets_last_seen_from_memento_datetime() {
+        let keypair = Keypair::random();
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
+        let last_seen = Timestamp::parse_http_date("Sun, 06 Nov 1994 08:49:37 GMT").unwrap();
+
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get({
+                let payload = signed_packet.to_relay_payload();
+                let last_seen = last_seen.format_http_date();
+
+                move || {
+                    let payload = payload.clone();
+                    let last_seen = last_seen.clone();
+
+                    async move { ([(MEMENTO_DATETIME, last_seen)], payload) }
+                }
+            }),
+        );
+
+        let base_url = serve(app).await;
+
+        let client = RelayClient::new(base_url, Duration::from_secs(1)).unwrap();
+        let resolved = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
+        assert_eq!(resolved.last_seen(), &last_seen);
+    }
+
+    #[tokio::test]
+    async fn resolve_ignores_invalid_memento_datetime() {
+        let keypair = Keypair::random();
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get({
+                let payload = signed_packet.to_relay_payload();
+
+                move || {
+                    let payload = payload.clone();
+
+                    async move { ([(MEMENTO_DATETIME, "not an http date")], payload) }
+                }
+            }),
+        );
+        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+
+        let resolved = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
+        assert_ne!(
+            resolved.last_seen(),
+            &Timestamp::parse_http_date("Sun, 06 Nov 1994 08:49:37 GMT").unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_ignores_future_memento_datetime() {
+        let keypair = Keypair::random();
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
+        let future_last_seen = Timestamp::now() + 60_000_000;
+
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get({
+                let payload = signed_packet.to_relay_payload();
+                let future_last_seen = future_last_seen.format_http_date();
+
+                move || {
+                    let payload = payload.clone();
+                    let future_last_seen = future_last_seen.clone();
+
+                    async move { ([(MEMENTO_DATETIME, future_last_seen)], payload) }
+                }
+            }),
+        );
+        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+
+        let resolved = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
+        assert!(resolved.last_seen() <= &Timestamp::now());
+    }
+
+    #[tokio::test]
+    async fn resolve_succeeds_without_memento_datetime() {
+        let keypair = Keypair::random();
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get({
+                let payload = signed_packet.to_relay_payload();
+
+                move || {
+                    let payload = payload.clone();
+
+                    async move { payload }
+                }
+            }),
+        );
+        let client = RelayClient::new(serve(app).await, Duration::from_secs(1)).unwrap();
+
+        let resolved = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
+    }
+
+    async fn serve(app: Router) -> Url {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap())
+            .parse()
+            .unwrap();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        base_url
+    }
+}

--- a/pkarr/src/types/resolve_policy.rs
+++ b/pkarr/src/types/resolve_policy.rs
@@ -1,11 +1,14 @@
 //! Resolve policies.
 
-use serde::Deserialize;
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 
 /// Controls whether resolution may use only cached packets,
 /// prefer cached packets before querying the DHT, or bypass cached reads and
 /// query the DHT network directly.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ResolvePolicy {
     /// Return only a locally cached or relay-cached packet, even if expired.
     ///
@@ -30,4 +33,76 @@ pub enum ResolvePolicy {
     /// Useful when you need the most recent packet, for example for recovering
     /// after stale sequence errors.
     DhtNetworkOnly,
+}
+
+impl ResolvePolicy {
+    /// Return the canonical string representation.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LocalOrRelayCacheOnly => "LocalOrRelayCacheOnly",
+            Self::CacheFirst => "CacheFirst",
+            Self::DhtNetworkOnly => "DhtNetworkOnly",
+        }
+    }
+}
+
+impl fmt::Display for ResolvePolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ResolvePolicy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LocalOrRelayCacheOnly" => Ok(Self::LocalOrRelayCacheOnly),
+            "CacheFirst" => Ok(Self::CacheFirst),
+            "DhtNetworkOnly" => Ok(Self::DhtNetworkOnly),
+            _ => Err(format!("invalid resolve policy: {s}")),
+        }
+    }
+}
+
+impl Serialize for ResolvePolicy {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ResolvePolicy {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_and_parse_roundtrip() {
+        for policy in [
+            ResolvePolicy::LocalOrRelayCacheOnly,
+            ResolvePolicy::CacheFirst,
+            ResolvePolicy::DhtNetworkOnly,
+        ] {
+            let s = policy.to_string();
+            assert_eq!(s, policy.as_str());
+            assert_eq!(s.parse::<ResolvePolicy>(), Ok(policy));
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_policy() {
+        assert!("Unknown".parse::<ResolvePolicy>().is_err());
+    }
 }


### PR DESCRIPTION
Add a public RelayClient for publishing and resolving SignedPackets
against one relay endpoint. Move single-relay HTTP behavior out of the
multi-relay client and map relay failures through a dedicated RelayError.
