### PR TITLE
fix(relay): add rustls feature to reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ resolver = "3"
 name = "pkarr"
 
 [workspace.dependencies]
-reqwest = { version = "0.13", default-features = false }
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 simple-dns = { version = "0.11.2" }


### PR DESCRIPTION
Without it reqwest fails to recognise https schemes with:
`invalid URL, scheme is not http`.
