### PR TITLE
fix(relays): use webpki-roots TLS for the relay HTTP client (Android verifier panic + revocation false-positives)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3217,6 +3218,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -82,6 +82,8 @@ page_size = { version = "0.6.0", optional = true }
 # feat: tls
 rustls = { workspace = true, optional = true }
 webpki = { package = "rustls-webpki", version = "0.103", optional = true }
+# feat: relays (native) — webpki/Mozilla root bundle for the relay HTTP client's TLS
+webpki-roots = { version = "1", optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.4.1", default-features = false, features = [
@@ -133,7 +135,10 @@ signed_packet = [
 ## Enable the [Client] with [mainline] support.
 dht = ["dep:mainline", "__client"]
 ## Enables [Client] with [Relays](https://github.com/pubky/pkarr/blob/main/design/relays.md).
-relays = ["dep:url", "dep:reqwest", "dep:futures-buffered", "__client"]
+# `dep:rustls`/`dep:webpki-roots` are native-only deps (see the `cfg(not(target_family =
+# "wasm"))` table); they give the relay HTTP client a webpki-roots TLS config and are
+# ignored on wasm, where the browser handles TLS.
+relays = ["dep:url", "dep:reqwest", "dep:futures-buffered", "dep:rustls", "dep:webpki-roots", "__client"]
 
 # Extra
 ## Use [LmdbCache][extra::lmdb_cache::LmdbCache] implementation.

--- a/pkarr/src/relay_client.rs
+++ b/pkarr/src/relay_client.rs
@@ -32,6 +32,42 @@ pub struct RelayClient {
     publish_timeout: Duration,
 }
 
+/// Build the reqwest client used to talk to a relay.
+///
+/// On native targets the relay's ICANN TLS is validated against the webpki/Mozilla root
+/// bundle WITHOUT certificate revocation checking. reqwest's default rustls config uses
+/// `rustls-platform-verifier`, which on Android (a) panics unless it is first handed the
+/// `JavaVM` + app `Context` before the first handshake, and (b) hard-fails revocation —
+/// with Let's Encrypt's sharded-CRL hierarchy this falsely rejects valid relay
+/// certificates on some devices ("invalid peer certificate: Revoked"). Browsers soft-fail
+/// revocation; this matches that behavior and needs no platform-specific initialization.
+#[cfg(not(wasm_browser))]
+fn build_relay_http_client() -> Result<Client, RelayError> {
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let mut tls_config = rustls::ClientConfig::builder_with_provider(
+        rustls::crypto::ring::default_provider().into(),
+    )
+    .with_safe_default_protocol_versions()
+    .expect("version supported by ring")
+    .with_root_certificates(root_store)
+    .with_no_client_auth();
+    tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+    Client::builder()
+        .use_preconfigured_tls(tls_config)
+        .build()
+        .map_err(|e| RelayError::Build(e.to_string()))
+}
+
+/// On WASM the browser performs TLS, so no rustls config is needed.
+#[cfg(wasm_browser)]
+fn build_relay_http_client() -> Result<Client, RelayError> {
+    Client::builder()
+        .build()
+        .map_err(|e| RelayError::Build(e.to_string()))
+}
+
 impl RelayClient {
     /// Build a client for one relay endpoint.
     ///
@@ -43,9 +79,7 @@ impl RelayClient {
         resolve_timeout: Duration,
         publish_timeout: Duration,
     ) -> Result<Self, RelayError> {
-        let client = Client::builder()
-            .build()
-            .map_err(|e| RelayError::Build(e.to_string()))?;
+        let client = build_relay_http_client()?;
         if base_url.cannot_be_a_base() {
             return Err(RelayError::Build(format!(
                 "Invalid base url of a relay: `{base_url}`"


### PR DESCRIPTION
## Summary

The per-relay HTTP client is built with reqwest's default rustls config, which is `rustls-platform-verifier` (`pkarr/src/relay_client.rs` — `RelayClient::new` previously did `Client::builder().build()`). On Android this causes two failures, and **neither is fixable by the consumer**, because the relay client accepts no TLS config:

1. **Panic without init.** `rustls-platform-verifier` must be handed the `JavaVM` + app `Context` before the first handshake, or it panics with `Expect rustls-platform-verifier to be initialized`. Consumers loading pkarr via uniffi/JNA (where `JNI_OnLoad` never fires) have to add a JNI shim purely to initialize this.
2. **Revocation false-positives.** The platform verifier hard-fails revocation on Android. With Let's Encrypt's newer sharded-CRL hierarchy, valid relay certs are falsely rejected on some devices with `invalid peer certificate: Revoked`.

Relays are enabled by default (`ClientBuilder::default()` → `DEFAULT_RELAYS`) and are the primary resolution path on mobile, where mainline DHT (UDP) is often unavailable — so this is on the hot path for many apps.

## Fix

Preconfigure the relay client (native only) with an explicit webpki/Mozilla-roots rustls config using the **ring** provider (matching the rest of pkarr's TLS code) and **no** revocation checking — matching browsers' soft-fail behavior and requiring no platform-specific initialization.

- `pkarr/src/relay_client.rs` — `build_relay_http_client()`, gated on `cfg(not(wasm_browser))`. WASM keeps the plain builder (the browser performs TLS).
- `pkarr/Cargo.toml` — adds a native-only optional `webpki-roots = "1"` dep and wires `dep:rustls`/`dep:webpki-roots` into the `relays` feature. Both are declared only under the `cfg(not(target_family = "wasm"))` dependency table, so they are ignored on wasm.

This also means apps no longer need the platform verifier (and its Android init dance) just to use relays.

## Testing

Verified to compile across the relevant matrix:

- `cargo check -p pkarr` (native, default `full-client`)
- `cargo check -p pkarr --no-default-features --features relays` (native, minimal)
- `cargo check -p pkarr --target wasm32-unknown-unknown --no-default-features --features relays` (wasm — confirms the native-only deps are ignored and no rustls is pulled)
- `cargo test -p pkarr --no-default-features --features relays --lib --no-run`

## Notes

- Companion fix in pubky-core for the same root cause on its own ICANN client: pubky/pubky-core#456.
- Alternative designs if you'd prefer: expose a builder hook to inject a custom relay `reqwest::Client`/`rustls::ClientConfig`, rather than hard-coding webpki-roots. Happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)