### PR TITLE
fix(relay): handle container shutdown signals

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   pkarr-relay:
     build: .
-    restart: unless-stopped
     
     # need both TCP and UDP
     ports:

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -41,11 +41,27 @@ async fn main() -> Result<()> {
         }
     };
 
-    tokio::signal::ctrl_c().await?;
+    shutdown_signal().await?;
 
     info!("shutdown");
 
     relay.shutdown();
 
     Ok(())
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() -> tokio::io::Result<()> {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut terminate = signal(SignalKind::terminate())?;
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => result,
+        _ = terminate.recv() => Ok(()),
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() -> tokio::io::Result<()> {
+    tokio::signal::ctrl_c().await
 }


### PR DESCRIPTION
Listen for SIGTERM in addition to Ctrl-C so Docker and Compose
shutdown requests stop the relay promptly.

Remove the Compose restart policy for local relay runs.
