### PR TITLE
refactor(relay): split DHT service and index rendering

### DIFF
--- a/relay/src/dht_service.rs
+++ b/relay/src/dht_service.rs
@@ -1,0 +1,377 @@
+use std::sync::{Arc, Mutex};
+
+use http::StatusCode;
+use pkarr::dht::{
+    DhtClient, DhtInfo, ReportPolicy, ResolveError as DhtResolveError, ResolveReport,
+    ResolveResponse,
+};
+use pkarr::extra::lmdb_cache::LmdbCache;
+use pkarr::mainline::errors::ConcurrencyError;
+use pkarr::{Cache, CacheKey, PublicKey, ResolvePolicy, SignedPacket, Timestamp};
+use tracing::warn;
+
+use crate::error::Error;
+use crate::rate_limiting::UserDhtRateLimiter;
+use crate::real_ip::RealIp;
+
+/// Cache-aware DHT service used by relay handlers.
+#[derive(Debug, Clone)]
+pub(crate) struct DhtService {
+    minimum_ttl: u32,
+    maximum_ttl: u32,
+    cache: Arc<LmdbCache>,
+    cache_write_lock: Arc<Mutex<()>>,
+    dht: DhtClient,
+    report_policy: ReportPolicy,
+    rate_limiter: Option<UserDhtRateLimiter>,
+}
+
+impl DhtService {
+    /// Create a cache-aware DHT service.
+    pub(crate) fn new(
+        minimum_ttl: u32,
+        maximum_ttl: u32,
+        cache: Arc<LmdbCache>,
+        dht: DhtClient,
+        report_policy: ReportPolicy,
+        rate_limiter: Option<UserDhtRateLimiter>,
+    ) -> Self {
+        Self {
+            minimum_ttl,
+            maximum_ttl,
+            cache,
+            cache_write_lock: Arc::new(Mutex::new(())),
+            dht,
+            report_policy,
+            rate_limiter,
+        }
+    }
+
+    /// Publish a signed packet through the DHT and update the relay cache.
+    pub(crate) async fn publish(
+        &self,
+        public_key: &PublicKey,
+        signed_packet: &SignedPacket,
+        cas: Option<Timestamp>,
+        real_ip: Option<&RealIp>,
+    ) -> Result<(), Error> {
+        let key = CacheKey::from(public_key);
+        if let Some(cached) = self.cache.get_read_only(&key) {
+            if cached.more_recent_than(signed_packet) {
+                return Err(Error::new(
+                    StatusCode::CONFLICT,
+                    ConcurrencyError::NotMostRecent,
+                ));
+            }
+        }
+
+        self.enforce_user_dht_rate_limit(real_ip)?;
+
+        let stored_at = self.dht.publish(signed_packet, cas).await?;
+        let warnings = self.report_policy.classify_publish_result(stored_at);
+        if !warnings.is_empty() {
+            warn!(
+                ?public_key,
+                ?warnings,
+                "DHT publish completed with warnings"
+            );
+        }
+
+        self.update_cache_if_needed(&key, signed_packet);
+
+        Ok(())
+    }
+
+    /// Resolve a packet using relay cache and DHT policy semantics.
+    pub(crate) async fn resolve_packet(
+        &self,
+        public_key: &PublicKey,
+        policy: ResolvePolicy,
+        real_ip: Option<&RealIp>,
+    ) -> Result<SignedPacket, Error> {
+        let key = CacheKey::from(public_key);
+        let cached = self.cache.get(&key);
+
+        let packet = match policy {
+            ResolvePolicy::LocalOrRelayCacheOnly => {
+                cached.ok_or_else(|| Error::with_status(StatusCode::NOT_FOUND))
+            }
+            ResolvePolicy::CacheFirst => {
+                self.resolve_cache_first(public_key, key, cached.as_ref(), real_ip)
+                    .await
+            }
+            ResolvePolicy::DhtNetworkOnly => {
+                self.resolve_dht_network_only(public_key, real_ip).await
+            }
+        }?;
+
+        self.update_cache_if_needed(&key, &packet);
+        Ok(packet)
+    }
+
+    /// Return cache size and capacity.
+    pub(crate) fn cache_stats(&self) -> CacheStats {
+        CacheStats {
+            size: self.cache.len(),
+            capacity: self.cache.capacity(),
+        }
+    }
+
+    /// Return the relay TTL for a signed packet.
+    pub(crate) fn ttl(&self, packet: &SignedPacket) -> u32 {
+        packet.ttl(self.minimum_ttl, self.maximum_ttl)
+    }
+
+    /// Return information about the underlying DHT node.
+    pub(crate) async fn info(&self) -> DhtInfo {
+        self.dht.info().await
+    }
+
+    async fn resolve_cache_first(
+        &self,
+        public_key: &PublicKey,
+        key: CacheKey,
+        cached: Option<&SignedPacket>,
+        real_ip: Option<&RealIp>,
+    ) -> Result<SignedPacket, Error> {
+        if let Some(packet) = cached {
+            if !packet.is_expired(self.minimum_ttl, self.maximum_ttl) {
+                return Ok(packet.clone());
+            }
+        }
+
+        let more_recent_than = cached.map(SignedPacket::timestamp).and_then(decrement);
+        self.enforce_user_dht_rate_limit(real_ip)?;
+
+        let response = self.dht.resolve(public_key, more_recent_than).await;
+
+        self.resolve_cache_first_dht_response(public_key, key, cached, response)
+            .await
+    }
+
+    async fn resolve_cache_first_dht_response(
+        &self,
+        public_key: &PublicKey,
+        key: CacheKey,
+        cached: Option<&SignedPacket>,
+        response: ResolveResponse,
+    ) -> Result<SignedPacket, Error> {
+        let first_packet = response
+            .first()
+            .cloned()
+            .map(|packet| apply_cached_floor(Ok(packet), cached));
+
+        match first_packet {
+            Some(Ok(packet)) => {
+                let service = self.clone();
+                let public_key = public_key.clone();
+                // Do not waste late responses with potentially newer packets.
+                tokio::spawn(async move {
+                    let resolved = response.complete().await;
+                    service.log_resolve_warnings(&public_key, &resolved.report);
+                    if let Ok(packet) = resolved.most_recent {
+                        service.update_cache_if_needed(&key, &packet);
+                    }
+                });
+                Ok(packet)
+            }
+            Some(Err(DhtResolveError::NotFound)) | None => {
+                let resolved = response.complete().await;
+                self.log_resolve_warnings(public_key, &resolved.report);
+                apply_cached_floor(resolved.most_recent, cached).map_err(Error::from)
+            }
+            Some(Err(error)) => Err(error.into()),
+        }
+    }
+
+    async fn resolve_dht_network_only(
+        &self,
+        public_key: &PublicKey,
+        real_ip: Option<&RealIp>,
+    ) -> Result<SignedPacket, Error> {
+        // DhtNetworkOnly reports the DHT's current state without using the relay
+        // cache as a lower bound or as invalid-sequence suppression.
+        self.enforce_user_dht_rate_limit(real_ip)?;
+
+        let resolved = self.dht.resolve(public_key, None).await.complete().await;
+        self.log_resolve_warnings(public_key, &resolved.report);
+
+        Ok(resolved.most_recent?)
+    }
+
+    fn log_resolve_warnings(&self, public_key: &PublicKey, report: &ResolveReport) {
+        let warnings = self.report_policy.classify_resolve_report(report);
+        if !warnings.is_empty() {
+            warn!(
+                ?public_key,
+                ?warnings,
+                "DHT resolve completed with warnings"
+            );
+        }
+    }
+
+    fn update_cache_if_needed(&self, key: &CacheKey, signed_packet: &SignedPacket) {
+        let _lock = self
+            .cache_write_lock
+            .lock()
+            .expect("DhtService cache_write_lock");
+
+        let should_update = match self.cache.get_read_only(key) {
+            None => true,
+            Some(cached) if signed_packet.more_recent_than(&cached) => true,
+            Some(cached) if signed_packet.is_same_as(&cached) => {
+                // The packet is the same but we refresh the last seen.
+                signed_packet.last_seen() > cached.last_seen()
+            }
+            _ => false,
+        };
+
+        if should_update {
+            self.cache.put(key, signed_packet);
+        }
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn enforce_user_dht_rate_limit(&self, real_ip: Option<&RealIp>) -> Result<(), Error> {
+        if let (Some(rate_limiter), Some(real_ip)) = (&self.rate_limiter, real_ip) {
+            if rate_limiter.is_limited(&real_ip.0) {
+                return Err(Error::new(
+                    StatusCode::TOO_MANY_REQUESTS,
+                    "Too many requests to DHT nodes",
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Cache size metrics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CacheStats {
+    /// Number of packets in the cache.
+    pub(crate) size: usize,
+    /// Maximum cache capacity.
+    pub(crate) capacity: usize,
+}
+
+fn apply_cached_floor(
+    result: Result<SignedPacket, DhtResolveError>,
+    cached: Option<&SignedPacket>,
+) -> Result<SignedPacket, DhtResolveError> {
+    let Some(cached) = cached else {
+        return result;
+    };
+
+    match result {
+        Ok(packet) if cached.more_recent_than(&packet) => Err(DhtResolveError::NotFound),
+        Ok(packet) => Ok(packet),
+        Err(DhtResolveError::InvalidSignedPacket { seq })
+            if u64::try_from(seq).is_ok_and(|seq| cached.timestamp().as_u64() >= seq) =>
+        {
+            Err(DhtResolveError::NotFound)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn decrement(timestamp: Timestamp) -> Option<Timestamp> {
+    timestamp.as_u64().checked_sub(1).map(Timestamp::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_cached_floor, decrement};
+    use crate::error::Error;
+    use axum::response::IntoResponse;
+    use http::StatusCode;
+    use pkarr::{dht::ResolveError, Keypair, SignedPacket, Timestamp};
+
+    #[test]
+    fn zero_timestamp_has_no_dht_lower_bound() {
+        assert_eq!(decrement(Timestamp::from(0)), None);
+        assert_eq!(decrement(Timestamp::from(1)), Some(Timestamp::from(0)));
+    }
+
+    #[test]
+    fn cached_packet_suppresses_invalid_seq_that_is_not_newer() {
+        let cached = SignedPacket::builder()
+            .timestamp(Timestamp::from(10))
+            .sign(&Keypair::random())
+            .unwrap();
+
+        let response = Error::from(
+            apply_cached_floor(
+                Err(ResolveError::InvalidSignedPacket { seq: 10 }),
+                Some(&cached),
+            )
+            .unwrap_err(),
+        )
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(!response
+            .headers()
+            .contains_key(pkarr::PKARR_INVALID_SIGNED_PACKET_SEQ));
+    }
+
+    #[test]
+    fn newer_invalid_seq_is_reported() {
+        let cached = SignedPacket::builder()
+            .timestamp(Timestamp::from(10))
+            .sign(&Keypair::random())
+            .unwrap();
+
+        let response = Error::from(
+            apply_cached_floor(
+                Err(ResolveError::InvalidSignedPacket { seq: 11 }),
+                Some(&cached),
+            )
+            .unwrap_err(),
+        )
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(response
+            .headers()
+            .contains_key(pkarr::PKARR_INVALID_SIGNED_PACKET_SEQ));
+    }
+
+    #[test]
+    fn cached_packet_suppresses_older_packet_with_same_timestamp() {
+        let keypair = Keypair::random();
+        let a = SignedPacket::builder()
+            .timestamp(Timestamp::from(10))
+            .txt("key".try_into().unwrap(), "a".try_into().unwrap(), 30)
+            .sign(&keypair)
+            .unwrap();
+        let b = SignedPacket::builder()
+            .timestamp(Timestamp::from(10))
+            .txt("key".try_into().unwrap(), "b".try_into().unwrap(), 30)
+            .sign(&keypair)
+            .unwrap();
+        let (cached, older) = if a.more_recent_than(&b) {
+            (a, b)
+        } else {
+            (b, a)
+        };
+
+        let result = apply_cached_floor(Ok(older), Some(&cached));
+
+        assert!(matches!(result, Err(ResolveError::NotFound)));
+    }
+
+    #[test]
+    fn invalid_seq_without_cached_floor_is_reported() {
+        let response = Error::from(
+            apply_cached_floor(Err(ResolveError::InvalidSignedPacket { seq: 10 }), None)
+                .unwrap_err(),
+        )
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert!(response
+            .headers()
+            .contains_key(pkarr::PKARR_INVALID_SIGNED_PACKET_SEQ));
+    }
+}

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -1,13 +1,9 @@
-use axum::extract::{Extension, Path, Query};
+use axum::extract::{Extension, Path, Query, State};
 use axum::response::Html;
-use axum::{extract::State, response::IntoResponse};
 use bytes::Bytes;
 use http::StatusCode;
-use pkarr::dht::{ReportPolicy, ResolveError as DhtResolveError, ResolveReport, ResolveResponse};
-use pkarr::mainline::errors::ConcurrencyError;
-use pkarr::{Cache, CacheKey, ResolvePolicy, SignedPacket, Timestamp};
+use pkarr::{ResolvePolicy, SignedPacket};
 use serde::Deserialize;
-use tracing::warn;
 
 use crate::error::Error;
 use crate::extractors::{IfMatch, IfModifiedSince, PublicKeyParam};
@@ -21,33 +17,14 @@ pub async fn put(
     IfMatch(cas): IfMatch,
     real_ip: Option<Extension<RealIp>>,
     body: Bytes,
-) -> Result<impl IntoResponse, Error> {
+) -> Result<StatusCode, Error> {
     let real_ip = real_ip.as_ref().map(|extension| &extension.0);
-    let signed_packet = pkarr::SignedPacket::from_relay_payload(&public_key, &body)
+    let signed_packet = SignedPacket::from_relay_payload(&public_key, &body)
         .map_err(|error| Error::new(StatusCode::BAD_REQUEST, error))?;
-
-    let key = CacheKey::from(&public_key);
-    if let Some(cached) = state.cache.get_read_only(&key) {
-        if cached.more_recent_than(&signed_packet) {
-            return Err(Error::new(
-                StatusCode::CONFLICT,
-                ConcurrencyError::NotMostRecent,
-            ));
-        }
-    }
-
-    enforce_user_dht_rate_limit(&state, real_ip)?;
-
-    let stored_at = state.dht.publish(&signed_packet, cas).await?;
-    let warnings = state.report_policy.classify_publish_result(stored_at);
-    if !warnings.is_empty() {
-        warn!(
-            ?public_key,
-            ?warnings,
-            "DHT publish completed with warnings"
-        );
-    }
-    update_cache_if_needed(&state, &key, &signed_packet);
+    state
+        .dht
+        .publish(&public_key, &signed_packet, cas, real_ip)
+        .await?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -60,13 +37,13 @@ pub async fn get(
     IfModifiedSince(if_modified_since): IfModifiedSince,
 ) -> Result<SignedPacketResponse, Error> {
     let real_ip = real_ip.as_ref().map(|extension| &extension.0);
-    let key = CacheKey::from(&public_key);
-
     let policy = query.policy.unwrap_or(ResolvePolicy::CacheFirst);
-    let packet = resolve_packet(&state, &public_key, key, policy, real_ip).await?;
+    let packet = state
+        .dht
+        .resolve_packet(&public_key, policy, real_ip)
+        .await?;
+    let ttl = state.dht.ttl(&packet);
 
-    update_cache_if_needed(&state, &key, &packet);
-    let ttl = packet.ttl(state.minimum_ttl, state.maximum_ttl);
     Ok(SignedPacketResponse::new(packet, ttl, if_modified_since))
 }
 
@@ -75,360 +52,6 @@ pub(crate) struct GetQuery {
     policy: Option<ResolvePolicy>,
 }
 
-pub async fn index(State(state): State<AppState>) -> Result<impl IntoResponse, Error> {
-    let cache = &state.cache;
-
-    let size = cache.len();
-    let capacity = cache.capacity();
-    let utilization = 100.0 * size as f32 / capacity as f32;
-
-    let info = state.dht.info().await;
-
-    let html_content = format!(
-        r#"<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pkarr Relay</title>
-    <style>
-        body {{
-            background-color: black;
-            color: white;
-            font-family: monospace;
-            margin: 20px;
-        }}
-        pre {{
-            margin: 0;
-        }}
-        a {{
-            color: white;
-        }}
-    </style>
-</head>
-<body>
-    <h1>Pkarr Relay</h1>
-    <p>This server is a <a href="https://github.com/pubky/pkarr/">Pkarr</a> <a href="https://github.com/pubky/pkarr/blob/main/design/relays.md">relay</a>.</p>
-
-    <h2>Versioning</h2>
-    <pre>
-    version : {version}
-    </pre>
-
-    <h2>Cache stats</h2>
-    <pre>
-    size:       : {size}
-    capacity:   : {capacity}
-    utilization : {utilization:.2}%
-    </pre>
-
-    <h2>Dht Info</h2>
-    <pre>
-    node port         : {node_port}
-    node firewalled   : {firewalled}
-    dht size estimate : {dht_size} Nodes ±{confidence:.2}%
-    </pre>
-</body>
-</html>"#,
-        version = env!("CARGO_PKG_VERSION"),
-        size = format_number(size),
-        capacity = format_number(capacity),
-        utilization = utilization,
-        confidence = info.dht_size_estimate().1,
-        dht_size = format_number(info.dht_size_estimate().0),
-        node_port = info
-            .public_address()
-            .map(|addr| addr.port())
-            .unwrap_or(info.local_addr().port()),
-        firewalled = info.firewalled(),
-    );
-
-    Ok(Html(html_content))
-}
-
-fn format_number(num: usize) -> String {
-    // Handle large numbers and format with suffixes
-    if num >= 1_000_000_000 {
-        return format!("{:.1}B", num as f64 / 1_000_000_000.0);
-    } else if num >= 1_000_000 {
-        return format!("{:.1}M", num as f64 / 1_000_000.0);
-    } else if num >= 1_000 {
-        return format!("{:.1}K", num as f64 / 1_000.0);
-    }
-
-    // Format with commas for thousands
-    let num_str = num.to_string();
-    let mut result = String::new();
-    let len = num_str.len();
-
-    for (i, c) in num_str.chars().enumerate() {
-        // Add a comma before every three digits, except for the first part
-        if i > 0 && (len - i) % 3 == 0 {
-            result.push(',');
-        }
-        result.push(c);
-    }
-
-    result
-}
-
-fn update_cache_if_needed(state: &AppState, key: &CacheKey, signed_packet: &SignedPacket) {
-    let _lock = state
-        .cache_write_lock
-        .lock()
-        .expect("AppState cache_write_lock");
-
-    let should_update = match state.cache.get_read_only(key) {
-        None => true,
-        Some(cached) if signed_packet.more_recent_than(&cached) => true,
-        Some(cached) if signed_packet.is_same_as(&cached) => {
-            // The packet is the same but we refresh the last seen.
-            signed_packet.last_seen() > cached.last_seen()
-        }
-        _ => false,
-    };
-
-    if should_update {
-        state.cache.put(key, signed_packet);
-    }
-}
-
-async fn resolve_packet(
-    state: &AppState,
-    public_key: &pkarr::PublicKey,
-    key: CacheKey,
-    policy: ResolvePolicy,
-    real_ip: Option<&RealIp>,
-) -> Result<SignedPacket, Error> {
-    let cached = state.cache.get(&key);
-
-    match policy {
-        ResolvePolicy::LocalOrRelayCacheOnly => {
-            cached.ok_or_else(|| Error::with_status(StatusCode::NOT_FOUND))
-        }
-        ResolvePolicy::CacheFirst => {
-            resolve_cache_first(state, public_key, key, cached.as_ref(), real_ip).await
-        }
-        ResolvePolicy::DhtNetworkOnly => resolve_dht_network_only(state, public_key, real_ip).await,
-    }
-}
-
-async fn resolve_cache_first(
-    state: &AppState,
-    public_key: &pkarr::PublicKey,
-    key: CacheKey,
-    cached: Option<&SignedPacket>,
-    real_ip: Option<&RealIp>,
-) -> Result<SignedPacket, Error> {
-    if let Some(packet) = cached {
-        if !packet.is_expired(state.minimum_ttl, state.maximum_ttl) {
-            return Ok(packet.clone());
-        }
-    }
-
-    let more_recent_than = cached.map(SignedPacket::timestamp).and_then(decrement);
-    enforce_user_dht_rate_limit(state, real_ip)?;
-    let response = state.dht.resolve(public_key, more_recent_than).await;
-
-    resolve_cache_first_dht_response(state, public_key, key, cached, response).await
-}
-
-async fn resolve_cache_first_dht_response(
-    state: &AppState,
-    public_key: &pkarr::PublicKey,
-    key: CacheKey,
-    cached: Option<&SignedPacket>,
-    response: ResolveResponse,
-) -> Result<SignedPacket, Error> {
-    let first_packet = response
-        .first()
-        .cloned()
-        .map(|packet| apply_cached_floor(Ok(packet), cached));
-
-    match first_packet {
-        Some(Ok(packet)) => {
-            let state = state.clone();
-            let public_key = public_key.clone();
-            // Do not waste late responses with potentially newer packets.
-            tokio::spawn(async move {
-                let resolved = response.complete().await;
-                log_resolve_warnings(&public_key, &resolved.report, state.report_policy);
-                if let Ok(packet) = resolved.most_recent {
-                    update_cache_if_needed(&state, &key, &packet);
-                }
-            });
-            Ok(packet)
-        }
-        Some(Err(DhtResolveError::NotFound)) | None => {
-            let resolved = response.complete().await;
-            log_resolve_warnings(public_key, &resolved.report, state.report_policy);
-            apply_cached_floor(resolved.most_recent, cached).map_err(Error::from)
-        }
-        Some(Err(error)) => Err(error.into()),
-    }
-}
-
-async fn resolve_dht_network_only(
-    state: &AppState,
-    public_key: &pkarr::PublicKey,
-    real_ip: Option<&RealIp>,
-) -> Result<SignedPacket, Error> {
-    enforce_user_dht_rate_limit(state, real_ip)?;
-
-    // DhtNetworkOnly reports the DHT's current state without using the relay
-    // cache as a lower bound or as invalid-sequence suppression.
-    let resolved = state.dht.resolve(public_key, None).await.complete().await;
-    log_resolve_warnings(public_key, &resolved.report, state.report_policy);
-
-    Ok(resolved.most_recent?)
-}
-
-fn apply_cached_floor(
-    result: Result<SignedPacket, DhtResolveError>,
-    cached: Option<&SignedPacket>,
-) -> Result<SignedPacket, DhtResolveError> {
-    let Some(cached) = cached else {
-        return result;
-    };
-
-    match result {
-        Ok(packet) if cached.more_recent_than(&packet) => Err(DhtResolveError::NotFound),
-        Ok(packet) => Ok(packet),
-        Err(DhtResolveError::InvalidSignedPacket { seq })
-            if u64::try_from(seq).is_ok_and(|seq| cached.timestamp().as_u64() >= seq) =>
-        {
-            Err(DhtResolveError::NotFound)
-        }
-        Err(error) => Err(error),
-    }
-}
-
-fn decrement(timestamp: Timestamp) -> Option<Timestamp> {
-    timestamp.as_u64().checked_sub(1).map(Timestamp::from)
-}
-
-fn log_resolve_warnings(
-    public_key: &pkarr::PublicKey,
-    report: &ResolveReport,
-    policy: ReportPolicy,
-) {
-    let warnings = policy.classify_resolve_report(report);
-    if !warnings.is_empty() {
-        warn!(
-            ?public_key,
-            ?warnings,
-            "DHT resolve completed with warnings"
-        );
-    }
-}
-
-#[allow(clippy::result_large_err)]
-fn enforce_user_dht_rate_limit(state: &AppState, real_ip: Option<&RealIp>) -> Result<(), Error> {
-    if let (Some(rate_limiter), Some(real_ip)) = (&state.user_dht_rate_limiter, real_ip) {
-        if rate_limiter.is_limited(&real_ip.0) {
-            return Err(Error::new(
-                StatusCode::TOO_MANY_REQUESTS,
-                "Too many requests to DHT nodes",
-            ));
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{apply_cached_floor, decrement};
-    use crate::error::Error;
-    use axum::response::IntoResponse;
-    use http::StatusCode;
-    use pkarr::{dht::ResolveError, Keypair, SignedPacket, Timestamp};
-
-    #[test]
-    fn zero_timestamp_has_no_dht_lower_bound() {
-        assert_eq!(decrement(Timestamp::from(0)), None);
-        assert_eq!(decrement(Timestamp::from(1)), Some(Timestamp::from(0)));
-    }
-
-    #[test]
-    fn cached_packet_suppresses_invalid_seq_that_is_not_newer() {
-        let cached = SignedPacket::builder()
-            .timestamp(Timestamp::from(10))
-            .sign(&Keypair::random())
-            .unwrap();
-
-        let response = Error::from(
-            apply_cached_floor(
-                Err(ResolveError::InvalidSignedPacket { seq: 10 }),
-                Some(&cached),
-            )
-            .unwrap_err(),
-        )
-        .into_response();
-
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-        assert!(!response
-            .headers()
-            .contains_key(pkarr::PKARR_INVALID_SIGNED_PACKET_SEQ));
-    }
-
-    #[test]
-    fn newer_invalid_seq_is_reported() {
-        let cached = SignedPacket::builder()
-            .timestamp(Timestamp::from(10))
-            .sign(&Keypair::random())
-            .unwrap();
-
-        let response = Error::from(
-            apply_cached_floor(
-                Err(ResolveError::InvalidSignedPacket { seq: 11 }),
-                Some(&cached),
-            )
-            .unwrap_err(),
-        )
-        .into_response();
-
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-        assert!(response
-            .headers()
-            .contains_key(pkarr::PKARR_INVALID_SIGNED_PACKET_SEQ));
-    }
-
-    #[test]
-    fn cached_packet_suppresses_older_packet_with_same_timestamp() {
-        let keypair = Keypair::random();
-        let a = SignedPacket::builder()
-            .timestamp(Timestamp::from(10))
-            .txt("key".try_into().unwrap(), "a".try_into().unwrap(), 30)
-            .sign(&keypair)
-            .unwrap();
-        let b = SignedPacket::builder()
-            .timestamp(Timestamp::from(10))
-            .txt("key".try_into().unwrap(), "b".try_into().unwrap(), 30)
-            .sign(&keypair)
-            .unwrap();
-        let (cached, older) = if a.more_recent_than(&b) {
-            (a, b)
-        } else {
-            (b, a)
-        };
-
-        let result = apply_cached_floor(Ok(older), Some(&cached));
-
-        assert!(matches!(result, Err(ResolveError::NotFound)));
-    }
-
-    #[test]
-    fn invalid_seq_without_cached_floor_is_reported() {
-        let response = Error::from(
-            apply_cached_floor(Err(ResolveError::InvalidSignedPacket { seq: 10 }), None)
-                .unwrap_err(),
-        )
-        .into_response();
-
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-        assert!(response
-            .headers()
-            .contains_key(pkarr::PKARR_INVALID_SIGNED_PACKET_SEQ));
-    }
+pub async fn index(State(state): State<AppState>) -> Html<String> {
+    crate::index::render(&state).await
 }

--- a/relay/src/index.html
+++ b/relay/src/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pkarr Relay</title>
+    <style>
+        body {
+            background-color: black;
+            color: white;
+            font-family: monospace;
+            margin: 20px;
+        }
+        pre {
+            margin: 0;
+        }
+        a {
+            color: white;
+        }
+    </style>
+</head>
+<body>
+    <h1>Pkarr Relay</h1>
+    <p>This server is a <a href="https://github.com/pubky/pkarr/">Pkarr</a> <a href="https://github.com/pubky/pkarr/blob/main/design/relays.md">relay</a>.</p>
+
+    <h2>Versioning</h2>
+    <pre>
+    version : __VERSION__
+    </pre>
+
+    <h2>Cache stats</h2>
+    <pre>
+    size:       : __CACHE_SIZE__
+    capacity:   : __CACHE_CAPACITY__
+    utilization : __CACHE_UTILIZATION__%
+    </pre>
+
+    <h2>Dht Info</h2>
+    <pre>
+    node port         : __NODE_PORT__
+    node firewalled   : __NODE_FIREWALLED__
+    dht size estimate : __DHT_SIZE__ Nodes +/-__DHT_CONFIDENCE__%
+    </pre>
+</body>
+</html>

--- a/relay/src/index.rs
+++ b/relay/src/index.rs
@@ -1,0 +1,56 @@
+use axum::response::Html;
+
+use crate::AppState;
+
+const TEMPLATE: &str = include_str!("index.html");
+
+/// Render the relay index page.
+pub(crate) async fn render(state: &AppState) -> Html<String> {
+    let cache = state.dht.cache_stats();
+
+    let size = cache.size;
+    let capacity = cache.capacity;
+    let utilization = 100.0 * size as f32 / capacity as f32;
+
+    let info = state.dht.info().await;
+
+    let (dht_size, confidence) = info.dht_size_estimate();
+    let node_port = info
+        .public_address()
+        .map(|addr| addr.port())
+        .unwrap_or(info.local_addr().port());
+    let html_content = TEMPLATE
+        .replace("__VERSION__", env!("CARGO_PKG_VERSION"))
+        .replace("__CACHE_SIZE__", &format_number(size))
+        .replace("__CACHE_CAPACITY__", &format_number(capacity))
+        .replace("__CACHE_UTILIZATION__", &format!("{utilization:.2}"))
+        .replace("__NODE_PORT__", &node_port.to_string())
+        .replace("__NODE_FIREWALLED__", &info.firewalled().to_string())
+        .replace("__DHT_SIZE__", &format_number(dht_size))
+        .replace("__DHT_CONFIDENCE__", &format!("{confidence:.2}"));
+
+    Html(html_content)
+}
+
+fn format_number(num: usize) -> String {
+    if num >= 1_000_000_000 {
+        return format!("{:.1}B", num as f64 / 1_000_000_000.0);
+    } else if num >= 1_000_000 {
+        return format!("{:.1}M", num as f64 / 1_000_000.0);
+    } else if num >= 1_000 {
+        return format!("{:.1}K", num as f64 / 1_000.0);
+    }
+
+    let num_str = num.to_string();
+    let mut result = String::new();
+    let len = num_str.len();
+
+    for (i, c) in num_str.chars().enumerate() {
+        if i > 0 && (len - i) % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+
+    result
+}

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -8,9 +8,11 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
 mod config;
+mod dht_service;
 mod error;
 mod extractors;
 mod handlers;
+mod index;
 mod quota_config;
 mod rate_limiting;
 mod real_ip;
@@ -19,7 +21,7 @@ mod response;
 use std::{
     net::{SocketAddr, SocketAddrV4, TcpListener, ToSocketAddrs},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::Duration,
 };
 
@@ -38,6 +40,7 @@ use pkarr::{
 use url::Url;
 
 use config::{RelayConfig, CACHE_DIR};
+use dht_service::DhtService;
 
 pub use quota_config::{RequestCountQuota, TimeUnit};
 pub use rate_limiting::RateLimiterConfig;
@@ -177,57 +180,33 @@ impl Relay {
 
         let cache = Arc::new(LmdbCache::open(&cache_path, config.cache.size)?);
 
-        let behind_proxy = config
-            .rate_limiter
-            .as_ref()
-            .map(|rate_limiter| rate_limiter.behind_proxy)
-            .unwrap_or(false);
+        let rate_limiters =
+            build_rate_limiters(config.rate_limiter.as_ref(), &mut dht_config).await?;
 
-        let (rate_limiter, user_dht_rate_limiter) = match config.rate_limiter.as_ref() {
-            Some(rate_limiter_config) => {
-                let rate_limiter = rate_limiting::IpRateLimiter::new(rate_limiter_config)
-                    .await
-                    .map_err(|e| anyhow!("Failed to build IpRateLimiter: {e}"))?;
-                let user_dht_rate_limiter =
-                    rate_limiting::UserDhtRateLimiter::new(rate_limiter_config)
-                        .await
-                        .map_err(|e| anyhow!("Failed to build UserDhtRateLimiter: {e}"))?;
-                let dht_rate_limiter = rate_limiting::DhtRateLimiter::new(rate_limiter_config)
-                    .await
-                    .map_err(|e| anyhow!("Failed to build DhtRateLimiter: {e}"))?;
-                dht_config.server_settings = pkarr::mainline::ServerSettings {
-                    filter: Box::new(dht_rate_limiter),
-                    ..Default::default()
-                };
-                (Some(rate_limiter), Some(user_dht_rate_limiter))
-            }
-            None => (None, None),
-        };
-
-        let dht = DhtClient::build(dht_config)?;
+        let dht_client = DhtClient::build(dht_config)?;
 
         let listener = TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], config.http.port)))?;
         // On axum-server 0.8.0 the `.set_nonblocking(true)` call does not take place internally anymore
         // See open issue https://github.com/programatik29/axum-server/issues/181
         listener.set_nonblocking(true)?;
 
-        let node_address = dht.info().await.local_addr();
+        let node_address = dht_client.info().await.local_addr();
         let relay_address = listener.local_addr()?;
 
         info!("Cache path: {cache_path:?}");
         info!("Running as a DHT node on {node_address}");
         info!("Running as a relay on TCP socket {relay_address}");
 
-        let state = AppState {
-            minimum_ttl: config.cache.minimum_ttl,
-            maximum_ttl: config.cache.maximum_ttl,
+        let dht = DhtService::new(
+            config.cache.minimum_ttl,
+            config.cache.maximum_ttl,
             cache,
-            cache_write_lock: Arc::new(Mutex::new(())),
-            user_dht_rate_limiter,
+            dht_client,
             report_policy,
-            dht,
-        };
-        let app = create_app(state, rate_limiter, behind_proxy);
+            rate_limiters.user_dht,
+        );
+        let state = AppState { dht };
+        let app = create_app(state, rate_limiters.http, rate_limiters.behind_proxy);
 
         let handle = Handle::new();
 
@@ -339,6 +318,46 @@ fn mainline_config(config: &RelayConfig) -> mainline::Config {
     }
 }
 
+struct RateLimiters {
+    http: Option<rate_limiting::IpRateLimiter>,
+    user_dht: Option<rate_limiting::UserDhtRateLimiter>,
+    behind_proxy: bool,
+}
+
+async fn build_rate_limiters(
+    rate_limiter_config: Option<&RateLimiterConfig>,
+    dht_config: &mut mainline::Config,
+) -> anyhow::Result<RateLimiters> {
+    let Some(rate_limiter_config) = rate_limiter_config else {
+        return Ok(RateLimiters {
+            http: None,
+            user_dht: None,
+            behind_proxy: false,
+        });
+    };
+
+    let http = rate_limiting::IpRateLimiter::new(rate_limiter_config)
+        .await
+        .map_err(|e| anyhow!("Failed to build IpRateLimiter: {e}"))?;
+    let user_dht = rate_limiting::UserDhtRateLimiter::new(rate_limiter_config)
+        .await
+        .map_err(|e| anyhow!("Failed to build UserDhtRateLimiter: {e}"))?;
+    let dht = rate_limiting::DhtRateLimiter::new(rate_limiter_config)
+        .await
+        .map_err(|e| anyhow!("Failed to build DhtRateLimiter: {e}"))?;
+
+    dht_config.server_settings = pkarr::mainline::ServerSettings {
+        filter: Box::new(dht),
+        ..Default::default()
+    };
+
+    Ok(RateLimiters {
+        http: Some(http),
+        user_dht: Some(user_dht),
+        behind_proxy: rate_limiter_config.behind_proxy,
+    })
+}
+
 fn create_app(
     state: AppState,
     rate_limiter: Option<rate_limiting::IpRateLimiter>,
@@ -390,16 +409,8 @@ fn to_socket_address_v4<T: ToSocketAddrs>(bootstrap: &[T]) -> Vec<SocketAddrV4> 
 }
 
 #[derive(Debug, Clone)]
-struct AppState {
-    minimum_ttl: u32,
-    maximum_ttl: u32,
-    cache: Arc<LmdbCache>,
-    // Synchronous mutex is fine here; handlers only hold it across cache reads/writes, never await points.
-    cache_write_lock: Arc<Mutex<()>>,
-    // Rate limiter for DHT operations initiated by HTTP user requests.
-    user_dht_rate_limiter: Option<rate_limiting::UserDhtRateLimiter>,
-    report_policy: ReportPolicy,
-    dht: DhtClient,
+pub(crate) struct AppState {
+    pub(crate) dht: DhtService,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Move cache-aware DHT publish and resolve logic out of HTTP handlers
into a relay DHT service. Move index page rendering into its own
module.
