### PR TITLE
fix: avoid starving a ready stream in `select_stream`

### DIFF
--- a/pkarr/src/client/futures.rs
+++ b/pkarr/src/client/futures.rs
@@ -126,27 +126,36 @@ impl Stream for SelectStream {
 
         match this.mode {
             Mode::RoundRobin(current) => {
-                // Alternate which stream to poll next
+                // The non-primary network this round.
+                let other = match current {
+                    Network::Dht => Network::Relays,
+                    Network::Relays => Network::Dht,
+                };
+
                 let (primary, secondary) = match current {
                     Network::Dht => (this.dht_stream.as_mut(), this.relays_stream.as_mut()),
                     Network::Relays => (this.relays_stream.as_mut(), this.dht_stream.as_mut()),
                 };
 
-                // Update the Network for next poll
-                this.mode = Mode::RoundRobin(match current {
-                    Network::Dht => Network::Relays,
-                    Network::Relays => Network::Dht,
-                });
+                // Alternate priority on the next poll.
+                this.mode = Mode::RoundRobin(other);
 
-                // Try polling the current primary stream
+                // Poll the primary first, but fall back to the secondary when it
+                // is pending so a ready secondary is never starved behind it.
                 match primary.poll_next(cx) {
                     Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
                     Poll::Ready(None) => {
-                        // Primary is exhausted, now only poll the remaining one
                         this.mode = Mode::Exhausted(current);
                         secondary.poll_next(cx)
                     }
-                    Poll::Pending => Poll::Pending,
+                    Poll::Pending => match secondary.poll_next(cx) {
+                        // Secondary exhausted: keep the pending primary alive.
+                        Poll::Ready(None) => {
+                            this.mode = Mode::Exhausted(other);
+                            Poll::Pending
+                        }
+                        poll => poll,
+                    },
                 }
             }
             Mode::Exhausted(exhausted) => match exhausted {
@@ -154,5 +163,66 @@ impl Stream for SelectStream {
                 Network::Relays => this.dht_stream.poll_next(cx),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::task::{Context, Poll, Waker};
+
+    use futures_lite::stream;
+
+    use crate::{Keypair, PublicKey, SignedPacket};
+
+    type BoxStream = Pin<Box<dyn Stream<Item = SignedPacket> + Send>>;
+
+    fn packet() -> SignedPacket {
+        SignedPacket::builder().sign(&Keypair::random()).unwrap()
+    }
+
+    fn pending() -> BoxStream {
+        Box::pin(stream::pending())
+    }
+
+    fn ready(packet: SignedPacket) -> BoxStream {
+        Box::pin(stream::once(packet))
+    }
+
+    /// A ready stream must be yielded on the first poll even when the
+    /// round-robin primary is pending. Regression test for a starvation bug
+    /// where `SelectStream` returned `Pending` without polling the secondary,
+    /// so a fast relay response sat unyielded until the slow DHT woke the task.
+    fn assert_yields(mut select: SelectStream, expected: PublicKey) {
+        let mut cx = Context::from_waker(Waker::noop());
+        match Pin::new(&mut select).poll_next(&mut cx) {
+            Poll::Ready(Some(got)) => assert_eq!(got.public_key(), expected),
+            Poll::Ready(None) => panic!("stream terminated unexpectedly"),
+            Poll::Pending => panic!("ready secondary starved behind a pending primary"),
+        }
+    }
+
+    #[test]
+    fn ready_relay_not_starved_by_pending_dht() {
+        // Starts in RoundRobin(Dht): DHT (primary) pending, relay ready.
+        let p = packet();
+        let expected = p.public_key();
+        assert_yields(select_stream(pending(), ready(p)), expected);
+    }
+
+    #[test]
+    fn ready_dht_not_starved_by_pending_relay() {
+        // Symmetric: round-robin pointer on Relays, relay (primary) pending.
+        let p = packet();
+        let expected = p.public_key();
+        assert_yields(
+            SelectStream {
+                mode: Mode::RoundRobin(Network::Relays),
+                dht_stream: ready(p),
+                relays_stream: pending(),
+            },
+            expected,
+        );
     }
 }


### PR DESCRIPTION
When the round-robin primary was pending, `poll_next` returned `Pending` without polling the secondary, so a ready relay response could sit unyielded until the slow DHT woke the task, inflating resolve latency to the DHT's worst case.

In practice, this meant that about 50% of the times, a lookup that could be resolved by a relay lookup (~30ms), was instead choosing the much longer DHT lookup branch (~2s).

This PR fixes this by polling the secondary on the primary's pending path; only returns `Pending` when both are pending.

---

## The bug

`Client::resolve` waits for the earliest positive response from the DHT and the relays, which are merged by `select_stream` (`src/client/futures.rs`). When both networks are enabled, a relay response that answers in ~30 ms can be left
unyielded for up to the DHT's worst-case latency (~2 s).

### Root cause

`SelectStream::poll_next` (round-robin mode) polls **only one** of the two inner streams per call, and returns `Poll::Pending` *without polling the other* when the chosen primary is pending:

```rust
match primary.poll_next(cx) {
    Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
    Poll::Ready(None) => { /* only here does it poll `secondary` */ }
    Poll::Pending => Poll::Pending,   // <-- secondary never polled
}
```

The round-robin pointer also flips on **every** poll, independent of which stream actually woke the task. So this interleaving is possible:

1. `current = Dht`: poll DHT → `Pending`. Flip to `Relays`. Return `Pending`. (The relay stream hasn't even started its request yet.)
2. DHT makes progress → wakes task. `current = Relays`: poll relays → request starts, `Pending`. Flip to `Dht`. Return `Pending`.
3. Relay responds in ~30 ms → relay waker fires → task polled. But `current = Dht`, so it polls the **DHT** (still `Pending`) and returns `Pending` **without polling the ready relay stream**. The relay waker has been consumed and isn't re-armed.
4. Nothing can re-poll the task until the **DHT** wakes it again — up to its full ~2 s — at which point `current = Relays` and the 30 ms-old relay packet is finally yielded.

Whether a given resolution hits the fast or slow path comes down to poll parity at the instant the relay becomes ready, so a meaningful fraction of resolutions pay DHT-worst-case latency despite the relay having answered almost immediately.

### Why relays-only / DHT-only are unaffected

With only one network configured, `merged_resolve_stream` returns that single stream directly and `select_stream` is never constructed, so the starvation cannot occur. The bug is specific to the DHT + relays configuration (the default).

## The fix

In round-robin mode, when the primary is `Pending`, **also poll the secondary** before returning `Pending`; only return `Pending` when *both* are pending. Exhaustion bookkeeping is preserved (when either stream returns `Ready(None)`,
the combinator switches to polling only the survivor). Primary-first ordering is kept for fairness.

## Tests

Two deterministic, runtime-free regression tests (manual `poll_next` with `Waker::noop()`, sharing one `assert_yields` helper):

- `ready_relay_not_starved_by_pending_dht` — DHT primary pending, relay ready: the relay item must come out on the first poll.
- `ready_dht_not_starved_by_pending_relay` — the symmetric case with the relay as the pending primary.