### PR TITLE
fix(resolve)!: tighten relay and DHT state handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/pkarr/src/client/builder.rs
+++ b/pkarr/src/client/builder.rs
@@ -13,7 +13,7 @@ use crate::{errors::BuildError, Client};
 pub const DEFAULT_MAX_RECURSION_DEPTH: u8 = 7;
 
 /// Default request timeout for DHT and relay requests.
-pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// [Client]'s Config
 #[derive(Clone)]
@@ -60,7 +60,7 @@ impl Default for Config {
             cache: None,
 
             #[cfg(dht)]
-            dht: Some(default_dht_config(DEFAULT_REQUEST_TIMEOUT)),
+            dht: Some(make_dht_config(DEFAULT_REQUEST_TIMEOUT)),
 
             #[cfg(feature = "relays")]
             relays: Some(
@@ -142,7 +142,7 @@ impl ClientBuilder {
         F: FnOnce(&mut mainline::Config) -> &mut mainline::Config,
     {
         if self.0.dht.is_none() {
-            self.0.dht = Some(default_dht_config(self.0.request_timeout));
+            self.0.dht = Some(make_dht_config(self.0.request_timeout));
         }
 
         if let Some(ref mut builder) = self.0.dht {
@@ -295,7 +295,7 @@ impl ClientBuilder {
 }
 
 #[cfg(dht)]
-fn default_dht_config(request_timeout: Duration) -> mainline::Config {
+fn make_dht_config(request_timeout: Duration) -> mainline::Config {
     mainline::Config {
         request_timeout,
         ..Default::default()

--- a/pkarr/src/client/builder.rs
+++ b/pkarr/src/client/builder.rs
@@ -12,10 +12,8 @@ use crate::{errors::BuildError, Client};
 #[cfg(feature = "endpoints")]
 pub const DEFAULT_MAX_RECURSION_DEPTH: u8 = 7;
 
-#[cfg(dht)]
-pub const DEFAULT_REQUEST_TIMEOUT: Duration = mainline::DEFAULT_REQUEST_TIMEOUT;
-#[cfg(not(dht))]
-pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+/// Default request timeout for DHT and relay requests.
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// [Client]'s Config
 #[derive(Clone)]
@@ -46,7 +44,7 @@ pub(crate) struct Config {
     ///
     /// The longer this timeout the longer resolve queries will take before consider failed.
     ///
-    /// Defaults to [DEFAULT_REQUEST_TIMEOUT]
+    /// Defaults to [DEFAULT_REQUEST_TIMEOUT].
     pub request_timeout: Duration,
 
     #[cfg(feature = "endpoints")]
@@ -62,7 +60,7 @@ impl Default for Config {
             cache: None,
 
             #[cfg(dht)]
-            dht: Some(mainline::Config::default()),
+            dht: Some(default_dht_config(DEFAULT_REQUEST_TIMEOUT)),
 
             #[cfg(feature = "relays")]
             relays: Some(
@@ -144,7 +142,7 @@ impl ClientBuilder {
         F: FnOnce(&mut mainline::Config) -> &mut mainline::Config,
     {
         if self.0.dht.is_none() {
-            self.0.dht = Some(Default::default());
+            self.0.dht = Some(default_dht_config(self.0.request_timeout));
         }
 
         if let Some(ref mut builder) = self.0.dht {
@@ -267,7 +265,7 @@ impl ClientBuilder {
     /// Set the maximum request timeout for both Dht and relays client.
     ///
     /// Useful for testing NOT FOUND responses, where you want to reach the timeout
-    /// sooner than the default of [mainline::DEFAULT_REQUEST_TIMEOUT].
+    /// sooner than the default of [DEFAULT_REQUEST_TIMEOUT].
     pub fn request_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.0.request_timeout = timeout;
         #[cfg(dht)]
@@ -293,6 +291,14 @@ impl ClientBuilder {
     /// Try building a [Client] with the configuration in this builder.
     pub fn build(&self) -> Result<Client, BuildError> {
         Client::new(self.0.clone())
+    }
+}
+
+#[cfg(dht)]
+fn default_dht_config(request_timeout: Duration) -> mainline::Config {
+    mainline::Config {
+        request_timeout,
+        ..Default::default()
     }
 }
 
@@ -342,4 +348,40 @@ pub enum InvalidRelayUrl {
     #[error("Relays Urls should have `http` or `https`: {0}")]
     /// Relays Urls should have `http` or `https`.
     NotHttp(String),
+}
+
+#[cfg(all(test, dht))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_dht_timeout_matches_client_timeout() {
+        let config = Config::default();
+        let dht_config = config
+            .dht
+            .as_ref()
+            .expect("dht should be enabled by default");
+
+        assert_eq!(config.request_timeout, DEFAULT_REQUEST_TIMEOUT);
+        assert_eq!(dht_config.request_timeout, DEFAULT_REQUEST_TIMEOUT);
+    }
+
+    #[test]
+    fn recreated_dht_config_uses_current_client_timeout() {
+        let timeout = Duration::from_secs(5);
+        let mut builder = Client::builder();
+
+        builder
+            .request_timeout(timeout)
+            .no_dht()
+            .dht(|config| config);
+
+        let dht_config = builder
+            .0
+            .dht
+            .as_ref()
+            .expect("dht config should be recreated");
+
+        assert_eq!(dht_config.request_timeout, timeout);
+    }
 }

--- a/pkarr/src/client/relays.rs
+++ b/pkarr/src/client/relays.rs
@@ -43,15 +43,13 @@ impl Debug for RelaysClient {
 impl RelaysClient {
     pub fn new(relays: Box<[Url]>, timeout: Duration) -> Result<Self, RelayError> {
         let inflight_publish = InflightPublishRequests::new(relays.len());
-        let resolve_timeout = timeout;
-        // Publish combines HTTP latency with the relay-side DHT PUT query.
-        let publish_timeout = resolve_timeout
-            .checked_mul(3)
-            .ok_or_else(|| RelayError::Build("publish timeout overflow".to_string()))?;
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|e| RelayError::Build(e.to_string()))?;
         let relays = relays
             .into_vec()
             .into_iter()
-            .map(|url| RelayClient::new(url, resolve_timeout, publish_timeout))
+            .map(|url| RelayClient::new(url, client.clone(), timeout))
             .collect::<Result<Vec<_>, _>>()?
             .into_boxed_slice();
 
@@ -138,7 +136,8 @@ impl RelaysClient {
                     )
                     .await
                 {
-                    Ok(signed_packet) => signed_packet,
+                    Ok(signed_packet) => Some(signed_packet),
+                    Err(RelayError::NotFound) => None,
                     Err(error) => {
                         cross_debug!("GET {} {:?}", relay.base_url(), error);
                         None
@@ -327,6 +326,7 @@ fn map_relay_error(error: RelayError) -> PublishError {
         | RelayError::InvalidSignedPacketSeq { .. }
         | RelayError::InvalidSignedPacketSeqHeader
         | RelayError::InvalidHeader(_)
+        | RelayError::NotFound
         | RelayError::UnexpectedStatus(_) => PublishError::UnexpectedResponses,
     }
 }

--- a/pkarr/src/client/tests.rs
+++ b/pkarr/src/client/tests.rs
@@ -40,7 +40,7 @@ pub(crate) fn builder(
     if std::env::var("CI").is_ok() {
         builder.request_timeout(Duration::from_millis(1000));
     } else {
-        builder.request_timeout(Duration::from_millis(200));
+        builder.request_timeout(Duration::from_millis(500));
     }
 
     match networks {

--- a/pkarr/src/lib.rs
+++ b/pkarr/src/lib.rs
@@ -37,7 +37,10 @@ pub use client::blocking::ClientBlocking;
 #[cfg(client)]
 pub use client::cache::{Cache, CacheKey, InMemoryCache};
 #[cfg(client)]
-pub use client::{builder::ClientBuilder, Client};
+pub use client::{
+    builder::{ClientBuilder, DEFAULT_REQUEST_TIMEOUT},
+    Client,
+};
 pub use types::*;
 
 // Rexports

--- a/pkarr/src/relay_client.rs
+++ b/pkarr/src/relay_client.rs
@@ -28,24 +28,20 @@ macro_rules! debug {
 pub struct RelayClient {
     base_url: Url,
     client: Client,
-    resolve_timeout: Duration,
-    publish_timeout: Duration,
+    timeout: Duration,
 }
 
 impl RelayClient {
-    /// Build a client for one relay endpoint.
+    /// Build a client for one relay endpoint using a [`reqwest::Client`].
+    ///
+    /// The `timeout` is applied to each relay request individually. This keeps
+    /// timeout behavior available on WASM targets, where reqwest does not
+    /// expose client-wide timeout configuration.
     ///
     /// # Errors
     ///
-    /// Returns an error if the underlying HTTP client cannot be built.
-    pub fn new(
-        base_url: Url,
-        resolve_timeout: Duration,
-        publish_timeout: Duration,
-    ) -> Result<Self, RelayError> {
-        let client = Client::builder()
-            .build()
-            .map_err(|e| RelayError::Build(e.to_string()))?;
+    /// Returns an error if `base_url` is not a valid relay base URL.
+    pub fn new(base_url: Url, client: Client, timeout: Duration) -> Result<Self, RelayError> {
         if base_url.cannot_be_a_base() {
             return Err(RelayError::Build(format!(
                 "Invalid base url of a relay: `{base_url}`"
@@ -55,8 +51,7 @@ impl RelayClient {
         Ok(Self {
             base_url,
             client,
-            resolve_timeout,
-            publish_timeout,
+            timeout,
         })
     }
 
@@ -81,7 +76,7 @@ impl RelayClient {
         let mut request = self
             .client
             .put(url.clone())
-            .timeout(self.publish_timeout)
+            .timeout(self.timeout)
             .body(packet.to_relay_payload());
 
         if let Some(cas) = cas {
@@ -107,14 +102,15 @@ impl RelayClient {
     /// # Errors
     ///
     /// Returns an error when the relay request fails, the response body is too
-    /// large, the returned relay payload does not verify, or the relay reports
-    /// a newer DHT mutable item that is not a valid signed packet.
+    /// large, the relay has no matching packet, the returned relay payload does
+    /// not verify, or the relay reports a newer DHT mutable item that is not a
+    /// valid signed packet.
     pub async fn resolve(
         &self,
         key: &PublicKey,
         policy: ResolvePolicy,
         newer_than: Option<Timestamp>,
-    ) -> Result<Option<SignedPacket>, RelayError> {
+    ) -> Result<SignedPacket, RelayError> {
         let url = self.build_url(key, Some(policy));
 
         let mut response = self
@@ -132,14 +128,18 @@ impl RelayClient {
         let status = response.status();
         if status == StatusCode::NOT_FOUND {
             if let Some(seq) = extract_invalid_signed_packet_seq(&response)? {
+                if invalid_seq_is_not_newer_than_request(seq, newer_than.as_ref()) {
+                    return Err(RelayError::NotFound);
+                }
+
                 return Err(RelayError::InvalidSignedPacketSeq { seq });
             }
 
-            return Ok(None);
+            return Err(RelayError::NotFound);
         }
 
         if status == StatusCode::NOT_MODIFIED {
-            return Ok(None);
+            return Err(RelayError::NotFound);
         }
 
         if status.is_client_error() || status.is_server_error() {
@@ -159,7 +159,11 @@ impl RelayClient {
             signed_packet.set_last_seen(&last_seen);
         }
 
-        Ok(Some(signed_packet))
+        if newer_than.is_some_and(|newer_than| signed_packet.timestamp() < newer_than) {
+            return Err(RelayError::NotFound);
+        }
+
+        Ok(signed_packet)
     }
 
     async fn send_resolve_request(
@@ -168,7 +172,7 @@ impl RelayClient {
         newer_than: Option<&Timestamp>,
         bypass_cache: bool,
     ) -> Result<Response, RelayError> {
-        let mut request = self.client.get(url.clone()).timeout(self.resolve_timeout);
+        let mut request = self.client.get(url.clone()).timeout(self.timeout);
 
         if let Some(newer_than) = newer_than {
             let newer_than = newer_than.format_http_date();
@@ -270,6 +274,10 @@ pub enum RelayError {
     /// Relay returned an unexpected status code.
     #[error("relay returned unexpected status code {0}")]
     UnexpectedStatus(StatusCode),
+
+    /// Relay found no signed packet.
+    #[error("relay found no signed packet")]
+    NotFound,
 }
 
 impl RelayError {
@@ -316,6 +324,14 @@ fn extract_invalid_signed_packet_seq(response: &Response) -> Result<Option<i64>,
                 .ok_or(RelayError::InvalidSignedPacketSeqHeader)
         })
         .transpose()
+}
+
+fn invalid_seq_is_not_newer_than_request(seq: i64, newer_than: Option<&Timestamp>) -> bool {
+    let Some(newer_than) = newer_than else {
+        return false;
+    };
+
+    seq >= 0 && seq as u64 <= newer_than.as_u64()
 }
 
 fn should_retry_with_cache_bypass(response: &Response, newer_than: Option<&Timestamp>) -> bool {
@@ -368,6 +384,7 @@ mod tests {
         atomic::{AtomicBool, Ordering},
         Arc,
     };
+    use std::time::Duration;
 
     use axum::{
         http::{HeaderMap, StatusCode as HttpStatusCode},
@@ -382,6 +399,11 @@ mod tests {
     use crate::Keypair;
 
     const TIMEOUT: Duration = Duration::from_secs(1);
+
+    fn test_client(base_url: Url) -> RelayClient {
+        let client = Client::builder().build().unwrap();
+        RelayClient::new(base_url, client, TIMEOUT).unwrap()
+    }
 
     #[test]
     fn relay_503_status_maps_to_dht_unavailable() {
@@ -400,24 +422,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_returns_none_on_not_found() {
+    async fn resolve_returns_not_found_on_not_found() {
         let keypair = Keypair::random();
         let app = Router::new().route(
             &format!("/{}", keypair.public_key()),
             get(|| async { HttpStatusCode::NOT_FOUND }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
-        let resolved = client
+        let error = client
             .resolve(
                 &keypair.public_key(),
                 ResolvePolicy::LocalOrRelayCacheOnly,
                 None,
             )
             .await
-            .unwrap();
+            .unwrap_err();
 
-        assert!(resolved.is_none());
+        assert!(matches!(error, RelayError::NotFound));
     }
 
     #[tokio::test]
@@ -432,7 +454,7 @@ mod tests {
                 )
             }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
         let error = client
             .resolve(
@@ -450,6 +472,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_maps_invalid_signed_packet_seq_at_request_bound_to_not_found() {
+        let keypair = Keypair::random();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get(|| async {
+                (
+                    HttpStatusCode::NOT_FOUND,
+                    [(PKARR_INVALID_SIGNED_PACKET_SEQ, "41")],
+                )
+            }),
+        );
+        let client = test_client(serve(app).await);
+
+        let error = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::CacheFirst,
+                Some(Timestamp::from(41)),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, RelayError::NotFound));
+    }
+
+    #[tokio::test]
+    async fn resolve_reports_invalid_signed_packet_seq_newer_than_request_bound() {
+        let keypair = Keypair::random();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get(|| async {
+                (
+                    HttpStatusCode::NOT_FOUND,
+                    [(PKARR_INVALID_SIGNED_PACKET_SEQ, "43")],
+                )
+            }),
+        );
+        let client = test_client(serve(app).await);
+
+        let error = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::CacheFirst,
+                Some(Timestamp::from(41)),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RelayError::InvalidSignedPacketSeq { seq: 43 }
+        ));
+    }
+
+    #[tokio::test]
     async fn resolve_rejects_malformed_invalid_signed_packet_seq_header() {
         let keypair = Keypair::random();
         let app = Router::new().route(
@@ -461,7 +538,7 @@ mod tests {
                 )
             }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
         let error = client
             .resolve(
@@ -476,24 +553,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_returns_none_on_not_modified() {
+    async fn resolve_returns_not_found_on_not_modified() {
         let keypair = Keypair::random();
         let app = Router::new().route(
             &format!("/{}", keypair.public_key()),
             get(|| async { HttpStatusCode::NOT_MODIFIED }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
-        let resolved = client
+        let error = client
             .resolve(
                 &keypair.public_key(),
                 ResolvePolicy::LocalOrRelayCacheOnly,
                 Some(Timestamp::now()),
             )
             .await
-            .unwrap();
+            .unwrap_err();
 
-        assert!(resolved.is_none());
+        assert!(matches!(error, RelayError::NotFound));
     }
 
     #[tokio::test]
@@ -520,7 +597,7 @@ mod tests {
                 }
             }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
         let resolved = client
             .resolve(
@@ -529,7 +606,6 @@ mod tests {
                 None,
             )
             .await
-            .unwrap()
             .unwrap();
 
         assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
@@ -559,7 +635,7 @@ mod tests {
                 }
             }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
         let resolved = client
             .resolve(
@@ -568,7 +644,6 @@ mod tests {
                 None,
             )
             .await
-            .unwrap()
             .unwrap();
 
         assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
@@ -581,7 +656,7 @@ mod tests {
             &format!("/{}", keypair.public_key()),
             get(|| async { vec![0; SignedPacket::MAX_BYTES as usize + 1] }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
         let error = client
             .resolve(
@@ -609,7 +684,7 @@ mod tests {
             &format!("/{}", keypair.public_key()),
             get(|| async { vec![0; 1] }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
         let error = client
             .resolve(
@@ -646,7 +721,7 @@ mod tests {
 
         let base_url = serve(app).await;
 
-        let client = RelayClient::new(base_url, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(base_url);
         let resolved = client
             .resolve(
                 &keypair.public_key(),
@@ -654,7 +729,6 @@ mod tests {
                 None,
             )
             .await
-            .unwrap()
             .unwrap();
 
         assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
@@ -677,7 +751,7 @@ mod tests {
                 }
             }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
         let resolved = client
             .resolve(
@@ -686,7 +760,6 @@ mod tests {
                 None,
             )
             .await
-            .unwrap()
             .unwrap();
 
         assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
@@ -716,7 +789,7 @@ mod tests {
                 }
             }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
         let resolved = client
             .resolve(
@@ -725,7 +798,6 @@ mod tests {
                 None,
             )
             .await
-            .unwrap()
             .unwrap();
 
         assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
@@ -748,7 +820,7 @@ mod tests {
                 }
             }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
         let resolved = client
             .resolve(
@@ -757,7 +829,39 @@ mod tests {
                 None,
             )
             .await
-            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn resolve_accepts_packet_with_same_timestamp_as_lower_bound() {
+        let keypair = Keypair::random();
+        let signed_packet = SignedPacket::builder()
+            .timestamp(Timestamp::from(42))
+            .sign(&keypair)
+            .unwrap();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            get({
+                let payload = signed_packet.to_relay_payload();
+
+                move || {
+                    let payload = payload.clone();
+
+                    async move { payload }
+                }
+            }),
+        );
+        let client = test_client(serve(app).await);
+
+        let resolved = client
+            .resolve(
+                &keypair.public_key(),
+                ResolvePolicy::CacheFirst,
+                Some(signed_packet.timestamp()),
+            )
+            .await
             .unwrap();
 
         assert_eq!(resolved.as_bytes(), signed_packet.as_bytes());
@@ -783,7 +887,7 @@ mod tests {
             }
         });
 
-        let client = RelayClient::new(https_url, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(https_url);
         let keypair = Keypair::random();
         let err = client
             .resolve(
@@ -805,7 +909,7 @@ mod tests {
             &format!("/{}", keypair.public_key()),
             get(move || async move { status }),
         );
-        let client = RelayClient::new(serve(app).await, TIMEOUT, TIMEOUT).unwrap();
+        let client = test_client(serve(app).await);
 
         client
             .resolve(

--- a/pkarr/src/types/resolve_policy.rs
+++ b/pkarr/src/types/resolve_policy.rs
@@ -19,18 +19,18 @@ pub enum ResolvePolicy {
     /// Useful for republishing.
     LocalOrRelayCacheOnly,
 
-    /// Use the cache (local or relay) if the packet is available and is within the TTL.
-    /// Query the DHT nodes on a cache miss. Use the first DHT response to
-    /// guarantee a fast response.
-    /// May return an outdated packet in edge cases.
+    /// Resolve with the fastest fresh answer without going backward.
     ///
-    /// When a cached packet is expired and the DHT is queried, the cached
-    /// sequence is still used as a floor: older DHT packets are not returned,
-    /// and invalid DHT mutable items at or below the cached sequence are
-    /// treated as stale.
+    /// Returns a cached packet when it is still within TTL. Otherwise queries
+    /// the DHT and returns the first acceptable result.
     ///
-    /// This is guaranteed to return only packets that are not expired.
-    /// Useful for normal application resolution while respecting TTLs.
+    /// If an expired cached packet exists, its sequence is used as a floor:
+    /// older DHT packets, and invalid DHT mutable items at or below that
+    /// sequence, are treated as stale rather than returned.
+    ///
+    /// This is the default policy for normal application resolution. It never
+    /// returns expired packets, but it may miss a newer DHT value because it
+    /// stops at the first acceptable response.
     CacheFirst,
 
     /// Query all relevant DHT nodes for the most recent value observed and

--- a/pkarr/src/types/resolve_policy.rs
+++ b/pkarr/src/types/resolve_policy.rs
@@ -39,8 +39,7 @@ pub enum ResolvePolicy {
     ///
     /// This policy ignores cached packets while querying and interpreting the
     /// DHT result. If the DHT currently contains an older valid packet than the
-    /// cache, that older packet is returned. If it contains an older invalid
-    /// mutable item, that invalid sequence is reported.
+    /// cache, that older packet is returned.
     ///
     /// This is guaranteed to return the newest valid signed packet, or the sequence
     /// number of a newer mutable item that is not a valid signed packet.

--- a/pkarr/src/types/resolve_policy.rs
+++ b/pkarr/src/types/resolve_policy.rs
@@ -8,6 +8,9 @@ use serde::{Deserialize, Serialize};
 /// Controls whether resolution may use only cached packets,
 /// prefer cached packets before querying the DHT, or bypass cached reads and
 /// query the DHT network directly.
+///
+/// Caches store valid `SignedPacket`s. Invalid DHT mutable items are reported
+/// by sequence number, but are not stored in the packet cache.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ResolvePolicy {
     /// Return only a locally cached or relay-cached packet, even if expired.
@@ -21,6 +24,11 @@ pub enum ResolvePolicy {
     /// guarantee a fast response.
     /// May return an outdated packet in edge cases.
     ///
+    /// When a cached packet is expired and the DHT is queried, the cached
+    /// sequence is still used as a floor: older DHT packets are not returned,
+    /// and invalid DHT mutable items at or below the cached sequence are
+    /// treated as stale.
+    ///
     /// This is guaranteed to return only packets that are not expired.
     /// Useful for normal application resolution while respecting TTLs.
     CacheFirst,
@@ -28,6 +36,11 @@ pub enum ResolvePolicy {
     /// Query all relevant DHT nodes for the most recent value observed and
     /// update the cache when that value contains a valid signed packet.
     /// This is slower, but more accurate.
+    ///
+    /// This policy ignores cached packets while querying and interpreting the
+    /// DHT result. If the DHT currently contains an older valid packet than the
+    /// cache, that older packet is returned. If it contains an older invalid
+    /// mutable item, that invalid sequence is reported.
     ///
     /// This is guaranteed to return the newest valid signed packet, or the sequence
     /// number of a newer mutable item that is not a valid signed packet.

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -3,7 +3,7 @@ use axum::response::Html;
 use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
 use http::StatusCode;
-use pkarr::dht::{ReportPolicy, ResolveReport};
+use pkarr::dht::{ReportPolicy, ResolveError as DhtResolveError, ResolveReport};
 use pkarr::mainline::errors::ConcurrencyError;
 use pkarr::{Cache, CacheKey, ResolvePolicy, SignedPacket, Timestamp};
 use serde::Deserialize;
@@ -61,23 +61,32 @@ pub async fn get(
     let key = CacheKey::from(&public_key);
 
     let policy = query.policy.unwrap_or(ResolvePolicy::CacheFirst);
-    let cached_packet = state.cache.get_read_only(&key);
-    let more_recent_than = cached_packet
+    let cached = state.cache.get(&key);
+    let more_recent_than = cached
         .as_ref()
         .map(SignedPacket::timestamp)
         .and_then(decrement);
 
-    let packet = match policy {
-        ResolvePolicy::LocalOrRelayCacheOnly => match cached_packet {
-            Some(packet) => packet,
-            None => return Err(Error::with_status(StatusCode::NOT_FOUND)),
-        },
-        ResolvePolicy::CacheFirst => match cached_packet {
-            Some(packet) if !packet.is_expired(state.minimum_ttl, state.maximum_ttl) => packet,
-            _ => {
-                enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-                let response = state.dht.resolve(&public_key, more_recent_than).await;
-                if let Some(packet) = response.first().cloned() {
+    let packet = match (policy, cached.as_ref()) {
+        (ResolvePolicy::LocalOrRelayCacheOnly, Some(packet)) => packet.clone(),
+        (ResolvePolicy::LocalOrRelayCacheOnly, None) => {
+            return Err(Error::with_status(StatusCode::NOT_FOUND));
+        }
+        (ResolvePolicy::CacheFirst, Some(packet))
+            if !packet.is_expired(state.minimum_ttl, state.maximum_ttl) =>
+        {
+            packet.clone()
+        }
+        (ResolvePolicy::CacheFirst, _) => {
+            enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
+            let response = state.dht.resolve(&public_key, more_recent_than).await;
+            let first_packet = response
+                .first()
+                .cloned()
+                .map(|packet| apply_cached_floor(Ok(packet), cached.as_ref()));
+
+            match first_packet {
+                Some(Ok(packet)) => {
                     let state = state.clone();
                     // Do not waste late responses with potentially newer packets.
                     tokio::spawn(async move {
@@ -88,21 +97,20 @@ pub async fn get(
                         }
                     });
                     packet
-                } else {
+                }
+                Some(Err(DhtResolveError::NotFound)) | None => {
                     let resolved = response.complete().await;
                     log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
-                    resolved.most_recent?
+                    apply_cached_floor(resolved.most_recent, cached.as_ref())?
                 }
+                Some(Err(error)) => return Err(error.into()),
             }
-        },
-        ResolvePolicy::DhtNetworkOnly => {
+        }
+        (ResolvePolicy::DhtNetworkOnly, _) => {
             enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-            let resolved = state
-                .dht
-                .resolve(&public_key, more_recent_than)
-                .await
-                .complete()
-                .await;
+            // DhtNetworkOnly reports the DHT's current state without using the
+            // relay cache as a lower bound or as invalid-sequence suppression.
+            let resolved = state.dht.resolve(&public_key, None).await.complete().await;
             log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
             resolved.most_recent?
         }
@@ -236,6 +244,26 @@ fn update_cache_if_needed(state: &AppState, key: &CacheKey, signed_packet: &Sign
     }
 }
 
+fn apply_cached_floor(
+    result: Result<SignedPacket, DhtResolveError>,
+    cached: Option<&SignedPacket>,
+) -> Result<SignedPacket, DhtResolveError> {
+    let Some(cached) = cached else {
+        return result;
+    };
+
+    match result {
+        Ok(packet) if cached.more_recent_than(&packet) => Err(DhtResolveError::NotFound),
+        Ok(packet) => Ok(packet),
+        Err(DhtResolveError::InvalidSignedPacket { seq })
+            if u64::try_from(seq).is_ok_and(|seq| cached.timestamp().as_u64() >= seq) =>
+        {
+            Err(DhtResolveError::NotFound)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 fn decrement(timestamp: Timestamp) -> Option<Timestamp> {
     timestamp.as_u64().checked_sub(1).map(Timestamp::from)
 }
@@ -275,12 +303,97 @@ fn enforce_user_dht_rate_limit(
 
 #[cfg(test)]
 mod tests {
-    use super::decrement;
-    use pkarr::Timestamp;
+    use super::{apply_cached_floor, decrement};
+    use crate::error::Error;
+    use axum::response::IntoResponse;
+    use http::StatusCode;
+    use pkarr::{dht::ResolveError, Keypair, SignedPacket, Timestamp};
 
     #[test]
     fn zero_timestamp_has_no_dht_lower_bound() {
         assert_eq!(decrement(Timestamp::from(0)), None);
         assert_eq!(decrement(Timestamp::from(1)), Some(Timestamp::from(0)));
+    }
+
+    #[test]
+    fn cached_packet_suppresses_invalid_seq_that_is_not_newer() {
+        let cached = SignedPacket::builder()
+            .timestamp(Timestamp::from(10))
+            .sign(&Keypair::random())
+            .unwrap();
+
+        let response = Error::from(
+            apply_cached_floor(
+                Err(ResolveError::InvalidSignedPacket { seq: 10 }),
+                Some(&cached),
+            )
+            .unwrap_err(),
+        )
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(!response
+            .headers()
+            .contains_key(pkarr::PKARR_INVALID_SIGNED_PACKET_SEQ));
+    }
+
+    #[test]
+    fn newer_invalid_seq_is_reported() {
+        let cached = SignedPacket::builder()
+            .timestamp(Timestamp::from(10))
+            .sign(&Keypair::random())
+            .unwrap();
+
+        let response = Error::from(
+            apply_cached_floor(
+                Err(ResolveError::InvalidSignedPacket { seq: 11 }),
+                Some(&cached),
+            )
+            .unwrap_err(),
+        )
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(response
+            .headers()
+            .contains_key(pkarr::PKARR_INVALID_SIGNED_PACKET_SEQ));
+    }
+
+    #[test]
+    fn cached_packet_suppresses_older_packet_with_same_timestamp() {
+        let keypair = Keypair::random();
+        let a = SignedPacket::builder()
+            .timestamp(Timestamp::from(10))
+            .txt("key".try_into().unwrap(), "a".try_into().unwrap(), 30)
+            .sign(&keypair)
+            .unwrap();
+        let b = SignedPacket::builder()
+            .timestamp(Timestamp::from(10))
+            .txt("key".try_into().unwrap(), "b".try_into().unwrap(), 30)
+            .sign(&keypair)
+            .unwrap();
+        let (cached, older) = if a.more_recent_than(&b) {
+            (a, b)
+        } else {
+            (b, a)
+        };
+
+        let result = apply_cached_floor(Ok(older), Some(&cached));
+
+        assert!(matches!(result, Err(ResolveError::NotFound)));
+    }
+
+    #[test]
+    fn invalid_seq_without_cached_floor_is_reported() {
+        let response = Error::from(
+            apply_cached_floor(Err(ResolveError::InvalidSignedPacket { seq: 10 }), None)
+                .unwrap_err(),
+        )
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(response
+            .headers()
+            .contains_key(pkarr::PKARR_INVALID_SIGNED_PACKET_SEQ));
     }
 }

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -3,7 +3,7 @@ use axum::response::Html;
 use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
 use http::StatusCode;
-use pkarr::dht::{ReportPolicy, ResolveError as DhtResolveError, ResolveReport};
+use pkarr::dht::{ReportPolicy, ResolveError as DhtResolveError, ResolveReport, ResolveResponse};
 use pkarr::mainline::errors::ConcurrencyError;
 use pkarr::{Cache, CacheKey, ResolvePolicy, SignedPacket, Timestamp};
 use serde::Deserialize;
@@ -22,6 +22,7 @@ pub async fn put(
     real_ip: Option<Extension<RealIp>>,
     body: Bytes,
 ) -> Result<impl IntoResponse, Error> {
+    let real_ip = real_ip.as_ref().map(|extension| &extension.0);
     let signed_packet = pkarr::SignedPacket::from_relay_payload(&public_key, &body)
         .map_err(|error| Error::new(StatusCode::BAD_REQUEST, error))?;
 
@@ -35,7 +36,7 @@ pub async fn put(
         }
     }
 
-    enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
+    enforce_user_dht_rate_limit(&state, real_ip)?;
 
     let stored_at = state.dht.publish(&signed_packet, cas).await?;
     let warnings = state.report_policy.classify_publish_result(stored_at);
@@ -58,63 +59,11 @@ pub async fn get(
     real_ip: Option<Extension<RealIp>>,
     IfModifiedSince(if_modified_since): IfModifiedSince,
 ) -> Result<SignedPacketResponse, Error> {
+    let real_ip = real_ip.as_ref().map(|extension| &extension.0);
     let key = CacheKey::from(&public_key);
 
     let policy = query.policy.unwrap_or(ResolvePolicy::CacheFirst);
-    let cached = state.cache.get(&key);
-    let more_recent_than = cached
-        .as_ref()
-        .map(SignedPacket::timestamp)
-        .and_then(decrement);
-
-    let packet = match (policy, cached.as_ref()) {
-        (ResolvePolicy::LocalOrRelayCacheOnly, Some(packet)) => packet.clone(),
-        (ResolvePolicy::LocalOrRelayCacheOnly, None) => {
-            return Err(Error::with_status(StatusCode::NOT_FOUND));
-        }
-        (ResolvePolicy::CacheFirst, Some(packet))
-            if !packet.is_expired(state.minimum_ttl, state.maximum_ttl) =>
-        {
-            packet.clone()
-        }
-        (ResolvePolicy::CacheFirst, _) => {
-            enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-            let response = state.dht.resolve(&public_key, more_recent_than).await;
-            let first_packet = response
-                .first()
-                .cloned()
-                .map(|packet| apply_cached_floor(Ok(packet), cached.as_ref()));
-
-            match first_packet {
-                Some(Ok(packet)) => {
-                    let state = state.clone();
-                    // Do not waste late responses with potentially newer packets.
-                    tokio::spawn(async move {
-                        let resolved = response.complete().await;
-                        log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
-                        if let Ok(packet) = resolved.most_recent {
-                            update_cache_if_needed(&state, &key, &packet);
-                        }
-                    });
-                    packet
-                }
-                Some(Err(DhtResolveError::NotFound)) | None => {
-                    let resolved = response.complete().await;
-                    log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
-                    apply_cached_floor(resolved.most_recent, cached.as_ref())?
-                }
-                Some(Err(error)) => return Err(error.into()),
-            }
-        }
-        (ResolvePolicy::DhtNetworkOnly, _) => {
-            enforce_user_dht_rate_limit(&state, real_ip.as_ref())?;
-            // DhtNetworkOnly reports the DHT's current state without using the
-            // relay cache as a lower bound or as invalid-sequence suppression.
-            let resolved = state.dht.resolve(&public_key, None).await.complete().await;
-            log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
-            resolved.most_recent?
-        }
-    };
+    let packet = resolve_packet(&state, &public_key, key, policy, real_ip).await?;
 
     update_cache_if_needed(&state, &key, &packet);
     let ttl = packet.ttl(state.minimum_ttl, state.maximum_ttl);
@@ -127,7 +76,7 @@ pub(crate) struct GetQuery {
 }
 
 pub async fn index(State(state): State<AppState>) -> Result<impl IntoResponse, Error> {
-    let cache = state.cache;
+    let cache = &state.cache;
 
     let size = cache.len();
     let capacity = cache.capacity();
@@ -244,6 +193,96 @@ fn update_cache_if_needed(state: &AppState, key: &CacheKey, signed_packet: &Sign
     }
 }
 
+async fn resolve_packet(
+    state: &AppState,
+    public_key: &pkarr::PublicKey,
+    key: CacheKey,
+    policy: ResolvePolicy,
+    real_ip: Option<&RealIp>,
+) -> Result<SignedPacket, Error> {
+    let cached = state.cache.get(&key);
+
+    match policy {
+        ResolvePolicy::LocalOrRelayCacheOnly => {
+            cached.ok_or_else(|| Error::with_status(StatusCode::NOT_FOUND))
+        }
+        ResolvePolicy::CacheFirst => {
+            resolve_cache_first(state, public_key, key, cached.as_ref(), real_ip).await
+        }
+        ResolvePolicy::DhtNetworkOnly => resolve_dht_network_only(state, public_key, real_ip).await,
+    }
+}
+
+async fn resolve_cache_first(
+    state: &AppState,
+    public_key: &pkarr::PublicKey,
+    key: CacheKey,
+    cached: Option<&SignedPacket>,
+    real_ip: Option<&RealIp>,
+) -> Result<SignedPacket, Error> {
+    if let Some(packet) = cached {
+        if !packet.is_expired(state.minimum_ttl, state.maximum_ttl) {
+            return Ok(packet.clone());
+        }
+    }
+
+    let more_recent_than = cached.map(SignedPacket::timestamp).and_then(decrement);
+    enforce_user_dht_rate_limit(state, real_ip)?;
+    let response = state.dht.resolve(public_key, more_recent_than).await;
+
+    resolve_cache_first_dht_response(state, public_key, key, cached, response).await
+}
+
+async fn resolve_cache_first_dht_response(
+    state: &AppState,
+    public_key: &pkarr::PublicKey,
+    key: CacheKey,
+    cached: Option<&SignedPacket>,
+    response: ResolveResponse,
+) -> Result<SignedPacket, Error> {
+    let first_packet = response
+        .first()
+        .cloned()
+        .map(|packet| apply_cached_floor(Ok(packet), cached));
+
+    match first_packet {
+        Some(Ok(packet)) => {
+            let state = state.clone();
+            let public_key = public_key.clone();
+            // Do not waste late responses with potentially newer packets.
+            tokio::spawn(async move {
+                let resolved = response.complete().await;
+                log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
+                if let Ok(packet) = resolved.most_recent {
+                    update_cache_if_needed(&state, &key, &packet);
+                }
+            });
+            Ok(packet)
+        }
+        Some(Err(DhtResolveError::NotFound)) | None => {
+            let resolved = response.complete().await;
+            log_resolve_warnings(public_key, &resolved.report, state.report_policy);
+            apply_cached_floor(resolved.most_recent, cached).map_err(Error::from)
+        }
+        Some(Err(error)) => Err(error.into()),
+    }
+}
+
+async fn resolve_dht_network_only(
+    state: &AppState,
+    public_key: &pkarr::PublicKey,
+    real_ip: Option<&RealIp>,
+) -> Result<SignedPacket, Error> {
+    enforce_user_dht_rate_limit(state, real_ip)?;
+
+    // DhtNetworkOnly reports the DHT's current state without using the relay
+    // cache as a lower bound or as invalid-sequence suppression.
+    let resolved = state.dht.resolve(public_key, None).await.complete().await;
+    log_resolve_warnings(public_key, &resolved.report, state.report_policy);
+
+    Ok(resolved.most_recent?)
+}
+
 fn apply_cached_floor(
     result: Result<SignedPacket, DhtResolveError>,
     cached: Option<&SignedPacket>,
@@ -284,12 +323,8 @@ fn log_resolve_warnings(
 }
 
 #[allow(clippy::result_large_err)]
-fn enforce_user_dht_rate_limit(
-    state: &AppState,
-    real_ip: Option<&Extension<RealIp>>,
-) -> Result<(), Error> {
-    if let (Some(rate_limiter), Some(Extension(real_ip))) = (&state.user_dht_rate_limiter, real_ip)
-    {
+fn enforce_user_dht_rate_limit(state: &AppState, real_ip: Option<&RealIp>) -> Result<(), Error> {
+    if let (Some(rate_limiter), Some(real_ip)) = (&state.user_dht_rate_limiter, real_ip) {
         if rate_limiter.is_limited(&real_ip.0) {
             return Err(Error::new(
                 StatusCode::TOO_MANY_REQUESTS,


### PR DESCRIPTION
Return RelayError::NotFound for missing or unchanged relay resolves
while keeping higher-level relay streams treating missing relay responses
as absent packets.

Use cached valid packets as a floor for CacheFirst DHT results, but let
DhtNetworkOnly report the DHT state without cache suppression.

Use a shared reqwest client for relay HTTP requests and apply
DEFAULT_REQUEST_TIMEOUT to both relay and default DHT request configs.

BREAKING CHANGE: RelayClient::new now accepts a reqwest::Client, and
RelayClient::resolve returns Result<SignedPacket, RelayError> instead of
Result<Option<SignedPacket>, RelayError>.
