### PR TITLE
build(relay): set default run binary to pkarr-relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 edition = "2021"
 description = "Pkarr relay (https://github.com/pubky/pkarr/blob/main/design/relays.md)"
+default-run = "pkarr-relay"
 license = "MIT"
 homepage = "https://pkdns.net"
 repository = "https://github.com/pubky/pkarr"


### PR DESCRIPTION
Configure Cargo to run the pkarr-relay binary by default when
invoking `cargo run`.
