### PR TITLE
feat(relay)!: split HTTP and DHT rate limiting

### DIFF
--- a/pkarr/src/client/tests.rs
+++ b/pkarr/src/client/tests.rs
@@ -1,6 +1,6 @@
 //! Client native tests
 
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, ToSocketAddrs};
 use std::{thread, time::Duration};
 
 use ntimestamp::Timestamp;
@@ -686,14 +686,21 @@ async fn discard_cache_with_zero_capacity() {
         .cache_size(0) // Comment this line out and it works
         .http_port(0)
         .storage(storage)
-        .pkarr(|builder| {
-            builder.no_default_network();
-            builder.bootstrap(&testnet.bootstrap);
-            builder.dht(|config| {
-                config.bind_address = Some(Ipv4Addr::LOCALHOST);
-                config
-            });
-            builder
+        .dht(|config| {
+            config.bootstrap = Some(
+                testnet
+                    .bootstrap
+                    .iter()
+                    .filter_map(|address| address.to_socket_addrs().ok())
+                    .flatten()
+                    .filter_map(|address| match address {
+                        std::net::SocketAddr::V4(address) => Some(address),
+                        std::net::SocketAddr::V6(_) => None,
+                    })
+                    .collect(),
+            );
+            config.bind_address = Some(Ipv4Addr::LOCALHOST);
+            config
         });
     let relay = unsafe { builder.run().await.unwrap() };
     let relay_url = relay.local_url();

--- a/relay/src/config.example.toml
+++ b/relay/src/config.example.toml
@@ -43,6 +43,13 @@ behind_proxy = false
 quota = "2r/s"
 # Optional HTTP request burst size. Defaults to the quota rate when omitted.
 burst = 10
+# Incoming DHT request quota per DHT peer IP address.
+# This is enforced by the internal Mainline DHT node before handling requests
+# from other DHT peers.
+dht_quota = "2r/s"
+# Optional incoming DHT request burst size.
+# Defaults to the DHT quota rate when omitted.
+dht_burst = 10
 # User-initiated DHT operation quota per IP address.
 # This is separate from the HTTP quota above and is consumed only when a
 # request makes the relay contact the DHT: PUT publishes, GET cache misses,

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -3,144 +3,160 @@
 use anyhow::{Context, Result};
 use pkarr::{DEFAULT_MAXIMUM_TTL, DEFAULT_MINIMUM_TTL};
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::Debug,
-    path::{Path, PathBuf},
-};
-
-pub const DEFAULT_CACHE_SIZE: usize = 1_000_000;
-pub const CACHE_DIR: &str = "pkarr-cache";
+use std::path::{Path, PathBuf};
 
 use crate::rate_limiting::RateLimiterConfig;
 
-#[derive(Serialize, Deserialize, Default)]
-struct ConfigToml {
-    http: Option<HttpConfig>,
-    mainline: Option<MainlineConfig>,
-    rate_limiter: Option<RateLimiterConfig>,
-    cache: Option<CacheConfig>,
-}
+pub const DEFAULT_CACHE_SIZE: usize = 1_000_000;
+pub const DEFAULT_HTTP_PORT: u16 = 6881;
+pub const CACHE_DIR: &str = "pkarr-cache";
 
-#[derive(Serialize, Deserialize, Default)]
-struct HttpConfig {
-    port: Option<u16>,
-}
-
-#[derive(Serialize, Deserialize, Default)]
-struct MainlineConfig {
-    port: Option<u16>,
-}
-
-#[derive(Serialize, Deserialize, Default)]
-struct CacheConfig {
-    path: Option<PathBuf>,
-    size: Option<usize>,
-    /// See [pkarr::ClientBuilder::minimum_ttl]
-    minimum_ttl: Option<u32>,
-    /// See [pkarr::ClientBuilder::maximum_ttl]
-    maximum_ttl: Option<u32>,
-}
-
-/// Pkarr Relay configuration
-///
-/// The config is usually loaded from a file with [`Self::load`].
-#[derive(Debug)]
-pub struct Config {
-    /// TCP port to run the HTTP server on
-    ///
-    /// Defaults to `6881`
-    pub http_port: u16,
-    /// Pkarr client builder
-    pub pkarr: pkarr::ClientBuilder,
-    /// Path to cache database
-    ///
-    /// Defaults to a directory in the OS data directory
-    pub cache_path: Option<PathBuf>,
-    /// See [pkarr::ClientBuilder::cache_size]
-    ///
-    /// Defaults to 1000_000
-    pub cache_size: usize,
-
-    pub minimum_ttl: u32,
-    pub maximum_ttl: u32,
-
-    /// IP rete limiter configuration
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RelayConfig {
+    #[serde(default)]
+    pub http: HttpConfig,
+    #[serde(default)]
+    pub mainline: MainlineConfig,
     pub rate_limiter: Option<RateLimiterConfig>,
+    #[serde(default)]
+    pub cache: CacheConfig,
 }
 
-impl Default for Config {
+impl Default for RelayConfig {
     fn default() -> Self {
-        let mut this = Self {
-            http_port: 6881,
-            pkarr: Default::default(),
-            cache_path: None,
-            cache_size: DEFAULT_CACHE_SIZE,
-            minimum_ttl: DEFAULT_MINIMUM_TTL,
-            maximum_ttl: DEFAULT_MAXIMUM_TTL,
+        Self {
+            http: HttpConfig::default(),
+            mainline: MainlineConfig::default(),
             rate_limiter: Some(RateLimiterConfig::default()),
-        };
-
-        this.pkarr.no_relays();
-
-        this
+            cache: CacheConfig::default(),
+        }
     }
 }
 
-impl Config {
-    /// Load the config from a file.
-    pub async fn load(path: impl AsRef<Path>) -> Result<Config> {
-        let config_file_path = path.as_ref();
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HttpConfig {
+    #[serde(default = "default_http_port")]
+    pub port: u16,
+}
 
-        let s = tokio::fs::read_to_string(path.as_ref())
+impl Default for HttpConfig {
+    fn default() -> Self {
+        Self {
+            port: default_http_port(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct MainlineConfig {
+    pub port: Option<u16>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CacheConfig {
+    pub path: Option<PathBuf>,
+    #[serde(default = "default_cache_size")]
+    pub size: usize,
+    #[serde(default = "default_minimum_ttl")]
+    pub minimum_ttl: u32,
+    #[serde(default = "default_maximum_ttl")]
+    pub maximum_ttl: u32,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            path: None,
+            size: default_cache_size(),
+            minimum_ttl: default_minimum_ttl(),
+            maximum_ttl: default_maximum_ttl(),
+        }
+    }
+}
+
+impl RelayConfig {
+    /// Load the config from a file.
+    pub async fn load(path: impl AsRef<Path>) -> Result<RelayConfig> {
+        let content = tokio::fs::read_to_string(path.as_ref())
             .await
             .with_context(|| format!("failed to read {}", path.as_ref().to_string_lossy()))?;
 
-        let config_toml: ConfigToml = toml::from_str(&s)?;
-
-        let mut config = Config::default();
-
-        if let Some(cache_config) = config_toml.cache {
-            if let Some(ttl) = cache_config.minimum_ttl {
-                config.pkarr.minimum_ttl(ttl);
-                config.minimum_ttl = ttl;
-            }
-            if let Some(ttl) = cache_config.maximum_ttl {
-                config.pkarr.maximum_ttl(ttl);
-                config.maximum_ttl = ttl;
-            }
-
-            if let Some(cache_path) = cache_config.path.as_ref() {
-                config.cache_path = Some(if cache_path.is_relative() {
-                    // support relative path.
-                    config_file_path
-                        .canonicalize()
-                        .expect("valid config path")
-                        .parent()
-                        .unwrap_or_else(|| Path::new("."))
-                        .join(cache_path)
-                        .canonicalize()
-                        .expect("valid cache path")
-                } else {
-                    cache_path.clone()
-                });
-            }
-
-            config.cache_size = cache_config.size.unwrap_or(DEFAULT_CACHE_SIZE);
-        }
-
-        if let Some(port) = config_toml.mainline.and_then(|m| m.port) {
-            config.pkarr.dht(|dht| {
-                dht.port = Some(port);
-                dht
-            });
-        }
-
-        if let Some(HttpConfig { port: Some(port) }) = config_toml.http {
-            config.http_port = port;
-        }
-
-        config.rate_limiter = config_toml.rate_limiter;
+        let mut config: RelayConfig = toml::from_str(&content)?;
+        config.cache.path = config
+            .cache
+            .path
+            .map(|cache_path| resolve_cache_path(cache_path, path.as_ref()))
+            .transpose()?;
+        validate_cache_ttl(&config.cache)?;
 
         Ok(config)
+    }
+}
+
+fn default_http_port() -> u16 {
+    DEFAULT_HTTP_PORT
+}
+
+fn default_cache_size() -> usize {
+    DEFAULT_CACHE_SIZE
+}
+
+fn default_minimum_ttl() -> u32 {
+    DEFAULT_MINIMUM_TTL
+}
+
+fn default_maximum_ttl() -> u32 {
+    DEFAULT_MAXIMUM_TTL
+}
+
+fn validate_cache_ttl(cache: &CacheConfig) -> Result<()> {
+    anyhow::ensure!(
+        cache.minimum_ttl <= cache.maximum_ttl,
+        "cache.minimum_ttl must be less than or equal to cache.maximum_ttl"
+    );
+
+    Ok(())
+}
+
+fn resolve_cache_path(cache_path: PathBuf, config_file_path: &Path) -> Result<PathBuf> {
+    if cache_path.is_absolute() {
+        return Ok(cache_path);
+    }
+
+    let config_dir = config_file_path
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", config_file_path.display()))?
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+
+    config_dir
+        .join(&cache_path)
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", cache_path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_cache_ttl, CacheConfig, RelayConfig};
+
+    #[test]
+    fn default_config_enables_rate_limiter() {
+        assert!(RelayConfig::default().rate_limiter.is_some());
+    }
+
+    #[test]
+    fn cache_ttl_bounds_must_be_ordered() {
+        let cache = CacheConfig {
+            minimum_ttl: 60,
+            maximum_ttl: 30,
+            ..Default::default()
+        };
+
+        let err = validate_cache_ttl(&cache).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("cache.minimum_ttl must be less than or equal to cache.maximum_ttl"));
     }
 }

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -17,7 +17,7 @@ mod real_ip;
 mod response;
 
 use std::{
-    net::{SocketAddr, TcpListener},
+    net::{SocketAddr, SocketAddrV4, TcpListener, ToSocketAddrs},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
     time::Duration,
@@ -30,21 +30,24 @@ use axum_server::Handle;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 use tracing::info;
 
-use pkarr::{dht::DhtClient, extra::lmdb_cache::LmdbCache, Timestamp};
+use pkarr::{dht::DhtClient, extra::lmdb_cache::LmdbCache, mainline, Timestamp};
 use url::Url;
 
-use config::{Config, CACHE_DIR};
+use config::{RelayConfig, CACHE_DIR};
 
 pub use quota_config::{RequestCountQuota, TimeUnit};
 pub use rate_limiting::RateLimiterConfig;
 
 /// A builder for Pkarr [Relay]
-pub struct RelayBuilder(Config);
+pub struct RelayBuilder {
+    config: RelayConfig,
+    dht: mainline::Config,
+}
 
 impl RelayBuilder {
     /// Set the port for the HTTP endpoint.
     pub fn http_port(&mut self, port: u16) -> &mut Self {
-        self.0.http_port = port;
+        self.config.http.port = port;
 
         self
     }
@@ -56,7 +59,7 @@ impl RelayBuilder {
     ///
     /// Defaults to the path to the user's data directory
     pub fn storage(&mut self, storage: PathBuf) -> &mut Self {
-        self.0.cache_path = Some(storage.join(CACHE_DIR));
+        self.config.cache.path = Some(storage.join(CACHE_DIR));
 
         self
     }
@@ -65,7 +68,7 @@ impl RelayBuilder {
     ///
     /// Defaults to `1_000_000`
     pub fn cache_size(&mut self, size: usize) -> &mut Self {
-        self.0.cache_size = size;
+        self.config.cache.size = size;
 
         self
     }
@@ -74,7 +77,7 @@ impl RelayBuilder {
     ///
     /// Useful when running in a local test network.
     pub fn disable_rate_limiter(&mut self) -> &mut Self {
-        self.0.rate_limiter = None;
+        self.config.rate_limiter = None;
 
         self
     }
@@ -83,17 +86,24 @@ impl RelayBuilder {
     ///
     /// Defaults to [RateLimiterConfig::default].
     pub fn rate_limiter_config(&mut self, config: RateLimiterConfig) -> &mut Self {
-        self.0.rate_limiter = Some(config);
+        self.config.rate_limiter = Some(config);
 
         self
     }
 
-    /// Allows mutating the internal [pkarr::ClientBuilder] with a callback function.
-    pub fn pkarr<F>(&mut self, f: F) -> &mut Self
+    /// Allows mutating the internal [pkarr::mainline] DHT configuration.
+    pub fn dht<F>(&mut self, f: F) -> &mut Self
     where
-        F: FnOnce(&mut pkarr::ClientBuilder) -> &mut pkarr::ClientBuilder,
+        F: FnOnce(&mut pkarr::mainline::Config) -> &mut pkarr::mainline::Config,
     {
-        f(&mut self.0.pkarr);
+        f(&mut self.dht);
+
+        self
+    }
+
+    /// Set the maximum request timeout for DHT requests.
+    pub fn request_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.dht.request_timeout = timeout;
 
         self
     }
@@ -104,7 +114,7 @@ impl RelayBuilder {
     /// This method is marked as unsafe because it uses `LmdbCache`, which can lead to
     /// undefined behavior if the lock file is corrupted or improperly handled.
     pub async unsafe fn run(self) -> anyhow::Result<Relay> {
-        unsafe { Relay::run(self.0) }.await
+        unsafe { Relay::run_with_dht(self.config, self.dht) }.await
     }
 }
 
@@ -129,18 +139,28 @@ impl Relay {
     ///
     /// # Returns
     /// A `Result` containing the `Relay` instance or an error.
-    async unsafe fn run(mut config: Config) -> anyhow::Result<Self> {
+    async unsafe fn run(config: RelayConfig) -> anyhow::Result<Self> {
+        let dht_config = mainline_config(&config);
+
+        unsafe { Self::run_with_dht(config, dht_config) }.await
+    }
+
+    async unsafe fn run_with_dht(
+        config: RelayConfig,
+        mut dht_config: mainline::Config,
+    ) -> anyhow::Result<Self> {
         tracing::debug!(?config, "Pkarr server config");
 
         let cache_path = config
-            .cache_path
+            .cache
+            .path
             .unwrap_or_else(|| {
                 tracing::warn!("Cache path is not configured, running ephemeral Relay");
                 std::env::temp_dir().join(Timestamp::now().to_string())
             })
             .join(CACHE_DIR);
 
-        let cache = Arc::new(LmdbCache::open(&cache_path, config.cache_size)?);
+        let cache = Arc::new(LmdbCache::open(&cache_path, config.cache.size)?);
 
         let behind_proxy = config
             .rate_limiter
@@ -157,36 +177,35 @@ impl Relay {
                     rate_limiting::UserDhtRateLimiter::new(rate_limiter_config)
                         .await
                         .map_err(|e| anyhow!("Failed to build UserDhtRateLimiter: {e}"))?;
-                config.pkarr.dht(|config| {
-                    config.server_settings = pkarr::mainline::ServerSettings {
-                        filter: Box::new(rate_limiter.clone()),
-                        ..Default::default()
-                    };
-                    config
-                });
+                let dht_rate_limiter = rate_limiting::DhtRateLimiter::new(rate_limiter_config)
+                    .await
+                    .map_err(|e| anyhow!("Failed to build DhtRateLimiter: {e}"))?;
+                dht_config.server_settings = pkarr::mainline::ServerSettings {
+                    filter: Box::new(dht_rate_limiter),
+                    ..Default::default()
+                };
                 (Some(rate_limiter), Some(user_dht_rate_limiter))
             }
             None => (None, None),
         };
 
-        let client = config.pkarr.build()?;
+        let dht = DhtClient::build(dht_config)?;
 
-        let listener = TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], config.http_port)))?;
+        let listener = TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], config.http.port)))?;
         // On axum-server 0.8.0 the `.set_nonblocking(true)` call does not take place internally anymore
         // See open issue https://github.com/programatik29/axum-server/issues/181
         listener.set_nonblocking(true)?;
 
-        let dht = client.dht().expect("dht network is enabled").clone();
         let node_address = dht.info().await.local_addr();
         let relay_address = listener.local_addr()?;
 
-        info!("Cache path: {:?}", cache_path);
+        info!("Cache path: {cache_path:?}");
         info!("Running as a DHT node on {node_address}");
         info!("Running as a relay on TCP socket {relay_address}");
 
         let state = AppState {
-            minimum_ttl: config.minimum_ttl,
-            maximum_ttl: config.maximum_ttl,
+            minimum_ttl: config.cache.minimum_ttl,
+            maximum_ttl: config.cache.maximum_ttl,
             cache,
             cache_write_lock: Arc::new(Mutex::new(())),
             user_dht_rate_limiter,
@@ -210,7 +229,10 @@ impl Relay {
 
     /// Create a builder for running a [Relay]
     pub fn builder() -> RelayBuilder {
-        RelayBuilder(Default::default())
+        RelayBuilder {
+            config: Default::default(),
+            dht: Default::default(),
+        }
     }
 
     /// Run a [Relay] with a configuration file path.
@@ -221,7 +243,7 @@ impl Relay {
     pub async unsafe fn run_with_config_file(
         config_path: impl AsRef<Path>,
     ) -> anyhow::Result<Self> {
-        unsafe { Self::run(Config::load(config_path).await?) }.await
+        unsafe { Self::run(RelayConfig::load(config_path).await?) }.await
     }
 
     /// Run an ephemeral Pkarr relay on a random port number for testing purposes.
@@ -233,25 +255,19 @@ impl Relay {
     /// Homeserver uses LMDB, opening which is marked [unsafe](https://docs.rs/heed/latest/heed/struct.EnvOpenOptions.html#safety-1),
     /// because the possible Undefined Behavior (UB) if the lock file is broken.
     pub async fn run_test(testnet: &pkarr::mainline::Testnet) -> anyhow::Result<Self> {
-        let mut config = Config {
-            cache_path: None,
-            http_port: 0,
+        let config = RelayConfig {
+            http: config::HttpConfig { port: 0 },
             rate_limiter: None,
             ..Default::default()
         };
 
-        config
-            .pkarr
-            .bootstrap(&testnet.bootstrap)
-            .request_timeout(Duration::from_millis(100))
-            .bootstrap(&testnet.bootstrap)
-            .dht(|config| {
-                config.server_mode = true;
-                config.bind_address = Some(std::net::Ipv4Addr::LOCALHOST);
-                config
-            });
+        let mut dht_config = mainline_config(&config);
+        dht_config.bootstrap = Some(to_socket_address_v4(&testnet.bootstrap));
+        dht_config.request_timeout = Duration::from_millis(100);
+        dht_config.server_mode = true;
+        dht_config.bind_address = Some(std::net::Ipv4Addr::LOCALHOST);
 
-        Ok(unsafe { Self::run(config).await? })
+        Ok(unsafe { Self::run_with_dht(config, dht_config).await? })
     }
 
     /// Run a Pkarr relay in a Testnet mode (on port 15411).
@@ -267,24 +283,19 @@ impl Relay {
             Box::leak(Box::new(node));
         }
 
-        let mut config = Config {
-            http_port: 15411,
-            cache_path: None,
+        let config = RelayConfig {
+            http: config::HttpConfig { port: 15411 },
             rate_limiter: None,
             ..Default::default()
         };
 
-        config
-            .pkarr
-            .request_timeout(Duration::from_millis(100))
-            .bootstrap(&testnet.bootstrap)
-            .dht(|config| {
-                config.server_mode = true;
-                config.bind_address = Some(std::net::Ipv4Addr::LOCALHOST);
-                config
-            });
+        let mut dht_config = mainline_config(&config);
+        dht_config.bootstrap = Some(to_socket_address_v4(&testnet.bootstrap));
+        dht_config.request_timeout = Duration::from_millis(100);
+        dht_config.server_mode = true;
+        dht_config.bind_address = Some(std::net::Ipv4Addr::LOCALHOST);
 
-        Self::run(config).await
+        Self::run_with_dht(config, dht_config).await
     }
 
     /// Returns the HTTP socket address of the relay.
@@ -301,6 +312,13 @@ impl Relay {
     /// Shutdown the relay server.
     pub fn shutdown(&self) {
         self.handle.shutdown();
+    }
+}
+
+fn mainline_config(config: &RelayConfig) -> mainline::Config {
+    mainline::Config {
+        port: config.mainline.port,
+        ..Default::default()
     }
 }
 
@@ -329,6 +347,23 @@ fn create_app(
     router
 }
 
+fn to_socket_address_v4<T: ToSocketAddrs>(bootstrap: &[T]) -> Vec<SocketAddrV4> {
+    bootstrap
+        .iter()
+        .flat_map(|address| {
+            address.to_socket_addrs().map(|addresses| {
+                addresses
+                    .filter_map(|address| match address {
+                        SocketAddr::V4(address) => Some(address),
+                        SocketAddr::V6(_) => None,
+                    })
+                    .collect::<Box<[_]>>()
+            })
+        })
+        .flatten()
+        .collect()
+}
+
 #[derive(Debug, Clone)]
 struct AppState {
     minimum_ttl: u32,
@@ -348,7 +383,7 @@ mod tests {
     use http::StatusCode;
     use pkarr::{Keypair, SignedPacket, Timestamp};
 
-    use super::{RateLimiterConfig, Relay, RequestCountQuota};
+    use super::{to_socket_address_v4, RateLimiterConfig, Relay, RequestCountQuota};
 
     #[tokio::test]
     async fn user_dht_rate_limit_only_blocks_dht_operations() {
@@ -417,18 +452,16 @@ mod tests {
                 behind_proxy: false,
                 quota: "60r/s".parse::<RequestCountQuota>().unwrap(),
                 burst: NonZeroU32::new(100),
+                dht_quota: "60r/s".parse::<RequestCountQuota>().unwrap(),
+                dht_burst: NonZeroU32::new(100),
                 user_dht_quota: "1r/h".parse::<RequestCountQuota>().unwrap(),
                 user_dht_burst: NonZeroU32::new(1),
             })
-            .pkarr(|builder| {
-                builder
-                    .no_default_network()
-                    .bootstrap(&testnet.bootstrap)
-                    .request_timeout(Duration::from_millis(100))
-                    .dht(|config| {
-                        config.bind_address = Some(Ipv4Addr::LOCALHOST);
-                        config
-                    })
+            .request_timeout(Duration::from_millis(100))
+            .dht(|config| {
+                config.bootstrap = Some(to_socket_address_v4(&testnet.bootstrap));
+                config.bind_address = Some(Ipv4Addr::LOCALHOST);
+                config
             });
 
         unsafe { builder.run().await.unwrap() }

--- a/relay/src/rate_limiting.rs
+++ b/relay/src/rate_limiting.rs
@@ -4,13 +4,16 @@ use crate::quota_config::{RequestCountQuota, TimeUnit};
 use crate::real_ip::RealIpKeyExtractor;
 use axum::Router;
 use governor::{
-    clock::QuantaInstant,
-    middleware::{NoOpMiddleware, RateLimitingMiddleware, StateInformationMiddleware},
+    clock::{QuantaClock, QuantaInstant},
+    middleware::{RateLimitingMiddleware, StateInformationMiddleware},
+    state::keyed::DashMapStateStore,
+    RateLimiter,
 };
 use serde::{Deserialize, Serialize};
 use tower_governor::governor::{GovernorConfig, GovernorConfigBuilder};
-use tower_governor::key_extractor::KeyExtractor;
-pub use tower_governor::GovernorLayer;
+use tower_governor::GovernorLayer;
+
+type IpAddrRateLimiter = RateLimiter<IpAddr, DashMapStateStore<IpAddr>, QuantaClock>;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
@@ -34,6 +37,17 @@ pub struct RateLimiterConfig {
     #[serde(default)]
     pub burst: Option<NonZeroU32>,
 
+    /// Incoming DHT request quota applied per DHT peer IP.
+    ///
+    /// This is enforced by the internal Mainline DHT node before handling
+    /// requests from other DHT peers.
+    pub dht_quota: RequestCountQuota,
+    /// Optional incoming DHT request burst size.
+    ///
+    /// When omitted, this defaults to the rate configured in [`Self::dht_quota`].
+    #[serde(default)]
+    pub dht_burst: Option<NonZeroU32>,
+
     /// User-initiated DHT operation quota applied per normalized real IP.
     ///
     /// This is separate from [`Self::quota`] and is consumed only when a request
@@ -50,18 +64,18 @@ pub struct RateLimiterConfig {
 
 impl Default for RateLimiterConfig {
     fn default() -> Self {
+        let default_quota = RequestCountQuota {
+            rate: NonZeroU32::new(2).expect("failed to build NonZeroU32"),
+            time_unit: TimeUnit::Second,
+        };
         Self {
             behind_proxy: false,
-            quota: RequestCountQuota {
-                rate: NonZeroU32::new(2).unwrap_or(NonZeroU32::MIN),
-                time_unit: TimeUnit::Second,
-            },
-            burst: NonZeroU32::new(10),
-            user_dht_quota: RequestCountQuota {
-                rate: NonZeroU32::new(2).unwrap_or(NonZeroU32::MIN),
-                time_unit: TimeUnit::Second,
-            },
-            user_dht_burst: NonZeroU32::new(10),
+            quota: default_quota.clone(),
+            burst: None,
+            dht_quota: default_quota.clone(),
+            dht_burst: None,
+            user_dht_quota: default_quota,
+            user_dht_burst: None,
         }
     }
 }
@@ -78,32 +92,21 @@ impl IpRateLimiter {
     /// This spawns a background task to clean up the rate limiting cache.
     pub async fn new(config: &RateLimiterConfig) -> Result<Self, String> {
         let quota = config.quota.to_governor_quota(config.burst)?;
-        let builder = GovernorConfigBuilder::default()
+        let governor_middleware = GovernorConfigBuilder::default()
             .use_headers()
-            .key_extractor(RealIpKeyExtractor);
-        let governor_middleware = build_with_quota(builder, &quota);
+            .key_extractor(RealIpKeyExtractor)
+            .period(quota.replenish_interval())
+            .burst_size(quota.burst_size().get())
+            .finish()
+            .expect("failed to build GovernorConfig from governor::Quota");
         let governor_middleware = Arc::new(governor_middleware);
 
-        // The governor needs a background task for garbage collection (to clear expired records)
-        let gc_interval = Duration::from_secs(60);
-
         let governor_limiter = governor_middleware.limiter().clone();
-        tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(gc_interval).await;
-                tracing::debug!("rate limiting storage size: {}", governor_limiter.len());
-                governor_limiter.retain_recent();
-            }
-        });
+        spawn_rate_limiter_gc("HTTP", governor_limiter);
 
         Ok(Self {
             governor_middleware,
         })
-    }
-
-    /// Check if the Ip is allowed to make more requests
-    pub fn is_limited(&self, ip: &IpAddr) -> bool {
-        self.governor_middleware.limiter().check_key(ip).is_err()
     }
 
     /// Add a [GovernorLayer] on the provided [Router]
@@ -113,9 +116,57 @@ impl IpRateLimiter {
 }
 
 #[derive(Debug, Clone)]
+struct IpAddrLimiter {
+    governor_limiter: Arc<IpAddrRateLimiter>,
+}
+
+impl IpAddrLimiter {
+    fn new(label: &'static str, quota: governor::Quota) -> Self {
+        let governor_limiter = Arc::new(RateLimiter::dashmap(quota));
+
+        spawn_rate_limiter_gc(label, governor_limiter.clone());
+
+        Self { governor_limiter }
+    }
+
+    fn is_allowed(&self, ip: &IpAddr) -> bool {
+        self.governor_limiter.check_key(ip).is_ok()
+    }
+}
+
+#[derive(Debug, Clone)]
+/// A rate limiter for incoming DHT requests keyed by peer IP.
+pub struct DhtRateLimiter {
+    limiter: IpAddrLimiter,
+}
+
+impl DhtRateLimiter {
+    /// Create a [DhtRateLimiter].
+    ///
+    /// This spawns a background task to clean up the rate limiting cache.
+    pub async fn new(config: &RateLimiterConfig) -> Result<Self, String> {
+        let quota = config.dht_quota.to_governor_quota(config.dht_burst)?;
+
+        Ok(Self {
+            limiter: IpAddrLimiter::new("DHT", quota),
+        })
+    }
+}
+
+impl pkarr::mainline::RequestFilter for DhtRateLimiter {
+    fn allow_request(
+        &self,
+        _request: &pkarr::mainline::RequestSpecific,
+        from: std::net::SocketAddrV4,
+    ) -> bool {
+        self.limiter.is_allowed(&IpAddr::from(*from.ip()))
+    }
+}
+
+#[derive(Debug, Clone)]
 /// A rate limiter for user-initiated DHT operations keyed by normalized real IP.
 pub struct UserDhtRateLimiter {
-    governor_middleware: Arc<GovernorConfig<RealIpKeyExtractor, NoOpMiddleware>>,
+    limiter: IpAddrLimiter,
 }
 
 impl UserDhtRateLimiter {
@@ -126,58 +177,37 @@ impl UserDhtRateLimiter {
         let quota = config
             .user_dht_quota
             .to_governor_quota(config.user_dht_burst)?;
-        let builder = GovernorConfigBuilder::default().key_extractor(RealIpKeyExtractor);
-        let governor_middleware = build_with_quota(builder, &quota);
-        let governor_middleware = Arc::new(governor_middleware);
-
-        let gc_interval = Duration::from_secs(60);
-
-        let governor_limiter = governor_middleware.limiter().clone();
-        tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(gc_interval).await;
-                tracing::debug!(
-                    "user DHT rate limiting storage size: {}",
-                    governor_limiter.len()
-                );
-                governor_limiter.retain_recent();
-            }
-        });
 
         Ok(Self {
-            governor_middleware,
+            limiter: IpAddrLimiter::new("user DHT", quota),
         })
     }
 
     /// Check if the IP is allowed to initiate more DHT operations.
     pub fn is_limited(&self, ip: &IpAddr) -> bool {
-        self.governor_middleware.limiter().check_key(ip).is_err()
+        !self.limiter.is_allowed(ip)
     }
 }
 
-impl pkarr::mainline::RequestFilter for IpRateLimiter {
-    fn allow_request(
-        &self,
-        _request: &pkarr::mainline::RequestSpecific,
-        from: std::net::SocketAddrV4,
-    ) -> bool {
-        !self.is_limited(&IpAddr::from(*from.ip()))
-    }
-}
-
-fn build_with_quota<K, M>(
-    mut builder: GovernorConfigBuilder<K, M>,
-    quota: &governor::Quota,
-) -> GovernorConfig<K, M>
-where
-    K: KeyExtractor,
-    M: RateLimitingMiddleware<QuantaInstant>,
+fn spawn_rate_limiter_gc<K, M>(
+    label: &'static str,
+    governor_limiter: Arc<RateLimiter<K, DashMapStateStore<K>, QuantaClock, M>>,
+) where
+    K: Clone + Eq + std::hash::Hash + Send + Sync + 'static,
+    M: RateLimitingMiddleware<QuantaInstant> + Send + Sync + 'static,
 {
-    builder
-        .period(quota.replenish_interval())
-        .burst_size(quota.burst_size().get())
-        .finish()
-        .expect("failed to build GovernorConfig from governor::Quota")
+    let gc_interval = Duration::from_secs(60);
+
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(gc_interval).await;
+            tracing::debug!(
+                "{label} rate limiting storage size: {}",
+                governor_limiter.len()
+            );
+            governor_limiter.retain_recent();
+        }
+    });
 }
 
 #[cfg(test)]
@@ -187,7 +217,7 @@ mod tests {
         num::NonZeroU32,
     };
 
-    use super::{RateLimiterConfig, UserDhtRateLimiter};
+    use super::{DhtRateLimiter, RateLimiterConfig, UserDhtRateLimiter};
     use crate::quota_config::RequestCountQuota;
 
     #[tokio::test]
@@ -204,6 +234,20 @@ mod tests {
         assert!(limiter.is_limited(&ip));
     }
 
+    #[tokio::test]
+    async fn dht_limiter_implements_request_filter() {
+        fn assert_request_filter<T: pkarr::mainline::RequestFilter>() {}
+        assert_request_filter::<DhtRateLimiter>();
+
+        let config = RateLimiterConfig {
+            dht_quota: "60r/s".parse::<RequestCountQuota>().unwrap(),
+            dht_burst: NonZeroU32::new(1),
+            ..Default::default()
+        };
+
+        DhtRateLimiter::new(&config).await.unwrap();
+    }
+
     #[test]
     fn rate_limiter_config_deserializes_new_quota_fields() {
         let config: RateLimiterConfig = toml::from_str(
@@ -211,6 +255,8 @@ mod tests {
 behind_proxy = false
 quota = "7r/s"
 burst = 13
+dht_quota = "11r/s"
+dht_burst = 17
 user_dht_quota = "3r/m"
 user_dht_burst = 5
 "#,
@@ -219,6 +265,8 @@ user_dht_burst = 5
 
         assert_eq!(config.quota.to_string(), "7r/s");
         assert_eq!(config.burst, NonZeroU32::new(13));
+        assert_eq!(config.dht_quota.to_string(), "11r/s");
+        assert_eq!(config.dht_burst, NonZeroU32::new(17));
         assert_eq!(config.user_dht_quota.to_string(), "3r/m");
         assert_eq!(config.user_dht_burst, NonZeroU32::new(5));
     }
@@ -229,6 +277,7 @@ user_dht_burst = 5
             r#"
 behind_proxy = false
 quota = "7r/s"
+dht_quota = "11r/s"
 user_dht_quota = "3r/m"
 "#,
         )
@@ -241,6 +290,14 @@ user_dht_quota = "3r/m"
                 .unwrap()
                 .burst_size(),
             NonZeroU32::new(7).unwrap()
+        );
+        assert_eq!(
+            config
+                .dht_quota
+                .to_governor_quota(config.dht_burst)
+                .unwrap()
+                .burst_size(),
+            NonZeroU32::new(11).unwrap()
         );
         assert_eq!(
             config
@@ -259,6 +316,7 @@ user_dht_quota = "3r/m"
 behind_proxy = false
 quota = "7r/s"
 burst = 0
+dht_quota = "11r/s"
 user_dht_quota = "3r/m"
 "#,
         )


### PR DESCRIPTION
Build the relay DHT client directly from mainline config and add
separate rate limits for HTTP requests, inbound DHT requests, and
user-triggered DHT operations.

BREAKING CHANGE: Existing relay config files with a [rate_limiter]
table must add the required dht_quota field. The relay now rejects
rate-limiter configs that omit dht_quota instead of applying a default
DHT peer request limit.

BREAKING CHANGE: RelayBuilder::pkarr has been removed. Use
RelayBuilder::dht and RelayBuilder::request_timeout to configure the
relay DHT client.
