### PR TITLE
feat(dht)!: add DHT query reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,9 +1480,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mainline"
-version = "6.2.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fd96e1eb0cff23f7048801d1561336c2e3c9f2b468d0271f27ad3463f583bf"
+checksum = "6dfad9601b9117218868271c05403853593d4817e7abeab5c95e11eee16382bb"
 dependencies = [
  "crc",
  "document-features",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -64,7 +64,7 @@ getrandom = { version = "0.4.1", default-features = false }
 tracing = { version = "0.1.44", optional = true }
 
 # feat: dht dependencies
-mainline = { version = "6.2.0", default-features = false, features = ["async"], optional = true }
+mainline = { version = "7.0.0", default-features = false, features = ["async"], optional = true }
 
 # feat: relay dependencies
 reqwest = { workspace = true, optional = true }

--- a/pkarr/src/client.rs
+++ b/pkarr/src/client.rs
@@ -323,7 +323,10 @@ impl Client {
         let dht_future = {
             let signed_packet = signed_packet.clone();
             self.dht().cloned().map(|dht| async move {
-                dht.publish(&signed_packet, cas).await.map_err(Into::into)
+                dht.publish(&signed_packet, cas)
+                    .await
+                    .map(drop)
+                    .map_err(Into::into)
             })
         };
 
@@ -458,7 +461,7 @@ impl Client {
         #[cfg(dht)]
         let dht_stream = self.dht().cloned().map(|dht| {
             let public_key = public_key.clone();
-            dht.resolve(&public_key, more_recent_than).boxed()
+            dht.resolve_stream(&public_key, more_recent_than).boxed()
         });
 
         #[cfg(relays)]

--- a/pkarr/src/client/relays.rs
+++ b/pkarr/src/client/relays.rs
@@ -324,6 +324,8 @@ fn map_relay_error(error: RelayError) -> PublishError {
         | RelayError::Request(_)
         | RelayError::BodyTooLarge { .. }
         | RelayError::InvalidSignedPacket(_)
+        | RelayError::InvalidSignedPacketSeq { .. }
+        | RelayError::InvalidSignedPacketSeqHeader
         | RelayError::InvalidHeader(_)
         | RelayError::UnexpectedStatus(_) => PublishError::UnexpectedResponses,
     }

--- a/pkarr/src/client/relays.rs
+++ b/pkarr/src/client/relays.rs
@@ -308,7 +308,7 @@ impl InflightPublishRequests {
 
 fn map_relay_error(error: RelayError) -> PublishError {
     match error {
-        RelayError::Timeout | RelayError::NoDhtResponses => {
+        RelayError::Timeout | RelayError::DhtUnavailable => {
             PublishError::Query(QueryError::Timeout)
         }
         RelayError::BadRequest => {
@@ -325,8 +325,6 @@ fn map_relay_error(error: RelayError) -> PublishError {
         | RelayError::BodyTooLarge { .. }
         | RelayError::InvalidSignedPacket(_)
         | RelayError::InvalidHeader(_)
-        | RelayError::NoValidDhtResponses
-        | RelayError::NoDhtNodesQueried
         | RelayError::UnexpectedStatus(_) => PublishError::UnexpectedResponses,
     }
 }
@@ -338,16 +336,8 @@ mod tests {
     #[test]
     fn dht_relay_errors_map_to_publish_errors() {
         assert!(matches!(
-            map_relay_error(RelayError::NoDhtResponses),
+            map_relay_error(RelayError::DhtUnavailable),
             PublishError::Query(QueryError::Timeout)
-        ));
-        assert!(matches!(
-            map_relay_error(RelayError::NoValidDhtResponses),
-            PublishError::UnexpectedResponses
-        ));
-        assert!(matches!(
-            map_relay_error(RelayError::NoDhtNodesQueried),
-            PublishError::UnexpectedResponses
         ));
     }
 }

--- a/pkarr/src/client/relays.rs
+++ b/pkarr/src/client/relays.rs
@@ -308,7 +308,9 @@ impl InflightPublishRequests {
 
 fn map_relay_error(error: RelayError) -> PublishError {
     match error {
-        RelayError::Timeout => PublishError::Query(QueryError::Timeout),
+        RelayError::Timeout | RelayError::NoDhtResponses => {
+            PublishError::Query(QueryError::Timeout)
+        }
         RelayError::BadRequest => {
             // This should be very unlikely unless relays are misbehaving, still worth
             // returning to the user to know that relays are misbehaving, and not just a
@@ -323,6 +325,29 @@ fn map_relay_error(error: RelayError) -> PublishError {
         | RelayError::BodyTooLarge { .. }
         | RelayError::InvalidSignedPacket(_)
         | RelayError::InvalidHeader(_)
+        | RelayError::NoValidDhtResponses
+        | RelayError::NoDhtNodesQueried
         | RelayError::UnexpectedStatus(_) => PublishError::UnexpectedResponses,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dht_relay_errors_map_to_publish_errors() {
+        assert!(matches!(
+            map_relay_error(RelayError::NoDhtResponses),
+            PublishError::Query(QueryError::Timeout)
+        ));
+        assert!(matches!(
+            map_relay_error(RelayError::NoValidDhtResponses),
+            PublishError::UnexpectedResponses
+        ));
+        assert!(matches!(
+            map_relay_error(RelayError::NoDhtNodesQueried),
+            PublishError::UnexpectedResponses
+        ));
     }
 }

--- a/pkarr/src/client/tests.rs
+++ b/pkarr/src/client/tests.rs
@@ -661,7 +661,7 @@ async fn regression_relay_cas(#[case] networks: Networks) {
     let most_recent = client
         .resolve_most_recent(&keypair.public_key())
         .await
-        .expect("valid packet");
+        .expect("valid signed packet");
 
     let new_packet = SignedPacket::builder()
         .cname("test".try_into().unwrap(), "test2".try_into().unwrap(), 600)

--- a/pkarr/src/dht/client.rs
+++ b/pkarr/src/dht/client.rs
@@ -8,7 +8,10 @@ use ntimestamp::Timestamp;
 
 use crate::{PublicKey, SignedPacket};
 
-use super::{DhtInfo, PublishError, ResolveError, ResolveOutcome, ResolveReport, ResolveResponse};
+use super::{
+    DhtInfo, PublishError, ResolveError, ResolveOutcome, ResolveReport, ResolveResponse,
+    ResolveValue,
+};
 
 /// Pkarr DHT client.
 #[derive(Clone, Debug)]
@@ -58,11 +61,22 @@ impl DhtClient {
 
     /// Resolve signed packets newer than the given timestamp and return query diagnostics.
     ///
+    /// The first valid signed packet is available immediately from the returned
+    /// [`ResolveResponse`]. Completing the response returns the most recent DHT
+    /// mutable value observed, which may be a newer mutable item that does not
+    /// contain a valid signed packet.
+    ///
+    /// BEP44 sequence numbers define mutable-item freshness. If a mutable item
+    /// with a higher sequence number is not a valid signed packet, that item is
+    /// still treated as the current DHT state and supersedes older valid signed
+    /// packets for the same key.
+    ///
     /// # Errors
     ///
     /// Returns an error when no signed packet is found or the DHT query did not
     /// receive enough useful responses to distinguish a miss from a query
-    /// failure.
+    /// failure. If DHT nodes return mutable values for the key but none verify
+    /// as signed packets, returns the newest observed mutable item sequence number.
     pub async fn resolve(
         &self,
         public_key: &PublicKey,
@@ -73,24 +87,29 @@ impl DhtClient {
             self.inner
                 .get_mutable_detailed(public_key.as_bytes(), None, more_recent_than);
 
-        let mut invalid_signed_packet_count = 0;
+        let mut highest_seq = None;
         while let Some(item) = detailed.items.next().await {
-            match SignedPacket::try_from(item) {
-                Ok(first) => {
-                    let most_recent = first.clone();
+            let seq = item.seq();
+            // BEP44 sequence numbers define the mutable item's freshness.
+            // A newer item that is not a valid signed packet still supersedes
+            // older valid signed packets for this key.
+            if seq >= highest_seq.unwrap_or(seq) {
+                highest_seq = Some(seq);
+                if let Ok(packet) = SignedPacket::try_from(&item) {
+                    let most_recent = packet.clone();
                     return Ok(ResolveResponse::new(
-                        first,
-                        finish_resolve(detailed, most_recent, invalid_signed_packet_count),
+                        packet,
+                        finish_resolve(detailed, most_recent),
                     ));
                 }
-                Err(_) => invalid_signed_packet_count += 1,
             }
         }
 
-        let report = ResolveReport::with_invalid_signed_packets(
-            detailed.outcome.recv().await,
-            invalid_signed_packet_count,
-        );
+        if let Some(seq) = highest_seq {
+            return Err(ResolveError::InvalidSignedPacket { seq });
+        }
+
+        let report = ResolveReport::new(detailed.outcome.recv().await);
         Err(report.into())
     }
 
@@ -151,23 +170,38 @@ impl TryFrom<MutableItem> for SignedPacket {
 async fn finish_resolve(
     mut detailed: GetMutableDetailed,
     mut most_recent: SignedPacket,
-    mut invalid_signed_packet_count: u32,
 ) -> ResolveOutcome {
+    let mut highest_seq = most_recent.timestamp().as_u64() as i64;
+
     while let Some(item) = detailed.items.next().await {
-        match SignedPacket::try_from(item) {
-            Ok(packet) if packet.more_recent_than(&most_recent) => most_recent = packet,
-            Ok(_) => {}
-            Err(_) => invalid_signed_packet_count += 1,
+        let seq = item.seq();
+        if seq >= highest_seq {
+            highest_seq = seq;
+            match SignedPacket::try_from(&item) {
+                Ok(packet) if packet.more_recent_than(&most_recent) => most_recent = packet,
+                _ => (),
+            }
         }
     }
 
-    let report = ResolveReport::with_invalid_signed_packets(
-        detailed.outcome.recv().await,
-        invalid_signed_packet_count,
-    );
+    let most_recent = completed_resolve_value(most_recent, highest_seq);
+    let report = ResolveReport::new(detailed.outcome.recv().await);
+
     ResolveOutcome {
         most_recent,
         report,
+    }
+}
+
+fn completed_resolve_value(most_recent: SignedPacket, highest_seq: i64) -> ResolveValue {
+    let packet_seq = most_recent.timestamp().as_u64() as i64;
+
+    if packet_seq >= highest_seq {
+        ResolveValue::ValidSignedPacket {
+            packet: most_recent,
+        }
+    } else {
+        ResolveValue::InvalidSignedPacket { seq: highest_seq }
     }
 }
 
@@ -201,5 +235,43 @@ mod tests {
         );
 
         assert_eq!(item, expected);
+    }
+
+    #[test]
+    fn completed_resolve_value_preserves_valid_signed_packet_when_invalid_seq_is_not_newer() {
+        let signed_packet = SignedPacket::builder()
+            .timestamp(10.into())
+            .address(
+                "_derp_region.iroh.".try_into().unwrap(),
+                "1.1.1.1".parse().unwrap(),
+                30,
+            )
+            .sign(&Keypair::random())
+            .unwrap();
+
+        assert_eq!(
+            super::completed_resolve_value(signed_packet.clone(), 10),
+            super::ResolveValue::ValidSignedPacket {
+                packet: signed_packet
+            }
+        );
+    }
+
+    #[test]
+    fn completed_resolve_value_respects_newer_invalid_signed_packet_seq() {
+        let signed_packet = SignedPacket::builder()
+            .timestamp(10.into())
+            .address(
+                "_derp_region.iroh.".try_into().unwrap(),
+                "1.1.1.1".parse().unwrap(),
+                30,
+            )
+            .sign(&Keypair::random())
+            .unwrap();
+
+        assert_eq!(
+            super::completed_resolve_value(signed_packet, 11),
+            super::ResolveValue::InvalidSignedPacket { seq: 11 }
+        );
     }
 }

--- a/pkarr/src/dht/client.rs
+++ b/pkarr/src/dht/client.rs
@@ -1,11 +1,19 @@
+use std::future::Future;
+
 use ed25519_dalek::Signature;
 use futures_lite::{Stream, StreamExt};
-use mainline::{async_dht::AsyncDht, Config, Dht, MutableItem};
+use mainline::{
+    async_dht::{AsyncDht, GetMutableDetailed},
+    Config, Dht, MutableItem,
+};
 use ntimestamp::Timestamp;
 
 use crate::{PublicKey, SignedPacket};
 
-use super::{DhtInfo, PublishError};
+use super::{DhtInfo, PublishError, ResolveFound, ResolveReport};
+
+/// Minimum DHT nodes expected to acknowledge storing a published packet.
+pub const MINIMUM_PUBLISH_STORED_NODES: u32 = 10;
 
 /// Pkarr DHT client.
 #[derive(Clone, Debug)]
@@ -27,14 +35,17 @@ impl DhtClient {
         &self,
         signed_packet: &SignedPacket,
         cas: Option<Timestamp>,
-    ) -> Result<(), PublishError> {
+    ) -> Result<u32, PublishError> {
         let cas = cas.map(|timestamp| timestamp.as_u64() as i64);
-        self.inner.put_mutable(signed_packet.into(), cas).await?;
-        Ok(())
+        Ok(self
+            .inner
+            .put_mutable(signed_packet.into(), cas)
+            .await?
+            .stored_at)
     }
 
     /// Resolve signed packets newer than the given timestamp.
-    pub fn resolve(
+    pub fn resolve_stream(
         &self,
         public_key: &PublicKey,
         more_recent_than: Option<Timestamp>,
@@ -44,6 +55,45 @@ impl DhtClient {
         self.inner
             .get_mutable(public_key.as_bytes(), None, more_recent_than)
             .filter_map(|item| SignedPacket::try_from(item).ok())
+    }
+
+    /// Resolve signed packets newer than the given timestamp and return query diagnostics.
+    pub async fn resolve(
+        &self,
+        public_key: &PublicKey,
+        more_recent_than: Option<Timestamp>,
+    ) -> Result<
+        ResolveFound<impl Future<Output = (SignedPacket, ResolveReport)> + Send>,
+        ResolveReport,
+    > {
+        let more_recent_than = more_recent_than.map(|timestamp| timestamp.as_u64() as i64);
+        let mut detailed =
+            self.inner
+                .get_mutable_detailed(public_key.as_bytes(), None, more_recent_than);
+
+        let mut invalid_signed_packet_count = 0;
+        while let Some(item) = detailed.items.next().await {
+            match SignedPacket::try_from(item) {
+                Ok(first) => {
+                    let most_recent = first.clone();
+                    return Ok(ResolveFound {
+                        first,
+                        completion: finish_resolve(
+                            detailed,
+                            most_recent,
+                            invalid_signed_packet_count,
+                        ),
+                    });
+                }
+                Err(_) => invalid_signed_packet_count += 1,
+            }
+        }
+
+        let report = ResolveReport::with_invalid_signed_packets(
+            detailed.outcome.recv().await,
+            invalid_signed_packet_count,
+        );
+        Err(report)
     }
 
     /// Return information about the underlying DHT node.
@@ -98,6 +148,27 @@ impl TryFrom<MutableItem> for SignedPacket {
     fn try_from(i: MutableItem) -> Result<Self, crate::errors::SignedPacketVerifyError> {
         SignedPacket::try_from(&i)
     }
+}
+
+async fn finish_resolve(
+    mut detailed: GetMutableDetailed,
+    mut most_recent: SignedPacket,
+    mut invalid_signed_packet_count: u32,
+) -> (SignedPacket, ResolveReport) {
+    while let Some(item) = detailed.items.next().await {
+        match SignedPacket::try_from(item) {
+            Ok(packet) if packet.more_recent_than(&most_recent) => most_recent = packet,
+            Ok(_) => {}
+            Err(_) => invalid_signed_packet_count += 1,
+        }
+    }
+
+    let report = ResolveReport::with_invalid_signed_packets(
+        detailed.outcome.recv().await,
+        invalid_signed_packet_count,
+    );
+
+    (most_recent, report)
 }
 
 #[cfg(test)]

--- a/pkarr/src/dht/client.rs
+++ b/pkarr/src/dht/client.rs
@@ -1,5 +1,3 @@
-use std::future::Future;
-
 use ed25519_dalek::Signature;
 use futures_lite::{Stream, StreamExt};
 use mainline::{
@@ -10,7 +8,7 @@ use ntimestamp::Timestamp;
 
 use crate::{PublicKey, SignedPacket};
 
-use super::{DhtInfo, PublishError, ResolveFound, ResolveReport};
+use super::{DhtInfo, PublishError, ResolveError, ResolveOutcome, ResolveReport, ResolveResponse};
 
 /// Minimum DHT nodes expected to acknowledge storing a published packet.
 pub const MINIMUM_PUBLISH_STORED_NODES: u32 = 10;
@@ -31,6 +29,10 @@ impl DhtClient {
     }
 
     /// Publish a signed packet to the DHT.
+    ///
+    /// # Returns
+    ///
+    /// The number of DHT nodes that acknowledged storing the packet.
     pub async fn publish(
         &self,
         signed_packet: &SignedPacket,
@@ -58,14 +60,17 @@ impl DhtClient {
     }
 
     /// Resolve signed packets newer than the given timestamp and return query diagnostics.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when no signed packet is found or the DHT query did not
+    /// receive enough useful responses to distinguish a miss from a query
+    /// failure.
     pub async fn resolve(
         &self,
         public_key: &PublicKey,
         more_recent_than: Option<Timestamp>,
-    ) -> Result<
-        ResolveFound<impl Future<Output = (SignedPacket, ResolveReport)> + Send>,
-        ResolveReport,
-    > {
+    ) -> Result<ResolveResponse, ResolveError> {
         let more_recent_than = more_recent_than.map(|timestamp| timestamp.as_u64() as i64);
         let mut detailed =
             self.inner
@@ -76,14 +81,10 @@ impl DhtClient {
             match SignedPacket::try_from(item) {
                 Ok(first) => {
                     let most_recent = first.clone();
-                    return Ok(ResolveFound {
+                    return Ok(ResolveResponse::new(
                         first,
-                        completion: finish_resolve(
-                            detailed,
-                            most_recent,
-                            invalid_signed_packet_count,
-                        ),
-                    });
+                        finish_resolve(detailed, most_recent, invalid_signed_packet_count),
+                    ));
                 }
                 Err(_) => invalid_signed_packet_count += 1,
             }
@@ -93,7 +94,7 @@ impl DhtClient {
             detailed.outcome.recv().await,
             invalid_signed_packet_count,
         );
-        Err(report)
+        Err(report.into())
     }
 
     /// Return information about the underlying DHT node.
@@ -154,7 +155,7 @@ async fn finish_resolve(
     mut detailed: GetMutableDetailed,
     mut most_recent: SignedPacket,
     mut invalid_signed_packet_count: u32,
-) -> (SignedPacket, ResolveReport) {
+) -> ResolveOutcome {
     while let Some(item) = detailed.items.next().await {
         match SignedPacket::try_from(item) {
             Ok(packet) if packet.more_recent_than(&most_recent) => most_recent = packet,
@@ -167,8 +168,10 @@ async fn finish_resolve(
         detailed.outcome.recv().await,
         invalid_signed_packet_count,
     );
-
-    (most_recent, report)
+    ResolveOutcome {
+        most_recent,
+        report,
+    }
 }
 
 #[cfg(test)]

--- a/pkarr/src/dht/client.rs
+++ b/pkarr/src/dht/client.rs
@@ -10,9 +10,6 @@ use crate::{PublicKey, SignedPacket};
 
 use super::{DhtInfo, PublishError, ResolveError, ResolveOutcome, ResolveReport, ResolveResponse};
 
-/// Minimum DHT nodes expected to acknowledge storing a published packet.
-pub const MINIMUM_PUBLISH_STORED_NODES: u32 = 10;
-
 /// Pkarr DHT client.
 #[derive(Clone, Debug)]
 pub struct DhtClient {

--- a/pkarr/src/dht/client.rs
+++ b/pkarr/src/dht/client.rs
@@ -8,10 +8,7 @@ use ntimestamp::Timestamp;
 
 use crate::{PublicKey, SignedPacket};
 
-use super::{
-    DhtInfo, PublishError, ResolveError, ResolveOutcome, ResolveReport, ResolveResponse,
-    ResolveValue,
-};
+use super::{DhtInfo, PublishError, ResolveError, ResolveOutcome, ResolveReport, ResolveResponse};
 
 /// Pkarr DHT client.
 #[derive(Clone, Debug)]
@@ -61,27 +58,20 @@ impl DhtClient {
 
     /// Resolve signed packets newer than the given timestamp and return query diagnostics.
     ///
-    /// The first valid signed packet is available immediately from the returned
-    /// [`ResolveResponse`]. Completing the response returns the most recent DHT
-    /// mutable value observed, which may be a newer mutable item that does not
-    /// contain a valid signed packet.
+    /// The first valid signed packet, if any, is available immediately from
+    /// the returned [`ResolveResponse`]. Completing the response returns the
+    /// most recent valid signed packet or a resolve error with diagnostics.
     ///
     /// BEP44 sequence numbers define mutable-item freshness. If a mutable item
     /// with a higher sequence number is not a valid signed packet, that item is
     /// still treated as the current DHT state and supersedes older valid signed
     /// packets for the same key.
     ///
-    /// # Errors
-    ///
-    /// Returns an error when no signed packet is found or the DHT query did not
-    /// receive enough useful responses to distinguish a miss from a query
-    /// failure. If DHT nodes return mutable values for the key but none verify
-    /// as signed packets, returns the newest observed mutable item sequence number.
     pub async fn resolve(
         &self,
         public_key: &PublicKey,
         more_recent_than: Option<Timestamp>,
-    ) -> Result<ResolveResponse, ResolveError> {
+    ) -> ResolveResponse {
         let more_recent_than = more_recent_than.map(|timestamp| timestamp.as_u64() as i64);
         let mut detailed =
             self.inner
@@ -97,20 +87,15 @@ impl DhtClient {
                 highest_seq = Some(seq);
                 if let Ok(packet) = SignedPacket::try_from(&item) {
                     let most_recent = packet.clone();
-                    return Ok(ResolveResponse::new(
-                        packet,
-                        finish_resolve(detailed, most_recent),
-                    ));
+                    return ResolveResponse::new(
+                        Some(packet),
+                        finish_resolve(detailed, Some(most_recent), highest_seq),
+                    );
                 }
             }
         }
 
-        if let Some(seq) = highest_seq {
-            return Err(ResolveError::InvalidSignedPacket { seq });
-        }
-
-        let report = ResolveReport::new(detailed.outcome.recv().await);
-        Err(report.into())
+        ResolveResponse::new(None, finish_resolve(detailed, None, highest_seq))
     }
 
     /// Return information about the underlying DHT node.
@@ -169,23 +154,28 @@ impl TryFrom<MutableItem> for SignedPacket {
 
 async fn finish_resolve(
     mut detailed: GetMutableDetailed,
-    mut most_recent: SignedPacket,
+    mut most_recent: Option<SignedPacket>,
+    mut highest_seq: Option<i64>,
 ) -> ResolveOutcome {
-    let mut highest_seq = most_recent.timestamp().as_u64() as i64;
-
     while let Some(item) = detailed.items.next().await {
         let seq = item.seq();
-        if seq >= highest_seq {
-            highest_seq = seq;
+        if seq >= highest_seq.unwrap_or(seq) {
+            highest_seq = Some(seq);
             match SignedPacket::try_from(&item) {
-                Ok(packet) if packet.more_recent_than(&most_recent) => most_recent = packet,
+                Ok(packet)
+                    if most_recent
+                        .as_ref()
+                        .is_none_or(|most_recent| packet.more_recent_than(most_recent)) =>
+                {
+                    most_recent = Some(packet)
+                }
                 _ => (),
             }
         }
     }
 
-    let most_recent = completed_resolve_value(most_recent, highest_seq);
     let report = ResolveReport::new(detailed.outcome.recv().await);
+    let most_recent = completed_resolve_result(most_recent, highest_seq, &report);
 
     ResolveOutcome {
         most_recent,
@@ -193,15 +183,28 @@ async fn finish_resolve(
     }
 }
 
-fn completed_resolve_value(most_recent: SignedPacket, highest_seq: i64) -> ResolveValue {
-    let packet_seq = most_recent.timestamp().as_u64() as i64;
+fn completed_resolve_result(
+    most_recent: Option<SignedPacket>,
+    highest_seq: Option<i64>,
+    report: &ResolveReport,
+) -> Result<SignedPacket, ResolveError> {
+    let Some(most_recent) = most_recent else {
+        return Err(if let Some(seq) = highest_seq {
+            ResolveError::InvalidSignedPacket { seq }
+        } else {
+            ResolveError::from(report.clone())
+        });
+    };
 
+    let Some(highest_seq) = highest_seq else {
+        return Ok(most_recent);
+    };
+
+    let packet_seq = most_recent.timestamp().as_u64() as i64;
     if packet_seq >= highest_seq {
-        ResolveValue::ValidSignedPacket {
-            packet: most_recent,
-        }
+        Ok(most_recent)
     } else {
-        ResolveValue::InvalidSignedPacket { seq: highest_seq }
+        Err(ResolveError::InvalidSignedPacket { seq: highest_seq })
     }
 }
 
@@ -210,6 +213,18 @@ mod tests {
     use mainline::MutableItem;
 
     use crate::{Keypair, SignedPacket};
+
+    fn report(outcome: mainline::GetMutableOutcome) -> super::ResolveReport {
+        super::ResolveReport::new(outcome)
+    }
+
+    fn healthy_report() -> super::ResolveReport {
+        report(mainline::GetMutableOutcome {
+            queried: 20,
+            values: 1,
+            ..Default::default()
+        })
+    }
 
     #[test]
     fn signed_packet_converts_to_mutable_item() {
@@ -238,7 +253,7 @@ mod tests {
     }
 
     #[test]
-    fn completed_resolve_value_preserves_valid_signed_packet_when_invalid_seq_is_not_newer() {
+    fn completed_resolve_result_preserves_valid_signed_packet_when_invalid_seq_is_not_newer() {
         let signed_packet = SignedPacket::builder()
             .timestamp(10.into())
             .address(
@@ -250,15 +265,17 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            super::completed_resolve_value(signed_packet.clone(), 10),
-            super::ResolveValue::ValidSignedPacket {
-                packet: signed_packet
-            }
+            super::completed_resolve_result(
+                Some(signed_packet.clone()),
+                Some(10),
+                &healthy_report()
+            ),
+            Ok(signed_packet)
         );
     }
 
     #[test]
-    fn completed_resolve_value_respects_newer_invalid_signed_packet_seq() {
+    fn completed_resolve_result_respects_newer_invalid_signed_packet_seq() {
         let signed_packet = SignedPacket::builder()
             .timestamp(10.into())
             .address(
@@ -270,8 +287,28 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            super::completed_resolve_value(signed_packet, 11),
-            super::ResolveValue::InvalidSignedPacket { seq: 11 }
+            super::completed_resolve_result(Some(signed_packet), Some(11), &healthy_report()),
+            Err(super::ResolveError::InvalidSignedPacket { seq: 11 })
+        );
+    }
+
+    #[test]
+    fn completed_resolve_result_reports_invalid_signed_packet_without_valid_packet() {
+        assert_eq!(
+            super::completed_resolve_result(None, Some(11), &healthy_report()),
+            Err(super::ResolveError::InvalidSignedPacket { seq: 11 })
+        );
+    }
+
+    #[test]
+    fn completed_resolve_result_classifies_report_without_any_packet() {
+        assert_eq!(
+            super::completed_resolve_result(
+                None,
+                None,
+                &report(mainline::GetMutableOutcome::default())
+            ),
+            Err(super::ResolveError::NoNodesQueried)
         );
     }
 }

--- a/pkarr/src/dht/error.rs
+++ b/pkarr/src/dht/error.rs
@@ -1,5 +1,7 @@
 use mainline::errors::PutMutableError;
 
+use super::ResolveReport;
+
 /// DHT publish error.
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PublishError {
@@ -52,5 +54,87 @@ impl From<PutMutableError> for PublishError {
                 mainline::errors::ConcurrencyError::CasFailed => PublishError::CasFailed,
             },
         }
+    }
+}
+
+/// DHT resolve error.
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ResolveError {
+    /// DHT query did not query any nodes.
+    #[error("no DHT nodes were queried")]
+    NoNodesQueried,
+
+    /// DHT query did not receive any responses.
+    #[error("no queried DHT nodes responded")]
+    NoNodesResponded,
+
+    /// DHT query did not receive any valid responses.
+    #[error("no responded DHT nodes returned valid response")]
+    NoValidResponses,
+
+    /// No signed packet was found.
+    #[error("signed packet not found")]
+    NotFound,
+}
+
+impl From<ResolveReport> for ResolveError {
+    fn from(report: ResolveReport) -> Self {
+        if report.queried() == 0 {
+            Self::NoNodesQueried
+        } else if report.responded() == 0 {
+            Self::NoNodesResponded
+        } else if report.valid_responses() == 0 {
+            Self::NoValidResponses
+        } else {
+            Self::NotFound
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(outcome: mainline::GetMutableOutcome) -> ResolveReport {
+        ResolveReport::with_invalid_signed_packets(outcome, 0)
+    }
+
+    #[test]
+    fn resolve_report_without_queried_nodes_maps_to_no_nodes_queried() {
+        let error = ResolveError::from(report(mainline::GetMutableOutcome::default()));
+
+        assert_eq!(error, ResolveError::NoNodesQueried);
+    }
+
+    #[test]
+    fn resolve_report_without_responses_maps_to_no_nodes_responded() {
+        let error = ResolveError::from(report(mainline::GetMutableOutcome {
+            queried: 20,
+            ..Default::default()
+        }));
+
+        assert_eq!(error, ResolveError::NoNodesResponded);
+    }
+
+    #[test]
+    fn resolve_report_without_valid_responses_maps_to_no_valid_responses() {
+        let error = ResolveError::from(report(mainline::GetMutableOutcome {
+            queried: 20,
+            invalid_responses: 1,
+            ..Default::default()
+        }));
+
+        assert_eq!(error, ResolveError::NoValidResponses);
+    }
+
+    #[test]
+    fn resolve_report_with_valid_responses_maps_to_not_found() {
+        let error = ResolveError::from(report(mainline::GetMutableOutcome {
+            queried: 20,
+            no_values: 1,
+            ..Default::default()
+        }));
+
+        assert_eq!(error, ResolveError::NotFound);
     }
 }

--- a/pkarr/src/dht/error.rs
+++ b/pkarr/src/dht/error.rs
@@ -68,13 +68,20 @@ pub enum ResolveError {
     #[error("no queried DHT nodes responded")]
     NoNodesResponded,
 
-    /// DHT query did not receive any valid responses.
-    #[error("no responded DHT nodes returned valid response")]
-    NoValidResponses,
+    /// DHT query did not receive any usable responses.
+    #[error("no responded DHT nodes returned usable response")]
+    NoUsableResponses,
 
     /// No signed packet was found.
     #[error("signed packet not found")]
     NotFound,
+
+    /// DHT returned mutable values for the key, but none were valid signed packets.
+    #[error("DHT mutable item at seq {seq} is not a valid signed packet")]
+    InvalidSignedPacket {
+        /// Mutable item sequence number.
+        seq: i64,
+    },
 }
 
 impl From<ResolveReport> for ResolveError {
@@ -83,8 +90,8 @@ impl From<ResolveReport> for ResolveError {
             Self::NoNodesQueried
         } else if report.responded() == 0 {
             Self::NoNodesResponded
-        } else if report.valid_responses() == 0 {
-            Self::NoValidResponses
+        } else if report.usable_responses() == 0 {
+            Self::NoUsableResponses
         } else {
             Self::NotFound
         }
@@ -96,7 +103,7 @@ mod tests {
     use super::*;
 
     fn report(outcome: mainline::GetMutableOutcome) -> ResolveReport {
-        ResolveReport::with_invalid_signed_packets(outcome, 0)
+        ResolveReport::new(outcome)
     }
 
     #[test]
@@ -117,18 +124,18 @@ mod tests {
     }
 
     #[test]
-    fn resolve_report_without_valid_responses_maps_to_no_valid_responses() {
+    fn resolve_report_without_usable_responses_maps_to_no_usable_responses() {
         let error = ResolveError::from(report(mainline::GetMutableOutcome {
             queried: 20,
             invalid_responses: 1,
             ..Default::default()
         }));
 
-        assert_eq!(error, ResolveError::NoValidResponses);
+        assert_eq!(error, ResolveError::NoUsableResponses);
     }
 
     #[test]
-    fn resolve_report_with_valid_responses_maps_to_not_found() {
+    fn resolve_report_with_usable_responses_maps_to_not_found() {
         let error = ResolveError::from(report(mainline::GetMutableOutcome {
             queried: 20,
             no_values: 1,

--- a/pkarr/src/dht/mod.rs
+++ b/pkarr/src/dht/mod.rs
@@ -3,11 +3,13 @@
 mod client;
 mod error;
 mod info;
+mod report_policy;
 mod resolve_report;
 mod resolve_response;
 
-pub use client::{DhtClient, MINIMUM_PUBLISH_STORED_NODES};
+pub use client::DhtClient;
 pub use error::{PublishError, ResolveError};
 pub use info::DhtInfo;
-pub use resolve_report::{ResolveReport, ResolveReportPolicy, ResolveWarning};
+pub use report_policy::{PublishWarning, ReportPolicy, ResolveWarning};
+pub use resolve_report::ResolveReport;
 pub use resolve_response::{ResolveOutcome, ResolveResponse};

--- a/pkarr/src/dht/mod.rs
+++ b/pkarr/src/dht/mod.rs
@@ -12,4 +12,4 @@ pub use error::{PublishError, ResolveError};
 pub use info::DhtInfo;
 pub use report_policy::{PublishWarning, ReportPolicy, ResolveWarning};
 pub use resolve_report::ResolveReport;
-pub use resolve_response::{ResolveOutcome, ResolveResponse};
+pub use resolve_response::{ResolveOutcome, ResolveResponse, ResolveValue};

--- a/pkarr/src/dht/mod.rs
+++ b/pkarr/src/dht/mod.rs
@@ -3,7 +3,10 @@
 mod client;
 mod error;
 mod info;
+mod resolve;
 
-pub use client::DhtClient;
+pub use client::{DhtClient, MINIMUM_PUBLISH_STORED_NODES};
 pub use error::PublishError;
 pub use info::DhtInfo;
+pub use resolve::ResolveSuspicion;
+pub use resolve::{ResolveFound, ResolveReport};

--- a/pkarr/src/dht/mod.rs
+++ b/pkarr/src/dht/mod.rs
@@ -3,10 +3,11 @@
 mod client;
 mod error;
 mod info;
-mod resolve;
+mod resolve_report;
+mod resolve_response;
 
 pub use client::{DhtClient, MINIMUM_PUBLISH_STORED_NODES};
-pub use error::PublishError;
+pub use error::{PublishError, ResolveError};
 pub use info::DhtInfo;
-pub use resolve::ResolveSuspicion;
-pub use resolve::{ResolveFound, ResolveReport};
+pub use resolve_report::{ResolveReport, ResolveReportPolicy, ResolveWarning};
+pub use resolve_response::{ResolveOutcome, ResolveResponse};

--- a/pkarr/src/dht/mod.rs
+++ b/pkarr/src/dht/mod.rs
@@ -12,4 +12,4 @@ pub use error::{PublishError, ResolveError};
 pub use info::DhtInfo;
 pub use report_policy::{PublishWarning, ReportPolicy, ResolveWarning};
 pub use resolve_report::ResolveReport;
-pub use resolve_response::{ResolveOutcome, ResolveResponse, ResolveValue};
+pub use resolve_response::{ResolveOutcome, ResolveResponse};

--- a/pkarr/src/dht/report_policy.rs
+++ b/pkarr/src/dht/report_policy.rs
@@ -7,10 +7,10 @@ const MINIMUM_PUBLISH_STORED_NODES: u32 = 10;
 const DEFAULT_MINIMUM_QUERIED_NODES: u32 = 20;
 
 /// Default minimum number of DHT nodes that should respond to a resolve query.
-const DEFAULT_MINIMUM_RESPONDED_NODES: u32 = 3;
+const DEFAULT_MINIMUM_RESPONDED_NODES: u32 = 5;
 
-/// Default minimum number of valid responses expected from a resolve query.
-const DEFAULT_MINIMUM_VALID_RESPONSES: u32 = 1;
+/// Default minimum number of usable responses expected from a resolve query.
+const DEFAULT_MINIMUM_USABLE_RESPONSES: u32 = 3;
 
 /// Testnet minimum number of DHT nodes expected to acknowledge storing a published packet.
 const TESTNET_MINIMUM_PUBLISH_STORED_NODES: u32 = 1;
@@ -21,8 +21,8 @@ const TESTNET_MINIMUM_QUERIED_NODES: u32 = 1;
 /// Testnet minimum number of DHT nodes that should respond to a resolve query.
 const TESTNET_MINIMUM_RESPONDED_NODES: u32 = 1;
 
-/// Testnet minimum number of valid responses expected from a resolve query.
-const TESTNET_MINIMUM_VALID_RESPONSES: u32 = 1;
+/// Testnet minimum number of usable responses expected from a resolve query.
+const TESTNET_MINIMUM_USABLE_RESPONSES: u32 = 1;
 
 /// Policy used to classify DHT query diagnostics.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -33,11 +33,19 @@ pub struct ReportPolicy {
     pub minimum_queried_nodes: u32,
     /// Minimum number of queried DHT nodes that should respond.
     pub minimum_responded_nodes: u32,
-    /// Minimum number of responses with a valid mutable GET shape.
-    pub minimum_valid_responses: u32,
-    /// Whether invalid values or invalid response shapes should be reported as warnings.
-    pub report_invalid_responses: bool,
+    /// Minimum number of responses with a usable mutable GET shape.
+    pub minimum_usable_responses: u32,
+    /// Whether unusable mutable GET responses should be reported as
+    /// [`ResolveWarning::MalformedResponses`].
+    ///
+    /// This covers mutable values that fail validation and malformed response
+    /// shapes, but not explicit KRPC error responses.
+    pub report_malformed_responses: bool,
     /// Whether KRPC error responses should be reported as warnings.
+    ///
+    /// KRPC errors are also unusable resolve responses, but they are kept
+    /// separate from malformed responses because they usually point to a
+    /// protocol-level error returned by the remote node.
     pub report_krpc_errors: bool,
 }
 
@@ -48,8 +56,8 @@ impl ReportPolicy {
             minimum_publish_stored_nodes: MINIMUM_PUBLISH_STORED_NODES,
             minimum_queried_nodes: DEFAULT_MINIMUM_QUERIED_NODES,
             minimum_responded_nodes: DEFAULT_MINIMUM_RESPONDED_NODES,
-            minimum_valid_responses: DEFAULT_MINIMUM_VALID_RESPONSES,
-            report_invalid_responses: true,
+            minimum_usable_responses: DEFAULT_MINIMUM_USABLE_RESPONSES,
+            report_malformed_responses: true,
             report_krpc_errors: true,
         }
     }
@@ -60,8 +68,8 @@ impl ReportPolicy {
             minimum_publish_stored_nodes: TESTNET_MINIMUM_PUBLISH_STORED_NODES,
             minimum_queried_nodes: TESTNET_MINIMUM_QUERIED_NODES,
             minimum_responded_nodes: TESTNET_MINIMUM_RESPONDED_NODES,
-            minimum_valid_responses: TESTNET_MINIMUM_VALID_RESPONSES,
-            report_invalid_responses: true,
+            minimum_usable_responses: TESTNET_MINIMUM_USABLE_RESPONSES,
+            report_malformed_responses: true,
             report_krpc_errors: true,
         }
     }
@@ -80,14 +88,11 @@ impl ReportPolicy {
 
     /// Classify warning diagnostics for a DHT resolve query.
     pub fn classify_resolve_report(&self, report: &ResolveReport) -> Vec<ResolveWarning> {
-        let outcome = &report.outcome;
-        let invalid_signed_packet_count = report.invalid_signed_packet_count;
+        let outcome = &report.0;
 
         let mut warnings = Vec::new();
         let responded = outcome.responded();
-        let valid_responses = outcome
-            .valid_responses()
-            .saturating_sub(invalid_signed_packet_count);
+        let usable_responses = outcome.valid_responses();
 
         if outcome.queried < self.minimum_queried_nodes {
             warnings.push(ResolveWarning::TooFewNodesQueried {
@@ -103,25 +108,26 @@ impl ReportPolicy {
             });
         }
 
-        if valid_responses < self.minimum_valid_responses {
-            warnings.push(ResolveWarning::TooFewValidResponses {
-                valid_responses,
-                minimum: self.minimum_valid_responses,
+        if usable_responses < self.minimum_usable_responses {
+            warnings.push(ResolveWarning::TooFewUsableResponses {
+                usable_responses,
+                minimum: self.minimum_usable_responses,
             });
         }
 
-        if self.report_invalid_responses
-            && (outcome.invalid_values > 0
-                || outcome.invalid_responses > 0
-                || invalid_signed_packet_count > 0)
+        // Values that fail validation and malformed response shapes are grouped
+        // together because both are unusable non-error responses from DHT nodes.
+        if self.report_malformed_responses
+            && (outcome.invalid_values > 0 || outcome.invalid_responses > 0)
         {
-            warnings.push(ResolveWarning::InvalidResponses {
-                invalid_values: outcome.invalid_values,
-                invalid_responses: outcome.invalid_responses,
-                invalid_signed_packets: invalid_signed_packet_count,
+            warnings.push(ResolveWarning::MalformedResponses {
+                malformed_values: outcome.invalid_values,
+                malformed_responses: outcome.invalid_responses,
             });
         }
 
+        // KRPC errors are unusable too, but unlike malformed responses they
+        // were explicit protocol-level errors returned by the queried node.
         if self.report_krpc_errors && outcome.krpc_errors > 0 {
             warnings.push(ResolveWarning::KrpcErrors {
                 krpc_errors: outcome.krpc_errors,
@@ -163,23 +169,28 @@ pub enum ResolveWarning {
         /// Minimum number of responses expected by the policy.
         minimum: u32,
     },
-    /// The query received fewer valid mutable GET responses than expected.
-    TooFewValidResponses {
-        /// Number of valid mutable GET responses.
-        valid_responses: u32,
-        /// Minimum number of valid responses expected by the policy.
+    /// The query received fewer usable mutable GET responses than expected.
+    TooFewUsableResponses {
+        /// Number of usable mutable GET responses.
+        usable_responses: u32,
+        /// Minimum number of usable responses expected by the policy.
         minimum: u32,
     },
-    /// The query received invalid values or invalid response shapes.
-    InvalidResponses {
+    /// The query received malformed or unusable mutable GET responses.
+    ///
+    /// These are responses that did not contain an explicit KRPC error, but
+    /// still could not be used as usable mutable GET responses.
+    MalformedResponses {
         /// Number of mutable value responses that failed validation.
-        invalid_values: u32,
-        /// Number of invalid response shapes returned.
-        invalid_responses: u32,
-        /// Number of mutable values that failed signed packet validation.
-        invalid_signed_packets: u32,
+        malformed_values: u32,
+        /// Number of malformed response shapes returned.
+        malformed_responses: u32,
     },
     /// The query received KRPC error responses.
+    ///
+    /// These are also unusable for resolution, but are kept separate from
+    /// [`ResolveWarning::MalformedResponses`] because the remote node returned an
+    /// explicit protocol-level error.
     KrpcErrors {
         /// Number of KRPC error responses returned.
         krpc_errors: u32,
@@ -188,7 +199,17 @@ pub enum ResolveWarning {
 
 #[cfg(test)]
 mod tests {
-    use super::{PublishWarning, ReportPolicy, MINIMUM_PUBLISH_STORED_NODES};
+    use super::{
+        PublishWarning, ReportPolicy, ResolveReport, ResolveWarning, MINIMUM_PUBLISH_STORED_NODES,
+    };
+
+    fn report(outcome: mainline::GetMutableOutcome) -> ResolveReport {
+        ResolveReport::new(outcome)
+    }
+
+    fn classify(report: &ResolveReport) -> Vec<ResolveWarning> {
+        ReportPolicy::mainnet().classify_resolve_report(report)
+    }
 
     #[test]
     fn mainnet_publish_policy_warns_when_too_few_nodes_store_packet() {
@@ -211,5 +232,118 @@ mod tests {
         assert!(ReportPolicy::testnet()
             .classify_publish_result(1)
             .is_empty());
+    }
+
+    #[test]
+    fn healthy_resolve_outcome_is_ok() {
+        let report = report(mainline::GetMutableOutcome {
+            queried: 20,
+            values: 1,
+            no_values: 4,
+            no_more_recent: 0,
+            invalid_values: 0,
+            invalid_responses: 0,
+            krpc_errors: 0,
+        });
+
+        assert!(classify(&report).is_empty());
+    }
+
+    #[test]
+    fn sparse_resolve_outcome_produces_warnings() {
+        let report = report(mainline::GetMutableOutcome {
+            queried: 2,
+            values: 0,
+            no_values: 0,
+            no_more_recent: 0,
+            invalid_values: 0,
+            invalid_responses: 0,
+            krpc_errors: 0,
+        });
+
+        let policy = ReportPolicy::mainnet();
+        assert_eq!(
+            classify(&report),
+            vec![
+                ResolveWarning::TooFewNodesQueried {
+                    queried: 2,
+                    minimum: policy.minimum_queried_nodes,
+                },
+                ResolveWarning::TooFewNodesResponded {
+                    responded: 0,
+                    minimum: policy.minimum_responded_nodes,
+                },
+                ResolveWarning::TooFewUsableResponses {
+                    usable_responses: 0,
+                    minimum: policy.minimum_usable_responses,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn malformed_and_error_resolve_responses_produce_warnings() {
+        let report = report(mainline::GetMutableOutcome {
+            queried: 20,
+            values: 1,
+            no_values: 2,
+            no_more_recent: 0,
+            invalid_values: 1,
+            invalid_responses: 1,
+            krpc_errors: 1,
+        });
+
+        assert_eq!(
+            classify(&report),
+            vec![
+                ResolveWarning::MalformedResponses {
+                    malformed_values: 1,
+                    malformed_responses: 1,
+                },
+                ResolveWarning::KrpcErrors { krpc_errors: 1 },
+            ]
+        );
+    }
+
+    #[test]
+    fn testnet_resolve_policy_relaxes_topology_thresholds() {
+        let report = report(mainline::GetMutableOutcome {
+            queried: 2,
+            values: 0,
+            no_values: 1,
+            no_more_recent: 0,
+            invalid_values: 0,
+            invalid_responses: 0,
+            krpc_errors: 0,
+        });
+
+        assert!(ReportPolicy::testnet()
+            .classify_resolve_report(&report)
+            .is_empty());
+    }
+
+    #[test]
+    fn custom_resolve_policy_controls_warning_thresholds() {
+        let report = report(mainline::GetMutableOutcome {
+            queried: 2,
+            values: 0,
+            no_values: 1,
+            no_more_recent: 0,
+            invalid_values: 1,
+            invalid_responses: 0,
+            krpc_errors: 1,
+        });
+
+        let warnings = ReportPolicy {
+            minimum_publish_stored_nodes: 1,
+            minimum_queried_nodes: 2,
+            minimum_responded_nodes: 1,
+            minimum_usable_responses: 1,
+            report_malformed_responses: false,
+            report_krpc_errors: false,
+        }
+        .classify_resolve_report(&report);
+
+        assert!(warnings.is_empty());
     }
 }

--- a/pkarr/src/dht/report_policy.rs
+++ b/pkarr/src/dht/report_policy.rs
@@ -1,0 +1,215 @@
+use super::resolve_report::ResolveReport;
+
+/// Default minimum number of DHT nodes expected to acknowledge storing a published packet.
+const MINIMUM_PUBLISH_STORED_NODES: u32 = 10;
+
+/// Default minimum number of DHT nodes a resolve query should visit.
+const DEFAULT_MINIMUM_QUERIED_NODES: u32 = 20;
+
+/// Default minimum number of DHT nodes that should respond to a resolve query.
+const DEFAULT_MINIMUM_RESPONDED_NODES: u32 = 3;
+
+/// Default minimum number of valid responses expected from a resolve query.
+const DEFAULT_MINIMUM_VALID_RESPONSES: u32 = 1;
+
+/// Testnet minimum number of DHT nodes expected to acknowledge storing a published packet.
+const TESTNET_MINIMUM_PUBLISH_STORED_NODES: u32 = 1;
+
+/// Testnet minimum number of DHT nodes a resolve query should visit.
+const TESTNET_MINIMUM_QUERIED_NODES: u32 = 1;
+
+/// Testnet minimum number of DHT nodes that should respond to a resolve query.
+const TESTNET_MINIMUM_RESPONDED_NODES: u32 = 1;
+
+/// Testnet minimum number of valid responses expected from a resolve query.
+const TESTNET_MINIMUM_VALID_RESPONSES: u32 = 1;
+
+/// Policy used to classify DHT query diagnostics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReportPolicy {
+    /// Minimum number of DHT nodes expected to acknowledge storing a published packet.
+    pub minimum_publish_stored_nodes: u32,
+    /// Minimum number of unique DHT nodes that should be queried.
+    pub minimum_queried_nodes: u32,
+    /// Minimum number of queried DHT nodes that should respond.
+    pub minimum_responded_nodes: u32,
+    /// Minimum number of responses with a valid mutable GET shape.
+    pub minimum_valid_responses: u32,
+    /// Whether invalid values or invalid response shapes should be reported as warnings.
+    pub report_invalid_responses: bool,
+    /// Whether KRPC error responses should be reported as warnings.
+    pub report_krpc_errors: bool,
+}
+
+impl ReportPolicy {
+    /// Create a policy with thresholds suitable for the public Mainline DHT.
+    pub fn mainnet() -> Self {
+        Self {
+            minimum_publish_stored_nodes: MINIMUM_PUBLISH_STORED_NODES,
+            minimum_queried_nodes: DEFAULT_MINIMUM_QUERIED_NODES,
+            minimum_responded_nodes: DEFAULT_MINIMUM_RESPONDED_NODES,
+            minimum_valid_responses: DEFAULT_MINIMUM_VALID_RESPONSES,
+            report_invalid_responses: true,
+            report_krpc_errors: true,
+        }
+    }
+
+    /// Create a policy with thresholds suitable for small local testnets.
+    pub fn testnet() -> Self {
+        Self {
+            minimum_publish_stored_nodes: TESTNET_MINIMUM_PUBLISH_STORED_NODES,
+            minimum_queried_nodes: TESTNET_MINIMUM_QUERIED_NODES,
+            minimum_responded_nodes: TESTNET_MINIMUM_RESPONDED_NODES,
+            minimum_valid_responses: TESTNET_MINIMUM_VALID_RESPONSES,
+            report_invalid_responses: true,
+            report_krpc_errors: true,
+        }
+    }
+
+    /// Classify warning diagnostics for a DHT publish query result.
+    pub fn classify_publish_result(&self, stored_at: u32) -> Vec<PublishWarning> {
+        if stored_at < self.minimum_publish_stored_nodes {
+            vec![PublishWarning::TooFewNodesStored {
+                stored_at,
+                minimum: self.minimum_publish_stored_nodes,
+            }]
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Classify warning diagnostics for a DHT resolve query.
+    pub fn classify_resolve_report(&self, report: &ResolveReport) -> Vec<ResolveWarning> {
+        let outcome = &report.outcome;
+        let invalid_signed_packet_count = report.invalid_signed_packet_count;
+
+        let mut warnings = Vec::new();
+        let responded = outcome.responded();
+        let valid_responses = outcome
+            .valid_responses()
+            .saturating_sub(invalid_signed_packet_count);
+
+        if outcome.queried < self.minimum_queried_nodes {
+            warnings.push(ResolveWarning::TooFewNodesQueried {
+                queried: outcome.queried,
+                minimum: self.minimum_queried_nodes,
+            });
+        }
+
+        if responded < self.minimum_responded_nodes {
+            warnings.push(ResolveWarning::TooFewNodesResponded {
+                responded,
+                minimum: self.minimum_responded_nodes,
+            });
+        }
+
+        if valid_responses < self.minimum_valid_responses {
+            warnings.push(ResolveWarning::TooFewValidResponses {
+                valid_responses,
+                minimum: self.minimum_valid_responses,
+            });
+        }
+
+        if self.report_invalid_responses
+            && (outcome.invalid_values > 0
+                || outcome.invalid_responses > 0
+                || invalid_signed_packet_count > 0)
+        {
+            warnings.push(ResolveWarning::InvalidResponses {
+                invalid_values: outcome.invalid_values,
+                invalid_responses: outcome.invalid_responses,
+                invalid_signed_packets: invalid_signed_packet_count,
+            });
+        }
+
+        if self.report_krpc_errors && outcome.krpc_errors > 0 {
+            warnings.push(ResolveWarning::KrpcErrors {
+                krpc_errors: outcome.krpc_errors,
+            });
+        }
+
+        warnings
+    }
+}
+
+/// Warning diagnostics found in a DHT publish query.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PublishWarning {
+    /// Fewer DHT nodes acknowledged storing the packet than expected.
+    TooFewNodesStored {
+        /// Number of DHT nodes that acknowledged storing the packet.
+        stored_at: u32,
+        /// Minimum number of storing nodes expected by the policy.
+        minimum: u32,
+    },
+}
+
+/// Warning diagnostics found in a DHT resolve query.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResolveWarning {
+    /// The query visited fewer unique DHT nodes than expected.
+    TooFewNodesQueried {
+        /// Number of unique DHT nodes queried.
+        queried: u32,
+        /// Minimum number of queried nodes expected by the policy.
+        minimum: u32,
+    },
+    /// The query received responses from fewer DHT nodes than expected.
+    TooFewNodesResponded {
+        /// Number of queried DHT nodes that responded.
+        responded: u32,
+        /// Minimum number of responses expected by the policy.
+        minimum: u32,
+    },
+    /// The query received fewer valid mutable GET responses than expected.
+    TooFewValidResponses {
+        /// Number of valid mutable GET responses.
+        valid_responses: u32,
+        /// Minimum number of valid responses expected by the policy.
+        minimum: u32,
+    },
+    /// The query received invalid values or invalid response shapes.
+    InvalidResponses {
+        /// Number of mutable value responses that failed validation.
+        invalid_values: u32,
+        /// Number of invalid response shapes returned.
+        invalid_responses: u32,
+        /// Number of mutable values that failed signed packet validation.
+        invalid_signed_packets: u32,
+    },
+    /// The query received KRPC error responses.
+    KrpcErrors {
+        /// Number of KRPC error responses returned.
+        krpc_errors: u32,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PublishWarning, ReportPolicy, MINIMUM_PUBLISH_STORED_NODES};
+
+    #[test]
+    fn mainnet_publish_policy_warns_when_too_few_nodes_store_packet() {
+        let policy = ReportPolicy::mainnet();
+
+        assert_eq!(
+            policy.classify_publish_result(MINIMUM_PUBLISH_STORED_NODES - 1),
+            vec![PublishWarning::TooFewNodesStored {
+                stored_at: MINIMUM_PUBLISH_STORED_NODES - 1,
+                minimum: MINIMUM_PUBLISH_STORED_NODES,
+            }]
+        );
+        assert!(policy
+            .classify_publish_result(MINIMUM_PUBLISH_STORED_NODES)
+            .is_empty());
+    }
+
+    #[test]
+    fn testnet_publish_policy_relaxes_stored_nodes_threshold() {
+        assert!(ReportPolicy::testnet()
+            .classify_publish_result(1)
+            .is_empty());
+    }
+}

--- a/pkarr/src/dht/report_policy.rs
+++ b/pkarr/src/dht/report_policy.rs
@@ -1,29 +1,5 @@
 use super::resolve_report::ResolveReport;
 
-/// Default minimum number of DHT nodes expected to acknowledge storing a published packet.
-const MINIMUM_PUBLISH_STORED_NODES: u32 = 10;
-
-/// Default minimum number of DHT nodes a resolve query should visit.
-const DEFAULT_MINIMUM_QUERIED_NODES: u32 = 20;
-
-/// Default minimum number of DHT nodes that should respond to a resolve query.
-const DEFAULT_MINIMUM_RESPONDED_NODES: u32 = 5;
-
-/// Default minimum number of usable responses expected from a resolve query.
-const DEFAULT_MINIMUM_USABLE_RESPONSES: u32 = 3;
-
-/// Testnet minimum number of DHT nodes expected to acknowledge storing a published packet.
-const TESTNET_MINIMUM_PUBLISH_STORED_NODES: u32 = 1;
-
-/// Testnet minimum number of DHT nodes a resolve query should visit.
-const TESTNET_MINIMUM_QUERIED_NODES: u32 = 1;
-
-/// Testnet minimum number of DHT nodes that should respond to a resolve query.
-const TESTNET_MINIMUM_RESPONDED_NODES: u32 = 1;
-
-/// Testnet minimum number of usable responses expected from a resolve query.
-const TESTNET_MINIMUM_USABLE_RESPONSES: u32 = 1;
-
 /// Policy used to classify DHT query diagnostics.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ReportPolicy {
@@ -50,28 +26,32 @@ pub struct ReportPolicy {
 }
 
 impl ReportPolicy {
+    const MAINNET: Self = Self {
+        minimum_publish_stored_nodes: 10,
+        minimum_queried_nodes: 20,
+        minimum_responded_nodes: 5,
+        minimum_usable_responses: 3,
+        report_malformed_responses: true,
+        report_krpc_errors: true,
+    };
+
+    const TESTNET: Self = Self {
+        minimum_publish_stored_nodes: 1,
+        minimum_queried_nodes: 1,
+        minimum_responded_nodes: 1,
+        minimum_usable_responses: 1,
+        report_malformed_responses: false,
+        report_krpc_errors: false,
+    };
+
     /// Create a policy with thresholds suitable for the public Mainline DHT.
     pub fn mainnet() -> Self {
-        Self {
-            minimum_publish_stored_nodes: MINIMUM_PUBLISH_STORED_NODES,
-            minimum_queried_nodes: DEFAULT_MINIMUM_QUERIED_NODES,
-            minimum_responded_nodes: DEFAULT_MINIMUM_RESPONDED_NODES,
-            minimum_usable_responses: DEFAULT_MINIMUM_USABLE_RESPONSES,
-            report_malformed_responses: true,
-            report_krpc_errors: true,
-        }
+        Self::MAINNET
     }
 
     /// Create a policy with thresholds suitable for small local testnets.
     pub fn testnet() -> Self {
-        Self {
-            minimum_publish_stored_nodes: TESTNET_MINIMUM_PUBLISH_STORED_NODES,
-            minimum_queried_nodes: TESTNET_MINIMUM_QUERIED_NODES,
-            minimum_responded_nodes: TESTNET_MINIMUM_RESPONDED_NODES,
-            minimum_usable_responses: TESTNET_MINIMUM_USABLE_RESPONSES,
-            report_malformed_responses: true,
-            report_krpc_errors: true,
-        }
+        Self::TESTNET
     }
 
     /// Classify warning diagnostics for a DHT publish query result.
@@ -199,9 +179,7 @@ pub enum ResolveWarning {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        PublishWarning, ReportPolicy, ResolveReport, ResolveWarning, MINIMUM_PUBLISH_STORED_NODES,
-    };
+    use super::{PublishWarning, ReportPolicy, ResolveReport, ResolveWarning};
 
     fn report(outcome: mainline::GetMutableOutcome) -> ResolveReport {
         ResolveReport::new(outcome)
@@ -214,17 +192,16 @@ mod tests {
     #[test]
     fn mainnet_publish_policy_warns_when_too_few_nodes_store_packet() {
         let policy = ReportPolicy::mainnet();
+        let minimum = policy.minimum_publish_stored_nodes;
 
         assert_eq!(
-            policy.classify_publish_result(MINIMUM_PUBLISH_STORED_NODES - 1),
+            policy.classify_publish_result(minimum - 1),
             vec![PublishWarning::TooFewNodesStored {
-                stored_at: MINIMUM_PUBLISH_STORED_NODES - 1,
-                minimum: MINIMUM_PUBLISH_STORED_NODES,
+                stored_at: minimum - 1,
+                minimum,
             }]
         );
-        assert!(policy
-            .classify_publish_result(MINIMUM_PUBLISH_STORED_NODES)
-            .is_empty());
+        assert!(policy.classify_publish_result(minimum).is_empty());
     }
 
     #[test]

--- a/pkarr/src/dht/resolve.rs
+++ b/pkarr/src/dht/resolve.rs
@@ -1,0 +1,383 @@
+use crate::SignedPacket;
+
+/// Successful immediate DHT resolve result.
+pub struct ResolveFound<F> {
+    /// First valid signed packet returned by the DHT query.
+    pub first: SignedPacket,
+    /// Future that drains the rest of the query and returns the most recent packet and report.
+    pub completion: F,
+}
+
+/// Default minimum number of DHT nodes a resolve query should visit.
+const DEFAULT_MINIMUM_QUERIED_NODES: u32 = 20;
+
+/// Default minimum number of DHT nodes that should respond to a resolve query.
+const DEFAULT_MINIMUM_RESPONDED_NODES: u32 = 3;
+
+/// Default minimum number of valid responses expected from a resolve query.
+const DEFAULT_MINIMUM_VALID_RESPONSES: u32 = 1;
+
+/// Policy used to classify DHT resolve query diagnostics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ResolveReportPolicy {
+    /// Minimum number of unique DHT nodes that should be queried.
+    minimum_queried_nodes: u32,
+    /// Minimum number of queried DHT nodes that should respond.
+    minimum_responded_nodes: u32,
+    /// Minimum number of responses with a valid mutable GET shape.
+    minimum_valid_responses: u32,
+    /// Whether invalid values or invalid response shapes should be reported as suspicious.
+    flag_invalid_responses: bool,
+    /// Whether KRPC error responses should be reported as suspicious.
+    flag_krpc_errors: bool,
+}
+
+impl Default for ResolveReportPolicy {
+    fn default() -> Self {
+        Self {
+            minimum_queried_nodes: DEFAULT_MINIMUM_QUERIED_NODES,
+            minimum_responded_nodes: DEFAULT_MINIMUM_RESPONDED_NODES,
+            minimum_valid_responses: DEFAULT_MINIMUM_VALID_RESPONSES,
+            flag_invalid_responses: true,
+            flag_krpc_errors: true,
+        }
+    }
+}
+
+impl ResolveReportPolicy {
+    /// Classify a raw Mainline mutable GET outcome with invalid signed packet diagnostics.
+    fn classify_with_invalid_signed_packets(
+        &self,
+        outcome: mainline::GetMutableOutcome,
+        invalid_signed_packet_count: u32,
+    ) -> ResolveReport {
+        ResolveReport {
+            suspicions: self.suspicions(&outcome, invalid_signed_packet_count),
+            outcome,
+            invalid_signed_packet_count,
+        }
+    }
+
+    fn suspicions(
+        &self,
+        outcome: &mainline::GetMutableOutcome,
+        invalid_signed_packet_count: u32,
+    ) -> Vec<ResolveSuspicion> {
+        let mut suspicions = Vec::new();
+        let responded = outcome.responded();
+        let valid_responses = outcome
+            .valid_responses()
+            .saturating_sub(invalid_signed_packet_count);
+
+        if outcome.queried < self.minimum_queried_nodes {
+            suspicions.push(ResolveSuspicion::TooFewNodesQueried {
+                queried: outcome.queried,
+                minimum: self.minimum_queried_nodes,
+            });
+        }
+
+        if responded < self.minimum_responded_nodes {
+            suspicions.push(ResolveSuspicion::TooFewNodesResponded {
+                responded,
+                minimum: self.minimum_responded_nodes,
+            });
+        }
+
+        if valid_responses < self.minimum_valid_responses {
+            suspicions.push(ResolveSuspicion::TooFewValidResponses {
+                valid_responses,
+                minimum: self.minimum_valid_responses,
+            });
+        }
+
+        if self.flag_invalid_responses
+            && (outcome.invalid_values > 0
+                || outcome.invalid_responses > 0
+                || invalid_signed_packet_count > 0)
+        {
+            suspicions.push(ResolveSuspicion::InvalidResponses {
+                invalid_values: outcome.invalid_values,
+                invalid_responses: outcome.invalid_responses,
+                invalid_signed_packets: invalid_signed_packet_count,
+            });
+        }
+
+        if self.flag_krpc_errors && outcome.krpc_errors > 0 {
+            suspicions.push(ResolveSuspicion::KrpcErrors {
+                krpc_errors: outcome.krpc_errors,
+            });
+        }
+
+        suspicions
+    }
+}
+
+/// Classified diagnostics for a DHT resolve query.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolveReport {
+    outcome: mainline::GetMutableOutcome,
+    invalid_signed_packet_count: u32,
+    suspicions: Vec<ResolveSuspicion>,
+}
+
+impl ResolveReport {
+    /// Classify a raw Mainline mutable GET outcome with invalid signed packet diagnostics.
+    pub(crate) fn with_invalid_signed_packets(
+        outcome: mainline::GetMutableOutcome,
+        invalid_signed_packet_count: u32,
+    ) -> Self {
+        ResolveReportPolicy::default()
+            .classify_with_invalid_signed_packets(outcome, invalid_signed_packet_count)
+    }
+
+    /// Returns true when the resolve query had suspicious diagnostics.
+    pub fn is_suspicious(&self) -> bool {
+        !self.suspicions.is_empty()
+    }
+
+    /// Number of unique DHT nodes queried.
+    pub fn queried(&self) -> u32 {
+        self.outcome.queried
+    }
+
+    /// Number of nodes that returned a GET response before timing out.
+    pub fn responded(&self) -> u32 {
+        self.outcome.responded()
+    }
+
+    /// Number of valid responses after deducting invalid signed packets.
+    pub fn valid_responses(&self) -> u32 {
+        self.outcome
+            .valid_responses()
+            .saturating_sub(self.invalid_signed_packet_count)
+    }
+
+    /// Suspicious diagnostics found for this resolve query.
+    pub fn suspicions(&self) -> &[ResolveSuspicion] {
+        &self.suspicions
+    }
+}
+
+/// Suspicious diagnostics found in a DHT resolve query.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResolveSuspicion {
+    /// The query visited fewer unique DHT nodes than expected.
+    TooFewNodesQueried {
+        /// Number of unique DHT nodes queried.
+        queried: u32,
+        /// Minimum number of queried nodes expected by the policy.
+        minimum: u32,
+    },
+    /// The query received responses from fewer DHT nodes than expected.
+    TooFewNodesResponded {
+        /// Number of queried DHT nodes that responded.
+        responded: u32,
+        /// Minimum number of responses expected by the policy.
+        minimum: u32,
+    },
+    /// The query received fewer valid mutable GET responses than expected.
+    TooFewValidResponses {
+        /// Number of valid mutable GET responses.
+        valid_responses: u32,
+        /// Minimum number of valid responses expected by the policy.
+        minimum: u32,
+    },
+    /// The query received invalid values or invalid response shapes.
+    InvalidResponses {
+        /// Number of mutable value responses that failed validation.
+        invalid_values: u32,
+        /// Number of invalid response shapes returned.
+        invalid_responses: u32,
+        /// Number of mutable values that failed signed packet validation.
+        invalid_signed_packets: u32,
+    },
+    /// The query received KRPC error responses.
+    KrpcErrors {
+        /// Number of KRPC error responses returned.
+        krpc_errors: u32,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn healthy_outcome_is_ok() {
+        let report = ResolveReport::with_invalid_signed_packets(
+            mainline::GetMutableOutcome {
+                queried: 20,
+                values: 1,
+                no_values: 2,
+                no_more_recent: 0,
+                invalid_values: 0,
+                invalid_responses: 0,
+                krpc_errors: 0,
+            },
+            0,
+        );
+
+        assert!(!report.is_suspicious());
+        assert!(report.suspicions().is_empty());
+    }
+
+    #[test]
+    fn sparse_outcome_is_suspicious() {
+        let report = ResolveReport::with_invalid_signed_packets(
+            mainline::GetMutableOutcome {
+                queried: 2,
+                values: 0,
+                no_values: 0,
+                no_more_recent: 0,
+                invalid_values: 0,
+                invalid_responses: 0,
+                krpc_errors: 0,
+            },
+            0,
+        );
+
+        assert!(report.is_suspicious());
+        assert_eq!(
+            report.suspicions(),
+            &[
+                ResolveSuspicion::TooFewNodesQueried {
+                    queried: 2,
+                    minimum: DEFAULT_MINIMUM_QUERIED_NODES,
+                },
+                ResolveSuspicion::TooFewNodesResponded {
+                    responded: 0,
+                    minimum: DEFAULT_MINIMUM_RESPONDED_NODES,
+                },
+                ResolveSuspicion::TooFewValidResponses {
+                    valid_responses: 0,
+                    minimum: DEFAULT_MINIMUM_VALID_RESPONSES,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_and_error_responses_are_suspicious() {
+        let report = ResolveReport::with_invalid_signed_packets(
+            mainline::GetMutableOutcome {
+                queried: 20,
+                values: 1,
+                no_values: 2,
+                no_more_recent: 0,
+                invalid_values: 1,
+                invalid_responses: 1,
+                krpc_errors: 1,
+            },
+            0,
+        );
+
+        assert!(report.is_suspicious());
+        assert_eq!(
+            report.suspicions(),
+            &[
+                ResolveSuspicion::InvalidResponses {
+                    invalid_values: 1,
+                    invalid_responses: 1,
+                    invalid_signed_packets: 0,
+                },
+                ResolveSuspicion::KrpcErrors { krpc_errors: 1 },
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_signed_packets_are_suspicious() {
+        let report = ResolveReport::with_invalid_signed_packets(
+            mainline::GetMutableOutcome {
+                queried: 20,
+                values: 3,
+                no_values: 2,
+                no_more_recent: 0,
+                invalid_values: 0,
+                invalid_responses: 0,
+                krpc_errors: 0,
+            },
+            2,
+        );
+
+        assert!(report.is_suspicious());
+        assert_eq!(
+            report.suspicions(),
+            &[ResolveSuspicion::InvalidResponses {
+                invalid_values: 0,
+                invalid_responses: 0,
+                invalid_signed_packets: 2,
+            }]
+        );
+    }
+
+    #[test]
+    fn invalid_signed_packets_are_deducted_from_valid_responses() {
+        let report = ResolveReport::with_invalid_signed_packets(
+            mainline::GetMutableOutcome {
+                queried: 20,
+                values: 3,
+                no_values: 0,
+                no_more_recent: 0,
+                invalid_values: 0,
+                invalid_responses: 0,
+                krpc_errors: 0,
+            },
+            3,
+        );
+
+        assert!(report.is_suspicious());
+        assert_eq!(report.valid_responses(), 0);
+        assert_eq!(
+            report.suspicions(),
+            &[
+                ResolveSuspicion::TooFewValidResponses {
+                    valid_responses: 0,
+                    minimum: DEFAULT_MINIMUM_VALID_RESPONSES,
+                },
+                ResolveSuspicion::InvalidResponses {
+                    invalid_values: 0,
+                    invalid_responses: 0,
+                    invalid_signed_packets: 3,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_signed_packet_deduction_saturates_valid_responses() {
+        let report = ResolveReport::with_invalid_signed_packets(
+            mainline::GetMutableOutcome {
+                queried: 20,
+                values: 1,
+                no_values: 0,
+                no_more_recent: 0,
+                invalid_values: 0,
+                invalid_responses: 0,
+                krpc_errors: 0,
+            },
+            2,
+        );
+
+        assert_eq!(report.valid_responses(), 0);
+        assert_eq!(
+            report.suspicions(),
+            &[
+                ResolveSuspicion::TooFewNodesResponded {
+                    responded: 1,
+                    minimum: DEFAULT_MINIMUM_RESPONDED_NODES,
+                },
+                ResolveSuspicion::TooFewValidResponses {
+                    valid_responses: 0,
+                    minimum: DEFAULT_MINIMUM_VALID_RESPONSES,
+                },
+                ResolveSuspicion::InvalidResponses {
+                    invalid_values: 0,
+                    invalid_responses: 0,
+                    invalid_signed_packets: 2,
+                },
+            ]
+        );
+    }
+}

--- a/pkarr/src/dht/resolve_report.rs
+++ b/pkarr/src/dht/resolve_report.rs
@@ -1,270 +1,31 @@
 /// Diagnostics for a DHT resolve query.
+///
+/// This wraps Mainline's raw mutable GET outcome so pkarr can expose stable
+/// diagnostics without exposing the Mainline type directly.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ResolveReport {
-    pub(super) outcome: mainline::GetMutableOutcome,
-    pub(super) invalid_signed_packet_count: u32,
-}
+pub struct ResolveReport(pub(super) mainline::GetMutableOutcome);
 
 impl ResolveReport {
-    /// Build a report from a raw Mainline mutable GET outcome with invalid signed packet diagnostics.
-    pub(crate) fn with_invalid_signed_packets(
-        outcome: mainline::GetMutableOutcome,
-        invalid_signed_packet_count: u32,
-    ) -> Self {
-        Self {
-            outcome,
-            invalid_signed_packet_count,
-        }
+    /// Build a report from a raw Mainline mutable GET outcome.
+    pub(crate) fn new(outcome: mainline::GetMutableOutcome) -> Self {
+        Self(outcome)
     }
 
     /// Number of unique DHT nodes queried.
     pub fn queried(&self) -> u32 {
-        self.outcome.queried
+        self.0.queried
     }
 
     /// Number of nodes that returned a GET response before timing out.
+    ///
+    /// This includes malformed responses and KRPC error responses; use
+    /// `ReportPolicy` to classify those counters into warnings.
     pub fn responded(&self) -> u32 {
-        self.outcome.responded()
+        self.0.responded()
     }
 
-    /// Number of valid responses after deducting invalid signed packets.
-    pub fn valid_responses(&self) -> u32 {
-        self.outcome
-            .valid_responses()
-            .saturating_sub(self.invalid_signed_packet_count)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::super::report_policy::{ReportPolicy, ResolveWarning};
-    use super::*;
-
-    fn classify(report: &ResolveReport) -> Vec<ResolveWarning> {
-        ReportPolicy::mainnet().classify_resolve_report(report)
-    }
-
-    #[test]
-    fn healthy_outcome_is_ok() {
-        let report = ResolveReport::with_invalid_signed_packets(
-            mainline::GetMutableOutcome {
-                queried: 20,
-                values: 1,
-                no_values: 2,
-                no_more_recent: 0,
-                invalid_values: 0,
-                invalid_responses: 0,
-                krpc_errors: 0,
-            },
-            0,
-        );
-
-        assert!(classify(&report).is_empty());
-    }
-
-    #[test]
-    fn sparse_outcome_produces_warnings() {
-        let report = ResolveReport::with_invalid_signed_packets(
-            mainline::GetMutableOutcome {
-                queried: 2,
-                values: 0,
-                no_values: 0,
-                no_more_recent: 0,
-                invalid_values: 0,
-                invalid_responses: 0,
-                krpc_errors: 0,
-            },
-            0,
-        );
-
-        let policy = ReportPolicy::mainnet();
-        assert_eq!(
-            classify(&report),
-            vec![
-                ResolveWarning::TooFewNodesQueried {
-                    queried: 2,
-                    minimum: policy.minimum_queried_nodes,
-                },
-                ResolveWarning::TooFewNodesResponded {
-                    responded: 0,
-                    minimum: policy.minimum_responded_nodes,
-                },
-                ResolveWarning::TooFewValidResponses {
-                    valid_responses: 0,
-                    minimum: policy.minimum_valid_responses,
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn invalid_and_error_responses_produce_warnings() {
-        let report = ResolveReport::with_invalid_signed_packets(
-            mainline::GetMutableOutcome {
-                queried: 20,
-                values: 1,
-                no_values: 2,
-                no_more_recent: 0,
-                invalid_values: 1,
-                invalid_responses: 1,
-                krpc_errors: 1,
-            },
-            0,
-        );
-
-        assert_eq!(
-            classify(&report),
-            vec![
-                ResolveWarning::InvalidResponses {
-                    invalid_values: 1,
-                    invalid_responses: 1,
-                    invalid_signed_packets: 0,
-                },
-                ResolveWarning::KrpcErrors { krpc_errors: 1 },
-            ]
-        );
-    }
-
-    #[test]
-    fn invalid_signed_packets_produce_warnings() {
-        let report = ResolveReport::with_invalid_signed_packets(
-            mainline::GetMutableOutcome {
-                queried: 20,
-                values: 3,
-                no_values: 2,
-                no_more_recent: 0,
-                invalid_values: 0,
-                invalid_responses: 0,
-                krpc_errors: 0,
-            },
-            2,
-        );
-
-        assert_eq!(
-            classify(&report),
-            vec![ResolveWarning::InvalidResponses {
-                invalid_values: 0,
-                invalid_responses: 0,
-                invalid_signed_packets: 2,
-            }]
-        );
-    }
-
-    #[test]
-    fn invalid_signed_packets_are_deducted_from_valid_responses() {
-        let report = ResolveReport::with_invalid_signed_packets(
-            mainline::GetMutableOutcome {
-                queried: 20,
-                values: 3,
-                no_values: 0,
-                no_more_recent: 0,
-                invalid_values: 0,
-                invalid_responses: 0,
-                krpc_errors: 0,
-            },
-            3,
-        );
-
-        assert_eq!(report.valid_responses(), 0);
-        let policy = ReportPolicy::mainnet();
-        assert_eq!(
-            classify(&report),
-            vec![
-                ResolveWarning::TooFewValidResponses {
-                    valid_responses: 0,
-                    minimum: policy.minimum_valid_responses,
-                },
-                ResolveWarning::InvalidResponses {
-                    invalid_values: 0,
-                    invalid_responses: 0,
-                    invalid_signed_packets: 3,
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn invalid_signed_packet_deduction_saturates_valid_responses() {
-        let report = ResolveReport::with_invalid_signed_packets(
-            mainline::GetMutableOutcome {
-                queried: 20,
-                values: 1,
-                no_values: 0,
-                no_more_recent: 0,
-                invalid_values: 0,
-                invalid_responses: 0,
-                krpc_errors: 0,
-            },
-            2,
-        );
-
-        assert_eq!(report.valid_responses(), 0);
-        let policy = ReportPolicy::mainnet();
-        assert_eq!(
-            classify(&report),
-            vec![
-                ResolveWarning::TooFewNodesResponded {
-                    responded: 1,
-                    minimum: policy.minimum_responded_nodes,
-                },
-                ResolveWarning::TooFewValidResponses {
-                    valid_responses: 0,
-                    minimum: policy.minimum_valid_responses,
-                },
-                ResolveWarning::InvalidResponses {
-                    invalid_values: 0,
-                    invalid_responses: 0,
-                    invalid_signed_packets: 2,
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn testnet_policy_relaxes_topology_thresholds() {
-        let report = ResolveReport::with_invalid_signed_packets(
-            mainline::GetMutableOutcome {
-                queried: 2,
-                values: 0,
-                no_values: 1,
-                no_more_recent: 0,
-                invalid_values: 0,
-                invalid_responses: 0,
-                krpc_errors: 0,
-            },
-            0,
-        );
-
-        assert!(ReportPolicy::testnet()
-            .classify_resolve_report(&report)
-            .is_empty());
-    }
-
-    #[test]
-    fn custom_policy_controls_warning_thresholds() {
-        let report = ResolveReport::with_invalid_signed_packets(
-            mainline::GetMutableOutcome {
-                queried: 2,
-                values: 0,
-                no_values: 1,
-                no_more_recent: 0,
-                invalid_values: 1,
-                invalid_responses: 0,
-                krpc_errors: 1,
-            },
-            0,
-        );
-
-        let warnings = ReportPolicy {
-            minimum_publish_stored_nodes: 1,
-            minimum_queried_nodes: 2,
-            minimum_responded_nodes: 1,
-            minimum_valid_responses: 1,
-            report_invalid_responses: false,
-            report_krpc_errors: false,
-        }
-        .classify_resolve_report(&report);
-
-        assert!(warnings.is_empty());
+    /// Number of usable responses.
+    pub fn usable_responses(&self) -> u32 {
+        self.0.valid_responses()
     }
 }

--- a/pkarr/src/dht/resolve_report.rs
+++ b/pkarr/src/dht/resolve_report.rs
@@ -1,13 +1,3 @@
-use crate::SignedPacket;
-
-/// Successful immediate DHT resolve result.
-pub struct ResolveFound<F> {
-    /// First valid signed packet returned by the DHT query.
-    pub first: SignedPacket,
-    /// Future that drains the rest of the query and returns the most recent packet and report.
-    pub completion: F,
-}
-
 /// Default minimum number of DHT nodes a resolve query should visit.
 const DEFAULT_MINIMUM_QUERIED_NODES: u32 = 20;
 
@@ -17,19 +7,28 @@ const DEFAULT_MINIMUM_RESPONDED_NODES: u32 = 3;
 /// Default minimum number of valid responses expected from a resolve query.
 const DEFAULT_MINIMUM_VALID_RESPONSES: u32 = 1;
 
+/// Testnet minimum number of DHT nodes a resolve query should visit.
+const TESTNET_MINIMUM_QUERIED_NODES: u32 = 2;
+
+/// Testnet minimum number of DHT nodes that should respond to a resolve query.
+const TESTNET_MINIMUM_RESPONDED_NODES: u32 = 1;
+
+/// Testnet minimum number of valid responses expected from a resolve query.
+const TESTNET_MINIMUM_VALID_RESPONSES: u32 = 1;
+
 /// Policy used to classify DHT resolve query diagnostics.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct ResolveReportPolicy {
+pub struct ResolveReportPolicy {
     /// Minimum number of unique DHT nodes that should be queried.
-    minimum_queried_nodes: u32,
+    pub minimum_queried_nodes: u32,
     /// Minimum number of queried DHT nodes that should respond.
-    minimum_responded_nodes: u32,
+    pub minimum_responded_nodes: u32,
     /// Minimum number of responses with a valid mutable GET shape.
-    minimum_valid_responses: u32,
-    /// Whether invalid values or invalid response shapes should be reported as suspicious.
-    flag_invalid_responses: bool,
-    /// Whether KRPC error responses should be reported as suspicious.
-    flag_krpc_errors: bool,
+    pub minimum_valid_responses: u32,
+    /// Whether invalid values or invalid response shapes should be reported as warnings.
+    pub warn_on_invalid_responses: bool,
+    /// Whether KRPC error responses should be reported as warnings.
+    pub warn_on_krpc_errors: bool,
 }
 
 impl Default for ResolveReportPolicy {
@@ -38,101 +37,95 @@ impl Default for ResolveReportPolicy {
             minimum_queried_nodes: DEFAULT_MINIMUM_QUERIED_NODES,
             minimum_responded_nodes: DEFAULT_MINIMUM_RESPONDED_NODES,
             minimum_valid_responses: DEFAULT_MINIMUM_VALID_RESPONSES,
-            flag_invalid_responses: true,
-            flag_krpc_errors: true,
+            warn_on_invalid_responses: true,
+            warn_on_krpc_errors: true,
         }
     }
 }
 
 impl ResolveReportPolicy {
-    /// Classify a raw Mainline mutable GET outcome with invalid signed packet diagnostics.
-    fn classify_with_invalid_signed_packets(
-        &self,
-        outcome: mainline::GetMutableOutcome,
-        invalid_signed_packet_count: u32,
-    ) -> ResolveReport {
-        ResolveReport {
-            suspicions: self.suspicions(&outcome, invalid_signed_packet_count),
-            outcome,
-            invalid_signed_packet_count,
+    /// Create a policy with thresholds suitable for small local testnets.
+    pub fn testnet() -> Self {
+        Self {
+            minimum_queried_nodes: TESTNET_MINIMUM_QUERIED_NODES,
+            minimum_responded_nodes: TESTNET_MINIMUM_RESPONDED_NODES,
+            minimum_valid_responses: TESTNET_MINIMUM_VALID_RESPONSES,
+            warn_on_invalid_responses: true,
+            warn_on_krpc_errors: true,
         }
     }
 
-    fn suspicions(
+    fn classify(
         &self,
         outcome: &mainline::GetMutableOutcome,
         invalid_signed_packet_count: u32,
-    ) -> Vec<ResolveSuspicion> {
-        let mut suspicions = Vec::new();
+    ) -> Vec<ResolveWarning> {
+        let mut warnings = Vec::new();
         let responded = outcome.responded();
         let valid_responses = outcome
             .valid_responses()
             .saturating_sub(invalid_signed_packet_count);
 
         if outcome.queried < self.minimum_queried_nodes {
-            suspicions.push(ResolveSuspicion::TooFewNodesQueried {
+            warnings.push(ResolveWarning::TooFewNodesQueried {
                 queried: outcome.queried,
                 minimum: self.minimum_queried_nodes,
             });
         }
 
         if responded < self.minimum_responded_nodes {
-            suspicions.push(ResolveSuspicion::TooFewNodesResponded {
+            warnings.push(ResolveWarning::TooFewNodesResponded {
                 responded,
                 minimum: self.minimum_responded_nodes,
             });
         }
 
         if valid_responses < self.minimum_valid_responses {
-            suspicions.push(ResolveSuspicion::TooFewValidResponses {
+            warnings.push(ResolveWarning::TooFewValidResponses {
                 valid_responses,
                 minimum: self.minimum_valid_responses,
             });
         }
 
-        if self.flag_invalid_responses
+        if self.warn_on_invalid_responses
             && (outcome.invalid_values > 0
                 || outcome.invalid_responses > 0
                 || invalid_signed_packet_count > 0)
         {
-            suspicions.push(ResolveSuspicion::InvalidResponses {
+            warnings.push(ResolveWarning::InvalidResponses {
                 invalid_values: outcome.invalid_values,
                 invalid_responses: outcome.invalid_responses,
                 invalid_signed_packets: invalid_signed_packet_count,
             });
         }
 
-        if self.flag_krpc_errors && outcome.krpc_errors > 0 {
-            suspicions.push(ResolveSuspicion::KrpcErrors {
+        if self.warn_on_krpc_errors && outcome.krpc_errors > 0 {
+            warnings.push(ResolveWarning::KrpcErrors {
                 krpc_errors: outcome.krpc_errors,
             });
         }
 
-        suspicions
+        warnings
     }
 }
 
-/// Classified diagnostics for a DHT resolve query.
+/// Diagnostics for a DHT resolve query.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolveReport {
     outcome: mainline::GetMutableOutcome,
     invalid_signed_packet_count: u32,
-    suspicions: Vec<ResolveSuspicion>,
 }
 
 impl ResolveReport {
-    /// Classify a raw Mainline mutable GET outcome with invalid signed packet diagnostics.
+    /// Build a report from a raw Mainline mutable GET outcome with invalid signed packet diagnostics.
     pub(crate) fn with_invalid_signed_packets(
         outcome: mainline::GetMutableOutcome,
         invalid_signed_packet_count: u32,
     ) -> Self {
-        ResolveReportPolicy::default()
-            .classify_with_invalid_signed_packets(outcome, invalid_signed_packet_count)
-    }
-
-    /// Returns true when the resolve query had suspicious diagnostics.
-    pub fn is_suspicious(&self) -> bool {
-        !self.suspicions.is_empty()
+        Self {
+            outcome,
+            invalid_signed_packet_count,
+        }
     }
 
     /// Number of unique DHT nodes queried.
@@ -152,16 +145,16 @@ impl ResolveReport {
             .saturating_sub(self.invalid_signed_packet_count)
     }
 
-    /// Suspicious diagnostics found for this resolve query.
-    pub fn suspicions(&self) -> &[ResolveSuspicion] {
-        &self.suspicions
+    /// Classify warning diagnostics for this resolve query using the given policy.
+    pub fn classify_warnings(&self, policy: ResolveReportPolicy) -> Vec<ResolveWarning> {
+        policy.classify(&self.outcome, self.invalid_signed_packet_count)
     }
 }
 
-/// Suspicious diagnostics found in a DHT resolve query.
+/// Warning diagnostics found in a DHT resolve query.
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ResolveSuspicion {
+pub enum ResolveWarning {
     /// The query visited fewer unique DHT nodes than expected.
     TooFewNodesQueried {
         /// Number of unique DHT nodes queried.
@@ -203,6 +196,10 @@ pub enum ResolveSuspicion {
 mod tests {
     use super::*;
 
+    fn classify(report: &ResolveReport) -> Vec<ResolveWarning> {
+        report.classify_warnings(ResolveReportPolicy::default())
+    }
+
     #[test]
     fn healthy_outcome_is_ok() {
         let report = ResolveReport::with_invalid_signed_packets(
@@ -218,12 +215,11 @@ mod tests {
             0,
         );
 
-        assert!(!report.is_suspicious());
-        assert!(report.suspicions().is_empty());
+        assert!(classify(&report).is_empty());
     }
 
     #[test]
-    fn sparse_outcome_is_suspicious() {
+    fn sparse_outcome_produces_warnings() {
         let report = ResolveReport::with_invalid_signed_packets(
             mainline::GetMutableOutcome {
                 queried: 2,
@@ -237,19 +233,18 @@ mod tests {
             0,
         );
 
-        assert!(report.is_suspicious());
         assert_eq!(
-            report.suspicions(),
-            &[
-                ResolveSuspicion::TooFewNodesQueried {
+            classify(&report),
+            vec![
+                ResolveWarning::TooFewNodesQueried {
                     queried: 2,
                     minimum: DEFAULT_MINIMUM_QUERIED_NODES,
                 },
-                ResolveSuspicion::TooFewNodesResponded {
+                ResolveWarning::TooFewNodesResponded {
                     responded: 0,
                     minimum: DEFAULT_MINIMUM_RESPONDED_NODES,
                 },
-                ResolveSuspicion::TooFewValidResponses {
+                ResolveWarning::TooFewValidResponses {
                     valid_responses: 0,
                     minimum: DEFAULT_MINIMUM_VALID_RESPONSES,
                 },
@@ -258,7 +253,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_and_error_responses_are_suspicious() {
+    fn invalid_and_error_responses_produce_warnings() {
         let report = ResolveReport::with_invalid_signed_packets(
             mainline::GetMutableOutcome {
                 queried: 20,
@@ -272,22 +267,21 @@ mod tests {
             0,
         );
 
-        assert!(report.is_suspicious());
         assert_eq!(
-            report.suspicions(),
-            &[
-                ResolveSuspicion::InvalidResponses {
+            classify(&report),
+            vec![
+                ResolveWarning::InvalidResponses {
                     invalid_values: 1,
                     invalid_responses: 1,
                     invalid_signed_packets: 0,
                 },
-                ResolveSuspicion::KrpcErrors { krpc_errors: 1 },
+                ResolveWarning::KrpcErrors { krpc_errors: 1 },
             ]
         );
     }
 
     #[test]
-    fn invalid_signed_packets_are_suspicious() {
+    fn invalid_signed_packets_produce_warnings() {
         let report = ResolveReport::with_invalid_signed_packets(
             mainline::GetMutableOutcome {
                 queried: 20,
@@ -301,10 +295,9 @@ mod tests {
             2,
         );
 
-        assert!(report.is_suspicious());
         assert_eq!(
-            report.suspicions(),
-            &[ResolveSuspicion::InvalidResponses {
+            classify(&report),
+            vec![ResolveWarning::InvalidResponses {
                 invalid_values: 0,
                 invalid_responses: 0,
                 invalid_signed_packets: 2,
@@ -327,16 +320,15 @@ mod tests {
             3,
         );
 
-        assert!(report.is_suspicious());
         assert_eq!(report.valid_responses(), 0);
         assert_eq!(
-            report.suspicions(),
-            &[
-                ResolveSuspicion::TooFewValidResponses {
+            classify(&report),
+            vec![
+                ResolveWarning::TooFewValidResponses {
                     valid_responses: 0,
                     minimum: DEFAULT_MINIMUM_VALID_RESPONSES,
                 },
-                ResolveSuspicion::InvalidResponses {
+                ResolveWarning::InvalidResponses {
                     invalid_values: 0,
                     invalid_responses: 0,
                     invalid_signed_packets: 3,
@@ -362,22 +354,68 @@ mod tests {
 
         assert_eq!(report.valid_responses(), 0);
         assert_eq!(
-            report.suspicions(),
-            &[
-                ResolveSuspicion::TooFewNodesResponded {
+            classify(&report),
+            vec![
+                ResolveWarning::TooFewNodesResponded {
                     responded: 1,
                     minimum: DEFAULT_MINIMUM_RESPONDED_NODES,
                 },
-                ResolveSuspicion::TooFewValidResponses {
+                ResolveWarning::TooFewValidResponses {
                     valid_responses: 0,
                     minimum: DEFAULT_MINIMUM_VALID_RESPONSES,
                 },
-                ResolveSuspicion::InvalidResponses {
+                ResolveWarning::InvalidResponses {
                     invalid_values: 0,
                     invalid_responses: 0,
                     invalid_signed_packets: 2,
                 },
             ]
         );
+    }
+
+    #[test]
+    fn testnet_policy_relaxes_topology_thresholds() {
+        let report = ResolveReport::with_invalid_signed_packets(
+            mainline::GetMutableOutcome {
+                queried: 2,
+                values: 0,
+                no_values: 1,
+                no_more_recent: 0,
+                invalid_values: 0,
+                invalid_responses: 0,
+                krpc_errors: 0,
+            },
+            0,
+        );
+
+        assert!(report
+            .classify_warnings(ResolveReportPolicy::testnet())
+            .is_empty());
+    }
+
+    #[test]
+    fn custom_policy_controls_warning_thresholds() {
+        let report = ResolveReport::with_invalid_signed_packets(
+            mainline::GetMutableOutcome {
+                queried: 2,
+                values: 0,
+                no_values: 1,
+                no_more_recent: 0,
+                invalid_values: 1,
+                invalid_responses: 0,
+                krpc_errors: 1,
+            },
+            0,
+        );
+
+        let warnings = report.classify_warnings(ResolveReportPolicy {
+            minimum_queried_nodes: 2,
+            minimum_responded_nodes: 1,
+            minimum_valid_responses: 1,
+            warn_on_invalid_responses: false,
+            warn_on_krpc_errors: false,
+        });
+
+        assert!(warnings.is_empty());
     }
 }

--- a/pkarr/src/dht/resolve_report.rs
+++ b/pkarr/src/dht/resolve_report.rs
@@ -1,119 +1,8 @@
-/// Default minimum number of DHT nodes a resolve query should visit.
-const DEFAULT_MINIMUM_QUERIED_NODES: u32 = 20;
-
-/// Default minimum number of DHT nodes that should respond to a resolve query.
-const DEFAULT_MINIMUM_RESPONDED_NODES: u32 = 3;
-
-/// Default minimum number of valid responses expected from a resolve query.
-const DEFAULT_MINIMUM_VALID_RESPONSES: u32 = 1;
-
-/// Testnet minimum number of DHT nodes a resolve query should visit.
-const TESTNET_MINIMUM_QUERIED_NODES: u32 = 2;
-
-/// Testnet minimum number of DHT nodes that should respond to a resolve query.
-const TESTNET_MINIMUM_RESPONDED_NODES: u32 = 1;
-
-/// Testnet minimum number of valid responses expected from a resolve query.
-const TESTNET_MINIMUM_VALID_RESPONSES: u32 = 1;
-
-/// Policy used to classify DHT resolve query diagnostics.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ResolveReportPolicy {
-    /// Minimum number of unique DHT nodes that should be queried.
-    pub minimum_queried_nodes: u32,
-    /// Minimum number of queried DHT nodes that should respond.
-    pub minimum_responded_nodes: u32,
-    /// Minimum number of responses with a valid mutable GET shape.
-    pub minimum_valid_responses: u32,
-    /// Whether invalid values or invalid response shapes should be reported as warnings.
-    pub warn_on_invalid_responses: bool,
-    /// Whether KRPC error responses should be reported as warnings.
-    pub warn_on_krpc_errors: bool,
-}
-
-impl Default for ResolveReportPolicy {
-    fn default() -> Self {
-        Self {
-            minimum_queried_nodes: DEFAULT_MINIMUM_QUERIED_NODES,
-            minimum_responded_nodes: DEFAULT_MINIMUM_RESPONDED_NODES,
-            minimum_valid_responses: DEFAULT_MINIMUM_VALID_RESPONSES,
-            warn_on_invalid_responses: true,
-            warn_on_krpc_errors: true,
-        }
-    }
-}
-
-impl ResolveReportPolicy {
-    /// Create a policy with thresholds suitable for small local testnets.
-    pub fn testnet() -> Self {
-        Self {
-            minimum_queried_nodes: TESTNET_MINIMUM_QUERIED_NODES,
-            minimum_responded_nodes: TESTNET_MINIMUM_RESPONDED_NODES,
-            minimum_valid_responses: TESTNET_MINIMUM_VALID_RESPONSES,
-            warn_on_invalid_responses: true,
-            warn_on_krpc_errors: true,
-        }
-    }
-
-    fn classify(
-        &self,
-        outcome: &mainline::GetMutableOutcome,
-        invalid_signed_packet_count: u32,
-    ) -> Vec<ResolveWarning> {
-        let mut warnings = Vec::new();
-        let responded = outcome.responded();
-        let valid_responses = outcome
-            .valid_responses()
-            .saturating_sub(invalid_signed_packet_count);
-
-        if outcome.queried < self.minimum_queried_nodes {
-            warnings.push(ResolveWarning::TooFewNodesQueried {
-                queried: outcome.queried,
-                minimum: self.minimum_queried_nodes,
-            });
-        }
-
-        if responded < self.minimum_responded_nodes {
-            warnings.push(ResolveWarning::TooFewNodesResponded {
-                responded,
-                minimum: self.minimum_responded_nodes,
-            });
-        }
-
-        if valid_responses < self.minimum_valid_responses {
-            warnings.push(ResolveWarning::TooFewValidResponses {
-                valid_responses,
-                minimum: self.minimum_valid_responses,
-            });
-        }
-
-        if self.warn_on_invalid_responses
-            && (outcome.invalid_values > 0
-                || outcome.invalid_responses > 0
-                || invalid_signed_packet_count > 0)
-        {
-            warnings.push(ResolveWarning::InvalidResponses {
-                invalid_values: outcome.invalid_values,
-                invalid_responses: outcome.invalid_responses,
-                invalid_signed_packets: invalid_signed_packet_count,
-            });
-        }
-
-        if self.warn_on_krpc_errors && outcome.krpc_errors > 0 {
-            warnings.push(ResolveWarning::KrpcErrors {
-                krpc_errors: outcome.krpc_errors,
-            });
-        }
-
-        warnings
-    }
-}
-
 /// Diagnostics for a DHT resolve query.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolveReport {
-    outcome: mainline::GetMutableOutcome,
-    invalid_signed_packet_count: u32,
+    pub(super) outcome: mainline::GetMutableOutcome,
+    pub(super) invalid_signed_packet_count: u32,
 }
 
 impl ResolveReport {
@@ -144,60 +33,15 @@ impl ResolveReport {
             .valid_responses()
             .saturating_sub(self.invalid_signed_packet_count)
     }
-
-    /// Classify warning diagnostics for this resolve query using the given policy.
-    pub fn classify_warnings(&self, policy: ResolveReportPolicy) -> Vec<ResolveWarning> {
-        policy.classify(&self.outcome, self.invalid_signed_packet_count)
-    }
-}
-
-/// Warning diagnostics found in a DHT resolve query.
-#[non_exhaustive]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ResolveWarning {
-    /// The query visited fewer unique DHT nodes than expected.
-    TooFewNodesQueried {
-        /// Number of unique DHT nodes queried.
-        queried: u32,
-        /// Minimum number of queried nodes expected by the policy.
-        minimum: u32,
-    },
-    /// The query received responses from fewer DHT nodes than expected.
-    TooFewNodesResponded {
-        /// Number of queried DHT nodes that responded.
-        responded: u32,
-        /// Minimum number of responses expected by the policy.
-        minimum: u32,
-    },
-    /// The query received fewer valid mutable GET responses than expected.
-    TooFewValidResponses {
-        /// Number of valid mutable GET responses.
-        valid_responses: u32,
-        /// Minimum number of valid responses expected by the policy.
-        minimum: u32,
-    },
-    /// The query received invalid values or invalid response shapes.
-    InvalidResponses {
-        /// Number of mutable value responses that failed validation.
-        invalid_values: u32,
-        /// Number of invalid response shapes returned.
-        invalid_responses: u32,
-        /// Number of mutable values that failed signed packet validation.
-        invalid_signed_packets: u32,
-    },
-    /// The query received KRPC error responses.
-    KrpcErrors {
-        /// Number of KRPC error responses returned.
-        krpc_errors: u32,
-    },
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::report_policy::{ReportPolicy, ResolveWarning};
     use super::*;
 
     fn classify(report: &ResolveReport) -> Vec<ResolveWarning> {
-        report.classify_warnings(ResolveReportPolicy::default())
+        ReportPolicy::mainnet().classify_resolve_report(report)
     }
 
     #[test]
@@ -233,20 +77,21 @@ mod tests {
             0,
         );
 
+        let policy = ReportPolicy::mainnet();
         assert_eq!(
             classify(&report),
             vec![
                 ResolveWarning::TooFewNodesQueried {
                     queried: 2,
-                    minimum: DEFAULT_MINIMUM_QUERIED_NODES,
+                    minimum: policy.minimum_queried_nodes,
                 },
                 ResolveWarning::TooFewNodesResponded {
                     responded: 0,
-                    minimum: DEFAULT_MINIMUM_RESPONDED_NODES,
+                    minimum: policy.minimum_responded_nodes,
                 },
                 ResolveWarning::TooFewValidResponses {
                     valid_responses: 0,
-                    minimum: DEFAULT_MINIMUM_VALID_RESPONSES,
+                    minimum: policy.minimum_valid_responses,
                 },
             ]
         );
@@ -321,12 +166,13 @@ mod tests {
         );
 
         assert_eq!(report.valid_responses(), 0);
+        let policy = ReportPolicy::mainnet();
         assert_eq!(
             classify(&report),
             vec![
                 ResolveWarning::TooFewValidResponses {
                     valid_responses: 0,
-                    minimum: DEFAULT_MINIMUM_VALID_RESPONSES,
+                    minimum: policy.minimum_valid_responses,
                 },
                 ResolveWarning::InvalidResponses {
                     invalid_values: 0,
@@ -353,16 +199,17 @@ mod tests {
         );
 
         assert_eq!(report.valid_responses(), 0);
+        let policy = ReportPolicy::mainnet();
         assert_eq!(
             classify(&report),
             vec![
                 ResolveWarning::TooFewNodesResponded {
                     responded: 1,
-                    minimum: DEFAULT_MINIMUM_RESPONDED_NODES,
+                    minimum: policy.minimum_responded_nodes,
                 },
                 ResolveWarning::TooFewValidResponses {
                     valid_responses: 0,
-                    minimum: DEFAULT_MINIMUM_VALID_RESPONSES,
+                    minimum: policy.minimum_valid_responses,
                 },
                 ResolveWarning::InvalidResponses {
                     invalid_values: 0,
@@ -388,8 +235,8 @@ mod tests {
             0,
         );
 
-        assert!(report
-            .classify_warnings(ResolveReportPolicy::testnet())
+        assert!(ReportPolicy::testnet()
+            .classify_resolve_report(&report)
             .is_empty());
     }
 
@@ -408,13 +255,15 @@ mod tests {
             0,
         );
 
-        let warnings = report.classify_warnings(ResolveReportPolicy {
+        let warnings = ReportPolicy {
+            minimum_publish_stored_nodes: 1,
             minimum_queried_nodes: 2,
             minimum_responded_nodes: 1,
             minimum_valid_responses: 1,
-            warn_on_invalid_responses: false,
-            warn_on_krpc_errors: false,
-        });
+            report_invalid_responses: false,
+            report_krpc_errors: false,
+        }
+        .classify_resolve_report(&report);
 
         assert!(warnings.is_empty());
     }

--- a/pkarr/src/dht/resolve_response.rs
+++ b/pkarr/src/dht/resolve_response.rs
@@ -1,19 +1,19 @@
 use std::{fmt, future::Future, pin::Pin};
 
-use super::resolve_report::ResolveReport;
+use super::{ResolveError, ResolveReport};
 use crate::SignedPacket;
 
 type ResolveCompletion = Pin<Box<dyn Future<Output = ResolveOutcome> + Send + 'static>>;
 
-/// Successful DHT resolve response returned after the first valid signed packet is found.
+/// DHT resolve response with optional first packet and completion diagnostics.
 pub struct ResolveResponse {
-    first: SignedPacket,
+    first: Option<SignedPacket>,
     completion: ResolveCompletion,
 }
 
 impl ResolveResponse {
     pub(crate) fn new(
-        first: SignedPacket,
+        first: Option<SignedPacket>,
         completion: impl Future<Output = ResolveOutcome> + Send + 'static,
     ) -> Self {
         Self {
@@ -23,8 +23,8 @@ impl ResolveResponse {
     }
 
     /// First valid signed packet returned by the DHT query.
-    pub fn first(&self) -> &SignedPacket {
-        &self.first
+    pub fn first(&self) -> Option<&SignedPacket> {
+        self.first.as_ref()
     }
 
     /// Finish the DHT query and return the most recent value and diagnostics.
@@ -44,30 +44,10 @@ impl fmt::Debug for ResolveResponse {
 /// Completed DHT resolve result.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolveOutcome {
-    /// Most recent mutable item returned by the DHT query.
-    pub most_recent: ResolveValue,
+    /// Most recent valid signed packet returned by the DHT query.
+    pub most_recent: Result<SignedPacket, ResolveError>,
     /// Diagnostics collected from the DHT query.
     pub report: ResolveReport,
-}
-
-/// Most recent mutable item returned by a completed DHT resolve query.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ResolveValue {
-    /// The most recent mutable item contains a valid signed packet.
-    ValidSignedPacket {
-        /// Valid signed packet contained by the mutable item.
-        packet: SignedPacket,
-    },
-    /// The most recent mutable item is newer than all valid signed packets, but
-    /// does not contain a valid signed packet.
-    ///
-    /// Older valid signed packets must not be treated as current when this
-    /// variant is returned; the newer invalid mutable item is the current DHT
-    /// state for the key.
-    InvalidSignedPacket {
-        /// Mutable item sequence number.
-        seq: i64,
-    },
 }
 
 #[cfg(test)]
@@ -100,16 +80,14 @@ mod tests {
     #[test]
     fn resolve_response_exposes_first_packet() {
         let first = signed_packet();
-        let response = ResolveResponse::new(first.clone(), async move {
+        let response = ResolveResponse::new(Some(first.clone()), async move {
             ResolveOutcome {
-                most_recent: ResolveValue::ValidSignedPacket {
-                    packet: signed_packet(),
-                },
+                most_recent: Ok(signed_packet()),
                 report: healthy_report(),
             }
         });
 
-        assert_eq!(response.first(), &first);
+        assert_eq!(response.first(), Some(&first));
     }
 
     #[test]
@@ -119,23 +97,16 @@ mod tests {
         let report = healthy_report();
         let expected_packet = most_recent.clone();
         let expected_report = report.clone();
-        let response = ResolveResponse::new(first, async move {
+        let response = ResolveResponse::new(Some(first), async move {
             ResolveOutcome {
-                most_recent: ResolveValue::ValidSignedPacket {
-                    packet: most_recent,
-                },
+                most_recent: Ok(most_recent),
                 report,
             }
         });
 
         let resolved = futures_lite::future::block_on(response.complete());
 
-        assert_eq!(
-            resolved.most_recent,
-            ResolveValue::ValidSignedPacket {
-                packet: expected_packet
-            }
-        );
+        assert_eq!(resolved.most_recent, Ok(expected_packet));
         assert_eq!(resolved.report, expected_report);
     }
 }

--- a/pkarr/src/dht/resolve_response.rs
+++ b/pkarr/src/dht/resolve_response.rs
@@ -1,0 +1,115 @@
+use std::{fmt, future::Future, pin::Pin};
+
+use super::resolve_report::ResolveReport;
+use crate::SignedPacket;
+
+type ResolveCompletion = Pin<Box<dyn Future<Output = ResolveOutcome> + Send + 'static>>;
+
+/// Successful DHT resolve response returned after the first valid packet is found.
+pub struct ResolveResponse {
+    first: SignedPacket,
+    completion: ResolveCompletion,
+}
+
+impl ResolveResponse {
+    pub(crate) fn new(
+        first: SignedPacket,
+        completion: impl Future<Output = ResolveOutcome> + Send + 'static,
+    ) -> Self {
+        Self {
+            first,
+            completion: Box::pin(completion),
+        }
+    }
+
+    /// First valid signed packet returned by the DHT query.
+    pub fn first(&self) -> &SignedPacket {
+        &self.first
+    }
+
+    /// Finish the DHT query and return the most recent packet and diagnostics.
+    pub async fn complete(self) -> ResolveOutcome {
+        self.completion.await
+    }
+}
+
+impl fmt::Debug for ResolveResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResolveResponse")
+            .field("first", &self.first)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Completed DHT resolve result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolveOutcome {
+    /// Most recent signed packet returned by the DHT query.
+    pub most_recent: SignedPacket,
+    /// Diagnostics collected from the DHT query.
+    pub report: ResolveReport,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn signed_packet() -> SignedPacket {
+        crate::SignedPacket::builder()
+            .address(
+                "_derp_region.iroh.".try_into().unwrap(),
+                "1.1.1.1".parse().unwrap(),
+                30,
+            )
+            .sign(&crate::Keypair::random())
+            .unwrap()
+    }
+
+    fn healthy_report() -> ResolveReport {
+        ResolveReport::with_invalid_signed_packets(
+            mainline::GetMutableOutcome {
+                queried: 20,
+                values: 1,
+                no_values: 2,
+                no_more_recent: 0,
+                invalid_values: 0,
+                invalid_responses: 0,
+                krpc_errors: 0,
+            },
+            0,
+        )
+    }
+
+    #[test]
+    fn resolve_response_exposes_first_packet() {
+        let first = signed_packet();
+        let response = ResolveResponse::new(first.clone(), async move {
+            ResolveOutcome {
+                most_recent: signed_packet(),
+                report: healthy_report(),
+            }
+        });
+
+        assert_eq!(response.first(), &first);
+    }
+
+    #[test]
+    fn resolve_response_completion_returns_resolve_outcome() {
+        let first = signed_packet();
+        let most_recent = signed_packet();
+        let report = healthy_report();
+        let expected_packet = most_recent.clone();
+        let expected_report = report.clone();
+        let response = ResolveResponse::new(first, async move {
+            ResolveOutcome {
+                most_recent,
+                report,
+            }
+        });
+
+        let resolved = futures_lite::future::block_on(response.complete());
+
+        assert_eq!(resolved.most_recent, expected_packet);
+        assert_eq!(resolved.report, expected_report);
+    }
+}

--- a/pkarr/src/dht/resolve_response.rs
+++ b/pkarr/src/dht/resolve_response.rs
@@ -5,7 +5,7 @@ use crate::SignedPacket;
 
 type ResolveCompletion = Pin<Box<dyn Future<Output = ResolveOutcome> + Send + 'static>>;
 
-/// Successful DHT resolve response returned after the first valid packet is found.
+/// Successful DHT resolve response returned after the first valid signed packet is found.
 pub struct ResolveResponse {
     first: SignedPacket,
     completion: ResolveCompletion,
@@ -27,7 +27,7 @@ impl ResolveResponse {
         &self.first
     }
 
-    /// Finish the DHT query and return the most recent packet and diagnostics.
+    /// Finish the DHT query and return the most recent value and diagnostics.
     pub async fn complete(self) -> ResolveOutcome {
         self.completion.await
     }
@@ -44,10 +44,30 @@ impl fmt::Debug for ResolveResponse {
 /// Completed DHT resolve result.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolveOutcome {
-    /// Most recent signed packet returned by the DHT query.
-    pub most_recent: SignedPacket,
+    /// Most recent mutable item returned by the DHT query.
+    pub most_recent: ResolveValue,
     /// Diagnostics collected from the DHT query.
     pub report: ResolveReport,
+}
+
+/// Most recent mutable item returned by a completed DHT resolve query.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResolveValue {
+    /// The most recent mutable item contains a valid signed packet.
+    ValidSignedPacket {
+        /// Valid signed packet contained by the mutable item.
+        packet: SignedPacket,
+    },
+    /// The most recent mutable item is newer than all valid signed packets, but
+    /// does not contain a valid signed packet.
+    ///
+    /// Older valid signed packets must not be treated as current when this
+    /// variant is returned; the newer invalid mutable item is the current DHT
+    /// state for the key.
+    InvalidSignedPacket {
+        /// Mutable item sequence number.
+        seq: i64,
+    },
 }
 
 #[cfg(test)]
@@ -66,18 +86,15 @@ mod tests {
     }
 
     fn healthy_report() -> ResolveReport {
-        ResolveReport::with_invalid_signed_packets(
-            mainline::GetMutableOutcome {
-                queried: 20,
-                values: 1,
-                no_values: 2,
-                no_more_recent: 0,
-                invalid_values: 0,
-                invalid_responses: 0,
-                krpc_errors: 0,
-            },
-            0,
-        )
+        ResolveReport::new(mainline::GetMutableOutcome {
+            queried: 20,
+            values: 1,
+            no_values: 2,
+            no_more_recent: 0,
+            invalid_values: 0,
+            invalid_responses: 0,
+            krpc_errors: 0,
+        })
     }
 
     #[test]
@@ -85,7 +102,9 @@ mod tests {
         let first = signed_packet();
         let response = ResolveResponse::new(first.clone(), async move {
             ResolveOutcome {
-                most_recent: signed_packet(),
+                most_recent: ResolveValue::ValidSignedPacket {
+                    packet: signed_packet(),
+                },
                 report: healthy_report(),
             }
         });
@@ -102,14 +121,21 @@ mod tests {
         let expected_report = report.clone();
         let response = ResolveResponse::new(first, async move {
             ResolveOutcome {
-                most_recent,
+                most_recent: ResolveValue::ValidSignedPacket {
+                    packet: most_recent,
+                },
                 report,
             }
         });
 
         let resolved = futures_lite::future::block_on(response.complete());
 
-        assert_eq!(resolved.most_recent, expected_packet);
+        assert_eq!(
+            resolved.most_recent,
+            ResolveValue::ValidSignedPacket {
+                packet: expected_packet
+            }
+        );
         assert_eq!(resolved.report, expected_report);
     }
 }

--- a/pkarr/src/lib.rs
+++ b/pkarr/src/lib.rs
@@ -24,6 +24,9 @@ pub const DEFAULT_MINIMUM_TTL: u32 = 300;
 pub const DEFAULT_MAXIMUM_TTL: u32 = 24 * 60 * 60;
 /// Default [Relays](https://github.com/pubky/pkarr/blob/main/design/relays.md).
 pub const DEFAULT_RELAYS: [&str; 2] = ["https://pkarr.pubky.app", "https://pkarr.pubky.org"];
+/// Relay response header carrying the mutable item sequence number when the
+/// DHT has a newer mutable item that is not a valid signed packet for a key.
+pub const PKARR_INVALID_SIGNED_PACKET_SEQ: &str = "Pkarr-Invalid-Signed-Packet-Seq";
 #[cfg(feature = "__client")]
 /// Default cache size: 1000
 pub const DEFAULT_CACHE_SIZE: usize = 1000;

--- a/pkarr/src/relay_client.rs
+++ b/pkarr/src/relay_client.rs
@@ -241,17 +241,9 @@ pub enum RelayError {
     #[error("relay requires compare-and-swap")]
     ConflictRisk,
 
-    /// Relay's DHT query found no valid responses.
-    #[error("relay DHT query found no valid responses")]
-    NoValidDhtResponses,
-
-    /// Relay did not query any DHT nodes.
-    #[error("relay queried no DHT nodes")]
-    NoDhtNodesQueried,
-
-    /// Relay queried DHT nodes, but none responded.
-    #[error("relay DHT query received no responses")]
-    NoDhtResponses,
+    /// Relay could not complete a DHT query.
+    #[error("relay DHT query is unavailable")]
+    DhtUnavailable,
 
     /// Relay returned an unexpected status code.
     #[error("relay returned unexpected status code {0}")]
@@ -275,9 +267,7 @@ impl RelayError {
             StatusCode::CONFLICT => Self::NotMostRecent,
             StatusCode::PRECONDITION_FAILED => Self::CasFailed,
             StatusCode::PRECONDITION_REQUIRED => Self::ConflictRisk,
-            StatusCode::BAD_GATEWAY => Self::NoValidDhtResponses,
-            StatusCode::SERVICE_UNAVAILABLE => Self::NoDhtNodesQueried,
-            StatusCode::GATEWAY_TIMEOUT => Self::NoDhtResponses,
+            StatusCode::SERVICE_UNAVAILABLE => Self::DhtUnavailable,
             status => Self::UnexpectedStatus(status),
         }
     }
@@ -358,34 +348,18 @@ mod tests {
     const TIMEOUT: Duration = Duration::from_secs(1);
 
     #[test]
-    fn relay_5xx_statuses_map_to_specific_errors() {
-        assert!(matches!(
-            RelayError::from_status(StatusCode::BAD_GATEWAY),
-            RelayError::NoValidDhtResponses
-        ));
+    fn relay_503_status_maps_to_dht_unavailable() {
         assert!(matches!(
             RelayError::from_status(StatusCode::SERVICE_UNAVAILABLE),
-            RelayError::NoDhtNodesQueried
-        ));
-        assert!(matches!(
-            RelayError::from_status(StatusCode::GATEWAY_TIMEOUT),
-            RelayError::NoDhtResponses
+            RelayError::DhtUnavailable
         ));
     }
 
     #[tokio::test]
-    async fn resolve_maps_dht_5xx_statuses_to_specific_errors() {
-        assert!(matches!(
-            resolve_error_for_status(HttpStatusCode::BAD_GATEWAY).await,
-            RelayError::NoValidDhtResponses
-        ));
+    async fn resolve_maps_503_to_dht_unavailable() {
         assert!(matches!(
             resolve_error_for_status(HttpStatusCode::SERVICE_UNAVAILABLE).await,
-            RelayError::NoDhtNodesQueried
-        ));
-        assert!(matches!(
-            resolve_error_for_status(HttpStatusCode::GATEWAY_TIMEOUT).await,
-            RelayError::NoDhtResponses
+            RelayError::DhtUnavailable
         ));
     }
 

--- a/pkarr/src/relay_client.rs
+++ b/pkarr/src/relay_client.rs
@@ -9,7 +9,7 @@ use reqwest::{
 use std::time::Duration;
 use url::Url;
 
-use crate::{PublicKey, ResolvePolicy, SignedPacket};
+use crate::{PublicKey, ResolvePolicy, SignedPacket, PKARR_INVALID_SIGNED_PACKET_SEQ};
 
 const MEMENTO_DATETIME: &str = "memento-datetime";
 const CACHE_BYPASS: &str = "no-cache, no-store, must-revalidate";
@@ -107,7 +107,8 @@ impl RelayClient {
     /// # Errors
     ///
     /// Returns an error when the relay request fails, the response body is too
-    /// large, or the returned relay payload does not verify.
+    /// large, the returned relay payload does not verify, or the relay reports
+    /// a newer DHT mutable item that is not a valid signed packet.
     pub async fn resolve(
         &self,
         key: &PublicKey,
@@ -129,7 +130,15 @@ impl RelayClient {
         }
 
         let status = response.status();
-        if status == StatusCode::NOT_MODIFIED || status == StatusCode::NOT_FOUND {
+        if status == StatusCode::NOT_FOUND {
+            if let Some(seq) = extract_invalid_signed_packet_seq(&response)? {
+                return Err(RelayError::InvalidSignedPacketSeq { seq });
+            }
+
+            return Ok(None);
+        }
+
+        if status == StatusCode::NOT_MODIFIED {
             return Ok(None);
         }
 
@@ -217,9 +226,22 @@ pub enum RelayError {
         limit: usize,
     },
 
-    /// Relay returned a malformed signed packet payload.
+    /// Relay returned an invalid signed packet payload.
     #[error("relay returned an invalid signed packet: {0}")]
     InvalidSignedPacket(crate::errors::SignedPacketVerifyError),
+
+    /// Relay reported a newer DHT mutable item that is not a valid signed packet.
+    #[error(
+        "relay reported a newer DHT mutable item at seq {seq} that is not a valid signed packet"
+    )]
+    InvalidSignedPacketSeq {
+        /// Mutable item sequence number.
+        seq: i64,
+    },
+
+    /// Relay returned a malformed invalid-signed-packet sequence header.
+    #[error("relay returned a malformed Pkarr-Invalid-Signed-Packet-Seq header")]
+    InvalidSignedPacketSeqHeader,
 
     /// Relay request contained an invalid header.
     #[error("relay request contained an invalid header: {0}")]
@@ -280,6 +302,20 @@ fn extract_memento_datetime(response: &Response) -> Option<Timestamp> {
         .and_then(|value| value.to_str().ok())
         .and_then(|value| Timestamp::parse_http_date(value).ok())
         .filter(|timestamp| timestamp <= &Timestamp::now())
+}
+
+fn extract_invalid_signed_packet_seq(response: &Response) -> Result<Option<i64>, RelayError> {
+    response
+        .headers()
+        .get(PKARR_INVALID_SIGNED_PACKET_SEQ)
+        .map(|value| {
+            value
+                .to_str()
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .ok_or(RelayError::InvalidSignedPacketSeqHeader)
+        })
+        .transpose()
 }
 
 fn should_retry_with_cache_bypass(response: &Response, newer_than: Option<&Timestamp>) -> bool {
@@ -382,6 +418,61 @@ mod tests {
             .unwrap();
 
         assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_invalid_signed_packet_seq_on_not_found() {
+        let keypair = Keypair::random();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get(|| async {
+                (
+                    HttpStatusCode::NOT_FOUND,
+                    [(PKARR_INVALID_SIGNED_PACKET_SEQ, "42")],
+                )
+            }),
+        );
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+
+        let error = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RelayError::InvalidSignedPacketSeq { seq: 42 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_rejects_malformed_invalid_signed_packet_seq_header() {
+        let keypair = Keypair::random();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get(|| async {
+                (
+                    HttpStatusCode::NOT_FOUND,
+                    [(PKARR_INVALID_SIGNED_PACKET_SEQ, "not a seq")],
+                )
+            }),
+        );
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+
+        let error = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RelayError::InvalidSignedPacketSeqHeader));
     }
 
     #[tokio::test]

--- a/pkarr/src/relay_client.rs
+++ b/pkarr/src/relay_client.rs
@@ -241,6 +241,18 @@ pub enum RelayError {
     #[error("relay requires compare-and-swap")]
     ConflictRisk,
 
+    /// Relay's DHT query found no valid responses.
+    #[error("relay DHT query found no valid responses")]
+    NoValidDhtResponses,
+
+    /// Relay did not query any DHT nodes.
+    #[error("relay queried no DHT nodes")]
+    NoDhtNodesQueried,
+
+    /// Relay queried DHT nodes, but none responded.
+    #[error("relay DHT query received no responses")]
+    NoDhtResponses,
+
     /// Relay returned an unexpected status code.
     #[error("relay returned unexpected status code {0}")]
     UnexpectedStatus(StatusCode),
@@ -263,6 +275,9 @@ impl RelayError {
             StatusCode::CONFLICT => Self::NotMostRecent,
             StatusCode::PRECONDITION_FAILED => Self::CasFailed,
             StatusCode::PRECONDITION_REQUIRED => Self::ConflictRisk,
+            StatusCode::BAD_GATEWAY => Self::NoValidDhtResponses,
+            StatusCode::SERVICE_UNAVAILABLE => Self::NoDhtNodesQueried,
+            StatusCode::GATEWAY_TIMEOUT => Self::NoDhtResponses,
             status => Self::UnexpectedStatus(status),
         }
     }
@@ -341,6 +356,38 @@ mod tests {
     use crate::Keypair;
 
     const TIMEOUT: Duration = Duration::from_secs(1);
+
+    #[test]
+    fn relay_5xx_statuses_map_to_specific_errors() {
+        assert!(matches!(
+            RelayError::from_status(StatusCode::BAD_GATEWAY),
+            RelayError::NoValidDhtResponses
+        ));
+        assert!(matches!(
+            RelayError::from_status(StatusCode::SERVICE_UNAVAILABLE),
+            RelayError::NoDhtNodesQueried
+        ));
+        assert!(matches!(
+            RelayError::from_status(StatusCode::GATEWAY_TIMEOUT),
+            RelayError::NoDhtResponses
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolve_maps_dht_5xx_statuses_to_specific_errors() {
+        assert!(matches!(
+            resolve_error_for_status(HttpStatusCode::BAD_GATEWAY).await,
+            RelayError::NoValidDhtResponses
+        ));
+        assert!(matches!(
+            resolve_error_for_status(HttpStatusCode::SERVICE_UNAVAILABLE).await,
+            RelayError::NoDhtNodesQueried
+        ));
+        assert!(matches!(
+            resolve_error_for_status(HttpStatusCode::GATEWAY_TIMEOUT).await,
+            RelayError::NoDhtResponses
+        ));
+    }
 
     #[tokio::test]
     async fn resolve_returns_none_on_not_found() {
@@ -685,6 +732,24 @@ mod tests {
             reached_listener.load(Ordering::SeqCst),
             "HTTPS request never reached the TCP listener, got {err:?}"
         );
+    }
+
+    async fn resolve_error_for_status(status: HttpStatusCode) -> RelayError {
+        let keypair = Keypair::random();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get(move || async move { status }),
+        );
+        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+
+        client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::LocalOrRelayCacheOnly,
+                None,
+            )
+            .await
+            .unwrap_err()
     }
 
     async fn serve(app: Router) -> Url {

--- a/pkarr/src/types/resolve_policy.rs
+++ b/pkarr/src/types/resolve_policy.rs
@@ -25,13 +25,15 @@ pub enum ResolvePolicy {
     /// Useful for normal application resolution while respecting TTLs.
     CacheFirst,
 
-    /// Query all relevant DHT nodes for the most recent packet observed and
-    /// update the cache after retrieval.
+    /// Query all relevant DHT nodes for the most recent value observed and
+    /// update the cache when that value contains a valid signed packet.
     /// This is slower, but more accurate.
     ///
-    /// This is guaranteed to return the newest packet.
-    /// Useful when you need the most recent packet, for example for recovering
-    /// after stale sequence errors.
+    /// This is guaranteed to return the newest valid signed packet, or the sequence
+    /// number of a newer mutable item that is not a valid signed packet.
+    /// A newer invalid signed packet is treated as the current DHT state.
+    /// Useful when you need to account for the most recent DHT state, for
+    /// example when recovering after stale sequence errors.
     DhtNetworkOnly,
 }
 

--- a/relay/src/error.rs
+++ b/relay/src/error.rs
@@ -83,22 +83,21 @@ impl From<dht::PublishError> for Error {
     }
 }
 
-impl From<dht::ResolveReport> for Error {
-    fn from(report: dht::ResolveReport) -> Self {
-        if report.queried() == 0 {
-            Error::new(StatusCode::SERVICE_UNAVAILABLE, "No DHT nodes were queried")
-        } else if report.responded() == 0 {
-            Error::new(
-                StatusCode::GATEWAY_TIMEOUT,
+impl From<dht::ResolveError> for Error {
+    fn from(error: dht::ResolveError) -> Self {
+        match error {
+            dht::ResolveError::NoNodesQueried => {
+                Error::new(StatusCode::SERVICE_UNAVAILABLE, "No DHT nodes were queried")
+            }
+            dht::ResolveError::NoNodesResponded => Error::new(
+                StatusCode::SERVICE_UNAVAILABLE,
                 "No queried DHT nodes responded",
-            )
-        } else if report.valid_responses() == 0 {
-            Error::new(
-                StatusCode::BAD_GATEWAY,
+            ),
+            dht::ResolveError::NoValidResponses => Error::new(
+                StatusCode::SERVICE_UNAVAILABLE,
                 "No responded DHT nodes returned valid response",
-            )
-        } else {
-            Error::with_status(StatusCode::NOT_FOUND)
+            ),
+            dht::ResolveError::NotFound => Error::with_status(StatusCode::NOT_FOUND),
         }
     }
 }

--- a/relay/src/error.rs
+++ b/relay/src/error.rs
@@ -2,16 +2,16 @@
 
 use axum::{
     extract::rejection::{ExtensionRejection, QueryRejection},
-    http::StatusCode,
+    http::{HeaderMap, HeaderValue, StatusCode},
     response::IntoResponse,
 };
-use pkarr::dht;
+use pkarr::{dht, PKARR_INVALID_SIGNED_PACKET_SEQ};
 
 #[derive(Debug, Clone)]
 pub struct Error {
-    // #[serde(with = "serde_status_code")]
     status: StatusCode,
     detail: Option<String>,
+    headers: HeaderMap,
 }
 
 impl Default for Error {
@@ -19,6 +19,7 @@ impl Default for Error {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             detail: None,
+            headers: HeaderMap::new(),
         }
     }
 }
@@ -28,6 +29,7 @@ impl Error {
         Self {
             status,
             detail: None,
+            headers: HeaderMap::new(),
         }
     }
 
@@ -37,16 +39,32 @@ impl Error {
             status: status_code,
             // title: Self::canonical_reason_to_string(&status_code),
             detail: Some(message.to_string()),
+            headers: HeaderMap::new(),
         }
+    }
+
+    pub(crate) fn invalid_signed_packet(seq: i64) -> Error {
+        let mut error = Self::new(
+            StatusCode::NOT_FOUND,
+            format!("DHT mutable item at seq {seq} is not a valid signed packet"),
+        );
+        error.headers.insert(
+            PKARR_INVALID_SIGNED_PACKET_SEQ,
+            HeaderValue::from_str(&seq.to_string())
+                .expect("i64 string is a valid HTTP header value"),
+        );
+        error
     }
 }
 
 impl IntoResponse for Error {
     fn into_response(self) -> axum::response::Response {
-        match self.detail {
+        let mut response = match self.detail {
             Some(detail) => (self.status, detail).into_response(),
             _ => (self.status,).into_response(),
-        }
+        };
+        response.headers_mut().extend(self.headers);
+        response
     }
 }
 
@@ -93,11 +111,31 @@ impl From<dht::ResolveError> for Error {
                 StatusCode::SERVICE_UNAVAILABLE,
                 "No queried DHT nodes responded",
             ),
-            dht::ResolveError::NoValidResponses => Error::new(
+            dht::ResolveError::NoUsableResponses => Error::new(
                 StatusCode::SERVICE_UNAVAILABLE,
-                "No responded DHT nodes returned valid response",
+                "No responded DHT nodes returned usable response",
             ),
             dht::ResolveError::NotFound => Error::with_status(StatusCode::NOT_FOUND),
+            dht::ResolveError::InvalidSignedPacket { seq } => Error::invalid_signed_packet(seq),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_signed_packet_error_returns_not_found_with_seq_header() {
+        let response = Error::invalid_signed_packet(42).into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            response
+                .headers()
+                .get(PKARR_INVALID_SIGNED_PACKET_SEQ)
+                .unwrap(),
+            "42"
+        );
     }
 }

--- a/relay/src/error.rs
+++ b/relay/src/error.rs
@@ -32,11 +32,11 @@ impl Error {
     }
 
     /// Create a new [`Error`].
-    pub fn new(status_code: StatusCode, message: Option<impl ToString>) -> Error {
+    pub fn new(status_code: StatusCode, message: impl ToString) -> Error {
         Self {
             status: status_code,
             // title: Self::canonical_reason_to_string(&status_code),
-            detail: message.map(|m| m.to_string()),
+            detail: Some(message.to_string()),
         }
     }
 }
@@ -52,19 +52,19 @@ impl IntoResponse for Error {
 
 impl From<QueryRejection> for Error {
     fn from(value: QueryRejection) -> Self {
-        Self::new(StatusCode::BAD_REQUEST, Some(value))
+        Self::new(StatusCode::BAD_REQUEST, value)
     }
 }
 
 impl From<ExtensionRejection> for Error {
     fn from(value: ExtensionRejection) -> Self {
-        Self::new(StatusCode::BAD_REQUEST, Some(value))
+        Self::new(StatusCode::BAD_REQUEST, value)
     }
 }
 
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {
-        Self::new(StatusCode::INTERNAL_SERVER_ERROR, Some(value))
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, value)
     }
 }
 
@@ -74,13 +74,31 @@ impl From<dht::PublishError> for Error {
             dht::PublishError::Timeout
             | dht::PublishError::NoClosestNodes
             | dht::PublishError::ErrorResponse { .. } => {
-                Self::new(StatusCode::INTERNAL_SERVER_ERROR, Some(error))
+                Self::new(StatusCode::INTERNAL_SERVER_ERROR, error)
             }
-            dht::PublishError::CasFailed => Self::new(StatusCode::PRECONDITION_FAILED, Some(error)),
-            dht::PublishError::ConflictRisk => {
-                Self::new(StatusCode::PRECONDITION_REQUIRED, Some(error))
-            }
-            dht::PublishError::NotMostRecent => Self::new(StatusCode::CONFLICT, Some(error)),
+            dht::PublishError::CasFailed => Self::new(StatusCode::PRECONDITION_FAILED, error),
+            dht::PublishError::ConflictRisk => Self::new(StatusCode::PRECONDITION_REQUIRED, error),
+            dht::PublishError::NotMostRecent => Self::new(StatusCode::CONFLICT, error),
+        }
+    }
+}
+
+impl From<dht::ResolveReport> for Error {
+    fn from(report: dht::ResolveReport) -> Self {
+        if report.queried() == 0 {
+            Error::new(StatusCode::SERVICE_UNAVAILABLE, "No DHT nodes were queried")
+        } else if report.responded() == 0 {
+            Error::new(
+                StatusCode::GATEWAY_TIMEOUT,
+                "No queried DHT nodes responded",
+            )
+        } else if report.valid_responses() == 0 {
+            Error::new(
+                StatusCode::BAD_GATEWAY,
+                "No responded DHT nodes returned valid response",
+            )
+        } else {
+            Error::with_status(StatusCode::NOT_FOUND)
         }
     }
 }

--- a/relay/src/extractors.rs
+++ b/relay/src/extractors.rs
@@ -66,8 +66,5 @@ where
 }
 
 fn invalid_header<T>(_error: T) -> RelayError {
-    RelayError::new(
-        StatusCode::BAD_REQUEST,
-        Some("Invalid IF_MATCH header value"),
-    )
+    RelayError::new(StatusCode::BAD_REQUEST, "Invalid IF_MATCH header value")
 }

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -3,7 +3,7 @@ use axum::response::Html;
 use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
 use http::StatusCode;
-use pkarr::dht::{ReportPolicy, ResolveReport};
+use pkarr::dht::{ReportPolicy, ResolveReport, ResolveValue};
 use pkarr::mainline::errors::ConcurrencyError;
 use pkarr::{Cache, CacheKey, ResolvePolicy, SignedPacket, Timestamp};
 use serde::Deserialize;
@@ -83,7 +83,9 @@ pub async fn get(
                 tokio::spawn(async move {
                     let resolved = result.complete().await;
                     log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
-                    update_cache_if_needed(&state, &key, &resolved.most_recent);
+                    if let ResolveValue::ValidSignedPacket { packet } = resolved.most_recent {
+                        update_cache_if_needed(&state, &key, &packet);
+                    }
                 });
                 packet
             }
@@ -97,7 +99,12 @@ pub async fn get(
                 .complete()
                 .await;
             log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
-            resolved.most_recent
+            match resolved.most_recent {
+                ResolveValue::ValidSignedPacket { packet } => packet,
+                ResolveValue::InvalidSignedPacket { seq } => {
+                    return Err(Error::invalid_signed_packet(seq))
+                }
+            }
         }
     };
 
@@ -248,6 +255,7 @@ fn log_resolve_warnings(
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn enforce_user_dht_rate_limit(
     state: &AppState,
     real_ip: Option<&Extension<RealIp>>,

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -3,7 +3,7 @@ use axum::response::Html;
 use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
 use http::StatusCode;
-use pkarr::dht::{ResolveReport, ResolveReportPolicy, MINIMUM_PUBLISH_STORED_NODES};
+use pkarr::dht::{ReportPolicy, ResolveReport};
 use pkarr::mainline::errors::ConcurrencyError;
 use pkarr::{Cache, CacheKey, ResolvePolicy, SignedPacket, Timestamp};
 use serde::Deserialize;
@@ -38,8 +38,13 @@ pub async fn put(
     enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
 
     let stored_at = state.dht.publish(&signed_packet, cas).await?;
-    if stored_at < MINIMUM_PUBLISH_STORED_NODES {
-        warn!(public_key = ?signed_packet.public_key(), stored_at, "DHT publish completed with warnings");
+    let warnings = state.report_policy.classify_publish_result(stored_at);
+    if !warnings.is_empty() {
+        warn!(
+            ?public_key,
+            ?warnings,
+            "DHT publish completed with warnings"
+        );
     }
     update_cache_if_needed(&state, &key, &signed_packet);
 
@@ -77,7 +82,7 @@ pub async fn get(
                 // Do not waste late responses with potentially newer packets.
                 tokio::spawn(async move {
                     let resolved = result.complete().await;
-                    log_resolve_warnings(&public_key, &resolved.report);
+                    log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
                     update_cache_if_needed(&state, &key, &resolved.most_recent);
                 });
                 packet
@@ -91,7 +96,7 @@ pub async fn get(
                 .await?
                 .complete()
                 .await;
-            log_resolve_warnings(&public_key, &resolved.report);
+            log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
             resolved.most_recent
         }
     };
@@ -228,8 +233,12 @@ fn decrement(timestamp: Timestamp) -> Option<Timestamp> {
     timestamp.as_u64().checked_sub(1).map(Timestamp::from)
 }
 
-fn log_resolve_warnings(public_key: &pkarr::PublicKey, report: &ResolveReport) {
-    let warnings = report.classify_warnings(ResolveReportPolicy::default());
+fn log_resolve_warnings(
+    public_key: &pkarr::PublicKey,
+    report: &ResolveReport,
+    policy: ReportPolicy,
+) {
+    let warnings = policy.classify_resolve_report(report);
     if !warnings.is_empty() {
         warn!(
             ?public_key,

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -3,7 +3,7 @@ use axum::response::Html;
 use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
 use http::StatusCode;
-use pkarr::dht::{ReportPolicy, ResolveReport, ResolveValue};
+use pkarr::dht::{ReportPolicy, ResolveReport};
 use pkarr::mainline::errors::ConcurrencyError;
 use pkarr::{Cache, CacheKey, ResolvePolicy, SignedPacket, Timestamp};
 use serde::Deserialize;
@@ -76,18 +76,23 @@ pub async fn get(
             Some(packet) if !packet.is_expired(state.minimum_ttl, state.maximum_ttl) => packet,
             _ => {
                 enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-                let response = state.dht.resolve(&public_key, more_recent_than).await?;
-                let packet = response.first().clone();
-                let state = state.clone();
-                // Do not waste late responses with potentially newer packets.
-                tokio::spawn(async move {
+                let response = state.dht.resolve(&public_key, more_recent_than).await;
+                if let Some(packet) = response.first().cloned() {
+                    let state = state.clone();
+                    // Do not waste late responses with potentially newer packets.
+                    tokio::spawn(async move {
+                        let resolved = response.complete().await;
+                        log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
+                        if let Ok(packet) = resolved.most_recent {
+                            update_cache_if_needed(&state, &key, &packet);
+                        }
+                    });
+                    packet
+                } else {
                     let resolved = response.complete().await;
                     log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
-                    if let ResolveValue::ValidSignedPacket { packet } = resolved.most_recent {
-                        update_cache_if_needed(&state, &key, &packet);
-                    }
-                });
-                packet
+                    resolved.most_recent?
+                }
             }
         },
         ResolvePolicy::DhtNetworkOnly => {
@@ -95,16 +100,11 @@ pub async fn get(
             let resolved = state
                 .dht
                 .resolve(&public_key, more_recent_than)
-                .await?
+                .await
                 .complete()
                 .await;
             log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
-            match resolved.most_recent {
-                ResolveValue::ValidSignedPacket { packet } => packet,
-                ResolveValue::InvalidSignedPacket { seq } => {
-                    return Err(Error::invalid_signed_packet(seq))
-                }
-            }
+            resolved.most_recent?
         }
     };
 

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -2,11 +2,12 @@ use axum::extract::{Extension, Path, Query};
 use axum::response::Html;
 use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
-use futures_lite::StreamExt;
 use http::StatusCode;
+use pkarr::dht::MINIMUM_PUBLISH_STORED_NODES;
 use pkarr::mainline::errors::ConcurrencyError;
 use pkarr::{Cache, CacheKey, ResolvePolicy, SignedPacket, Timestamp};
 use serde::Deserialize;
+use tracing::warn;
 
 use crate::error::Error;
 use crate::extractors::{IfMatch, IfModifiedSince, PublicKeyParam};
@@ -22,21 +23,24 @@ pub async fn put(
     body: Bytes,
 ) -> Result<impl IntoResponse, Error> {
     let signed_packet = pkarr::SignedPacket::from_relay_payload(&public_key, &body)
-        .map_err(|error| Error::new(StatusCode::BAD_REQUEST, Some(error)))?;
+        .map_err(|error| Error::new(StatusCode::BAD_REQUEST, error))?;
 
     let key = CacheKey::from(&public_key);
     if let Some(cached) = state.cache.get_read_only(&key) {
         if cached.more_recent_than(&signed_packet) {
             return Err(Error::new(
                 StatusCode::CONFLICT,
-                Some(ConcurrencyError::NotMostRecent),
+                ConcurrencyError::NotMostRecent,
             ));
         }
     }
 
     enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
 
-    state.dht.publish(&signed_packet, cas).await?;
+    let stored_at = state.dht.publish(&signed_packet, cas).await?;
+    if stored_at < MINIMUM_PUBLISH_STORED_NODES {
+        warn!(public_key = ?signed_packet.public_key(), stored_at, "suspicious DHT publish report");
+    }
     update_cache_if_needed(&state, &key, &signed_packet);
 
     Ok(StatusCode::NO_CONTENT)
@@ -59,40 +63,53 @@ pub async fn get(
         .and_then(decrement);
 
     let packet = match policy {
-        ResolvePolicy::LocalOrRelayCacheOnly => cached_packet,
+        ResolvePolicy::LocalOrRelayCacheOnly => match cached_packet {
+            Some(packet) => packet,
+            None => return Err(Error::with_status(StatusCode::NOT_FOUND)),
+        },
         ResolvePolicy::CacheFirst => match cached_packet {
-            Some(packet) if !packet.is_expired(state.minimum_ttl, state.maximum_ttl) => {
-                Some(packet)
-            }
+            Some(packet) if !packet.is_expired(state.minimum_ttl, state.maximum_ttl) => packet,
             _ => {
                 enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-                let mut stream = state.dht.resolve(&public_key, more_recent_than);
-                let packet = stream.next().await;
+                let result = state.dht.resolve(&public_key, more_recent_than).await?;
                 let state = state.clone();
                 // Do not waste late responses with potentially newer packets.
                 tokio::spawn(async move {
-                    if let Some(packet) = stream.fold(None, most_recent_packet).await {
-                        update_cache_if_needed(&state, &key, &packet);
+                    let (packet, report) = result.completion.await;
+                    if report.is_suspicious() {
+                        warn!(
+                            ?public_key,
+                            suspicions = ?report.suspicions(),
+                            "suspicious DHT resolve report"
+                        );
                     }
+                    update_cache_if_needed(&state, &key, &packet);
                 });
-                packet
+                result.first
             }
         },
         ResolvePolicy::DhtNetworkOnly => {
             enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-            let stream = state.dht.resolve(&public_key, more_recent_than);
-            stream.fold(None, most_recent_packet).await
+            let (packet, report) = state
+                .dht
+                .resolve(&public_key, more_recent_than)
+                .await?
+                .completion
+                .await;
+            if report.is_suspicious() {
+                warn!(
+                    ?public_key,
+                    suspicions = ?report.suspicions(),
+                    "suspicious DHT resolve report"
+                );
+            }
+            packet
         }
     };
 
-    if let Some(packet) = packet {
-        update_cache_if_needed(&state, &key, &packet);
-
-        let ttl = packet.ttl(state.minimum_ttl, state.maximum_ttl);
-        Ok(SignedPacketResponse::new(packet, ttl, if_modified_since))
-    } else {
-        Err(Error::with_status(StatusCode::NOT_FOUND))
-    }
+    update_cache_if_needed(&state, &key, &packet);
+    let ttl = packet.ttl(state.minimum_ttl, state.maximum_ttl);
+    Ok(SignedPacketResponse::new(packet, ttl, if_modified_since))
 }
 
 #[derive(Debug, Deserialize)]
@@ -231,7 +248,7 @@ fn enforce_user_dht_rate_limit(
         if rate_limiter.is_limited(&real_ip.0) {
             return Err(Error::new(
                 StatusCode::TOO_MANY_REQUESTS,
-                Some("Too many requests to DHT nodes"),
+                "Too many requests to DHT nodes",
             ));
         }
     }
@@ -239,112 +256,10 @@ fn enforce_user_dht_rate_limit(
     Ok(())
 }
 
-fn most_recent_packet(
-    most_recent: Option<SignedPacket>,
-    packet: SignedPacket,
-) -> Option<SignedPacket> {
-    match most_recent {
-        Some(mr) if mr.more_recent_than(&packet) => Some(mr),
-        _ => Some(packet),
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{decrement, most_recent_packet};
-    use pkarr::{Keypair, SignedPacket, Timestamp};
-
-    fn signed_packet(timestamp: u64, text: &str) -> SignedPacket {
-        signed_packet_for_key(&Keypair::random(), timestamp, text)
-    }
-
-    fn signed_packet_for_key(keypair: &Keypair, timestamp: u64, text: &str) -> SignedPacket {
-        SignedPacket::builder()
-            .timestamp(Timestamp::from(timestamp))
-            .txt("test".try_into().unwrap(), text.try_into().unwrap(), 30)
-            .sign(keypair)
-            .unwrap()
-    }
-
-    #[test]
-    fn most_recent_packet_selects_newest_packet() {
-        let packet = signed_packet(1, "first");
-
-        assert_eq!(
-            most_recent_packet(None, packet.clone()).unwrap().as_bytes(),
-            packet.as_bytes()
-        );
-
-        let existing = signed_packet(2, "existing");
-        let packet = signed_packet(1, "packet");
-
-        assert_eq!(
-            most_recent_packet(Some(existing.clone()), packet)
-                .unwrap()
-                .as_bytes(),
-            existing.as_bytes()
-        );
-
-        let existing = signed_packet(1, "existing");
-        let packet = signed_packet(2, "packet");
-
-        assert_eq!(
-            most_recent_packet(Some(existing), packet.clone())
-                .unwrap()
-                .as_bytes(),
-            packet.as_bytes()
-        );
-
-        let keypair = Keypair::random();
-        let a = signed_packet_for_key(&keypair, 1, "a");
-        let b = signed_packet_for_key(&keypair, 1, "b");
-        let (smaller, larger) = if a.encoded_packet() < b.encoded_packet() {
-            (a, b)
-        } else {
-            (b, a)
-        };
-
-        assert_eq!(
-            most_recent_packet(Some(larger.clone()), smaller.clone())
-                .unwrap()
-                .as_bytes(),
-            larger.as_bytes()
-        );
-
-        assert_eq!(
-            most_recent_packet(Some(smaller), larger.clone())
-                .unwrap()
-                .as_bytes(),
-            larger.as_bytes()
-        );
-    }
-
-    #[test]
-    fn most_recent_packet_uses_value_tie_breaker_for_same_timestamp() {
-        let keypair = Keypair::random();
-        let (smaller_value, larger_value) = (0..1000)
-            .find_map(|i| {
-                let a = signed_packet_for_key(&keypair, 1, &format!("a{i}"));
-                let b = signed_packet_for_key(&keypair, 1, &format!("b{i}"));
-
-                (a.encoded_packet().cmp(&b.encoded_packet()) != a.as_bytes().cmp(b.as_bytes()))
-                    .then(|| {
-                        if a.more_recent_than(&b) {
-                            (b, a)
-                        } else {
-                            (a, b)
-                        }
-                    })
-            })
-            .expect("test packet pair with conflicting signature and DNS value ordering");
-
-        assert_eq!(
-            most_recent_packet(Some(smaller_value), larger_value.clone())
-                .unwrap()
-                .encoded_packet(),
-            larger_value.encoded_packet()
-        );
-    }
+    use super::decrement;
+    use pkarr::Timestamp;
 
     #[test]
     fn zero_timestamp_has_no_dht_lower_bound() {

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -3,7 +3,7 @@ use axum::response::Html;
 use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
 use http::StatusCode;
-use pkarr::dht::MINIMUM_PUBLISH_STORED_NODES;
+use pkarr::dht::{ResolveReport, ResolveReportPolicy, MINIMUM_PUBLISH_STORED_NODES};
 use pkarr::mainline::errors::ConcurrencyError;
 use pkarr::{Cache, CacheKey, ResolvePolicy, SignedPacket, Timestamp};
 use serde::Deserialize;
@@ -39,7 +39,7 @@ pub async fn put(
 
     let stored_at = state.dht.publish(&signed_packet, cas).await?;
     if stored_at < MINIMUM_PUBLISH_STORED_NODES {
-        warn!(public_key = ?signed_packet.public_key(), stored_at, "suspicious DHT publish report");
+        warn!(public_key = ?signed_packet.public_key(), stored_at, "DHT publish completed with warnings");
     }
     update_cache_if_needed(&state, &key, &signed_packet);
 
@@ -72,38 +72,27 @@ pub async fn get(
             _ => {
                 enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
                 let result = state.dht.resolve(&public_key, more_recent_than).await?;
+                let packet = result.first().clone();
                 let state = state.clone();
                 // Do not waste late responses with potentially newer packets.
                 tokio::spawn(async move {
-                    let (packet, report) = result.completion.await;
-                    if report.is_suspicious() {
-                        warn!(
-                            ?public_key,
-                            suspicions = ?report.suspicions(),
-                            "suspicious DHT resolve report"
-                        );
-                    }
-                    update_cache_if_needed(&state, &key, &packet);
+                    let resolved = result.complete().await;
+                    log_resolve_warnings(&public_key, &resolved.report);
+                    update_cache_if_needed(&state, &key, &resolved.most_recent);
                 });
-                result.first
+                packet
             }
         },
         ResolvePolicy::DhtNetworkOnly => {
             enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-            let (packet, report) = state
+            let resolved = state
                 .dht
                 .resolve(&public_key, more_recent_than)
                 .await?
-                .completion
+                .complete()
                 .await;
-            if report.is_suspicious() {
-                warn!(
-                    ?public_key,
-                    suspicions = ?report.suspicions(),
-                    "suspicious DHT resolve report"
-                );
-            }
-            packet
+            log_resolve_warnings(&public_key, &resolved.report);
+            resolved.most_recent
         }
     };
 
@@ -237,6 +226,17 @@ fn update_cache_if_needed(state: &AppState, key: &CacheKey, signed_packet: &Sign
 
 fn decrement(timestamp: Timestamp) -> Option<Timestamp> {
     timestamp.as_u64().checked_sub(1).map(Timestamp::from)
+}
+
+fn log_resolve_warnings(public_key: &pkarr::PublicKey, report: &ResolveReport) {
+    let warnings = report.classify_warnings(ResolveReportPolicy::default());
+    if !warnings.is_empty() {
+        warn!(
+            ?public_key,
+            ?warnings,
+            "DHT resolve completed with warnings"
+        );
+    }
 }
 
 fn enforce_user_dht_rate_limit(

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -76,12 +76,12 @@ pub async fn get(
             Some(packet) if !packet.is_expired(state.minimum_ttl, state.maximum_ttl) => packet,
             _ => {
                 enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-                let result = state.dht.resolve(&public_key, more_recent_than).await?;
-                let packet = result.first().clone();
+                let response = state.dht.resolve(&public_key, more_recent_than).await?;
+                let packet = response.first().clone();
                 let state = state.clone();
                 // Do not waste late responses with potentially newer packets.
                 tokio::spawn(async move {
-                    let resolved = result.complete().await;
+                    let resolved = response.complete().await;
                     log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
                     if let ResolveValue::ValidSignedPacket { packet } = resolved.most_recent {
                         update_cache_if_needed(&state, &key, &packet);

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use anyhow::anyhow;
-use axum::{extract::DefaultBodyLimit, Router};
+use axum::{extract::DefaultBodyLimit, http::HeaderName, Router};
 use axum_server::Handle;
 
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
@@ -33,7 +33,7 @@ use tracing::info;
 use pkarr::{
     dht::{DhtClient, ReportPolicy},
     extra::lmdb_cache::LmdbCache,
-    mainline, Timestamp,
+    mainline, Timestamp, PKARR_INVALID_SIGNED_PACKET_SEQ,
 };
 use url::Url;
 
@@ -343,7 +343,7 @@ fn create_app(
         .route("/", axum::routing::get(crate::handlers::index))
         .with_state(state)
         .layer(DefaultBodyLimit::max(1104))
-        .layer(CorsLayer::very_permissive())
+        .layer(cors_layer())
         .layer(TraceLayer::new_for_http());
 
     if let Some(rate_limiter) = rate_limiter {
@@ -353,6 +353,14 @@ fn create_app(
     }
 
     router
+}
+
+fn cors_layer() -> CorsLayer {
+    let invalid_signed_packet_seq_header =
+        HeaderName::from_bytes(PKARR_INVALID_SIGNED_PACKET_SEQ.as_bytes())
+            .expect("Pkarr invalid signed packet seq header name is valid");
+
+    CorsLayer::very_permissive().expose_headers([invalid_signed_packet_seq_header])
 }
 
 fn to_socket_address_v4<T: ToSocketAddrs>(bootstrap: &[T]) -> Vec<SocketAddrV4> {
@@ -390,9 +398,37 @@ mod tests {
     use std::{net::Ipv4Addr, num::NonZeroU32, time::Duration};
 
     use http::StatusCode;
-    use pkarr::{Keypair, SignedPacket, Timestamp};
+    use pkarr::{Keypair, SignedPacket, Timestamp, PKARR_INVALID_SIGNED_PACKET_SEQ};
 
     use super::{to_socket_address_v4, RateLimiterConfig, Relay, RequestCountQuota};
+
+    #[tokio::test]
+    async fn cors_exposes_invalid_signed_packet_seq_header() {
+        let testnet = pkarr::mainline::Testnet::builder(2).build().unwrap();
+        let relay = run_rate_limited_relay(&testnet).await;
+
+        let response = reqwest::Client::new()
+            .get(relay.local_url())
+            .header("Origin", "https://example.com")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let exposed_headers = response
+            .headers()
+            .get("access-control-expose-headers")
+            .unwrap()
+            .to_str()
+            .unwrap();
+
+        assert!(exposed_headers.split(',').any(|header| header
+            .trim()
+            .eq_ignore_ascii_case(PKARR_INVALID_SIGNED_PACKET_SEQ)));
+
+        relay.shutdown();
+    }
 
     #[tokio::test]
     async fn user_dht_rate_limit_only_blocks_dht_operations() {

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -30,7 +30,11 @@ use axum_server::Handle;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 use tracing::info;
 
-use pkarr::{dht::DhtClient, extra::lmdb_cache::LmdbCache, mainline, Timestamp};
+use pkarr::{
+    dht::{DhtClient, ReportPolicy},
+    extra::lmdb_cache::LmdbCache,
+    mainline, Timestamp,
+};
 use url::Url;
 
 use config::{RelayConfig, CACHE_DIR};
@@ -42,6 +46,7 @@ pub use rate_limiting::RateLimiterConfig;
 pub struct RelayBuilder {
     config: RelayConfig,
     dht: mainline::Config,
+    report_policy: ReportPolicy,
 }
 
 impl RelayBuilder {
@@ -114,7 +119,7 @@ impl RelayBuilder {
     /// This method is marked as unsafe because it uses `LmdbCache`, which can lead to
     /// undefined behavior if the lock file is corrupted or improperly handled.
     pub async unsafe fn run(self) -> anyhow::Result<Relay> {
-        unsafe { Relay::run_with_dht(self.config, self.dht) }.await
+        unsafe { Relay::run_with_dht(self.config, self.dht, self.report_policy) }.await
     }
 }
 
@@ -142,12 +147,13 @@ impl Relay {
     async unsafe fn run(config: RelayConfig) -> anyhow::Result<Self> {
         let dht_config = mainline_config(&config);
 
-        unsafe { Self::run_with_dht(config, dht_config) }.await
+        unsafe { Self::run_with_dht(config, dht_config, ReportPolicy::mainnet()) }.await
     }
 
     async unsafe fn run_with_dht(
         config: RelayConfig,
         mut dht_config: mainline::Config,
+        report_policy: ReportPolicy,
     ) -> anyhow::Result<Self> {
         tracing::debug!(?config, "Pkarr server config");
 
@@ -209,6 +215,7 @@ impl Relay {
             cache,
             cache_write_lock: Arc::new(Mutex::new(())),
             user_dht_rate_limiter,
+            report_policy,
             dht,
         };
         let app = create_app(state, rate_limiter, behind_proxy);
@@ -232,6 +239,7 @@ impl Relay {
         RelayBuilder {
             config: Default::default(),
             dht: Default::default(),
+            report_policy: ReportPolicy::mainnet(),
         }
     }
 
@@ -267,7 +275,7 @@ impl Relay {
         dht_config.server_mode = true;
         dht_config.bind_address = Some(std::net::Ipv4Addr::LOCALHOST);
 
-        Ok(unsafe { Self::run_with_dht(config, dht_config).await? })
+        Ok(unsafe { Self::run_with_dht(config, dht_config, ReportPolicy::testnet()).await? })
     }
 
     /// Run a Pkarr relay in a Testnet mode (on port 15411).
@@ -295,7 +303,7 @@ impl Relay {
         dht_config.server_mode = true;
         dht_config.bind_address = Some(std::net::Ipv4Addr::LOCALHOST);
 
-        Self::run_with_dht(config, dht_config).await
+        Self::run_with_dht(config, dht_config, ReportPolicy::testnet()).await
     }
 
     /// Returns the HTTP socket address of the relay.
@@ -373,6 +381,7 @@ struct AppState {
     cache_write_lock: Arc<Mutex<()>>,
     // Rate limiter for DHT operations initiated by HTTP user requests.
     user_dht_rate_limiter: Option<rate_limiting::UserDhtRateLimiter>,
+    report_policy: ReportPolicy,
     dht: DhtClient,
 }
 

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -96,6 +96,15 @@ impl RelayBuilder {
         self
     }
 
+    /// Set the policy used to classify DHT query diagnostics.
+    ///
+    /// Defaults to [`ReportPolicy::mainnet`].
+    pub fn report_policy(&mut self, policy: ReportPolicy) -> &mut Self {
+        self.report_policy = policy;
+
+        self
+    }
+
     /// Allows mutating the internal [pkarr::mainline] DHT configuration.
     pub fn dht<F>(&mut self, f: F) -> &mut Self
     where


### PR DESCRIPTION
Add resolve diagnostics for mutable GET queries and return publish
storage counts from PUT queries so relays can report suspicious DHT
outcomes.

BREAKING CHANGE: DHT publish and resolve APIs now expose query report
data and return shapes changed accordingly.
