### PR TITLE
feat(relays)!: return stored node count from publish

### DIFF
--- a/design/relays.md
+++ b/design/relays.md
@@ -25,15 +25,19 @@ If-Match: 1741107004412159
 HTTP/2 204 NO CONTENT
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, PUT, OPTIONS	
+Access-Control-Expose-Headers: Pkarr-Dht-Stored-Nodes
+Pkarr-Dht-Stored-Nodes: 8
 ```
 
 Body is described at [Payload](#Payload) encoding section.
+
+`Pkarr-Dht-Stored-Nodes` tells clients how many DHT nodes acknowledged storing the packet.
 
 On receiving a PUT request, the relay server should:
 1. Encode the `seq` and `v` to a *bencode* message as follows: `3:seqi<sequence>e1:v<v's length>:<v's bytes>`
 2. Verify that the `sig` matches the encoded message from step 1, if it is invalid, return a `400 Bad Request` response.
 3. Perform the DHT Put request as defined in [BEP0044](https://www.bittorrent.org/beps/bep_0044.html), optionally using the `If-Match` as the CAS field, where the header value is the utf8-encoded u64 timestamp.
-4. If the DHT request is successful, return a `204 No Content` response, otherwise if any error occurred return a `500 Internal Server Error` response.
+4. If the DHT request is successful, return a `204 No Content` response with `Pkarr-Dht-Stored-Nodes` set to the number of DHT nodes that acknowledged storing the packet, otherwise if any error occurred return a `500 Internal Server Error` response.
 
 #### Errors
 

--- a/pkarr/src/client/relays.rs
+++ b/pkarr/src/client/relays.rs
@@ -81,6 +81,7 @@ impl RelaysClient {
                 let result = relay
                     .publish(&signed_packet, cas)
                     .await
+                    .map(drop)
                     .map_err(map_relay_error);
 
                 inflight.add_result(&public_key, result)
@@ -325,6 +326,7 @@ fn map_relay_error(error: RelayError) -> PublishError {
         | RelayError::InvalidSignedPacket(_)
         | RelayError::InvalidSignedPacketSeq { .. }
         | RelayError::InvalidSignedPacketSeqHeader
+        | RelayError::InvalidDhtStoredNodesHeader
         | RelayError::InvalidHeader(_)
         | RelayError::NotFound
         | RelayError::UnexpectedStatus(_) => PublishError::UnexpectedResponses,

--- a/pkarr/src/dht/report_policy.rs
+++ b/pkarr/src/dht/report_policy.rs
@@ -55,10 +55,10 @@ impl ReportPolicy {
     }
 
     /// Classify warning diagnostics for a DHT publish query result.
-    pub fn classify_publish_result(&self, stored_at: u32) -> Vec<PublishWarning> {
-        if stored_at < self.minimum_publish_stored_nodes {
+    pub fn classify_publish_result(&self, stored_on: u32) -> Vec<PublishWarning> {
+        if stored_on < self.minimum_publish_stored_nodes {
             vec![PublishWarning::TooFewNodesStored {
-                stored_at,
+                stored_on,
                 minimum: self.minimum_publish_stored_nodes,
             }]
         } else {
@@ -125,7 +125,7 @@ pub enum PublishWarning {
     /// Fewer DHT nodes acknowledged storing the packet than expected.
     TooFewNodesStored {
         /// Number of DHT nodes that acknowledged storing the packet.
-        stored_at: u32,
+        stored_on: u32,
         /// Minimum number of storing nodes expected by the policy.
         minimum: u32,
     },
@@ -197,7 +197,7 @@ mod tests {
         assert_eq!(
             policy.classify_publish_result(minimum - 1),
             vec![PublishWarning::TooFewNodesStored {
-                stored_at: minimum - 1,
+                stored_on: minimum - 1,
                 minimum,
             }]
         );

--- a/pkarr/src/lib.rs
+++ b/pkarr/src/lib.rs
@@ -27,6 +27,9 @@ pub const DEFAULT_RELAYS: [&str; 2] = ["https://pkarr.pubky.app", "https://pkarr
 /// Relay response header carrying the mutable item sequence number when the
 /// DHT has a newer mutable item that is not a valid signed packet for a key.
 pub const PKARR_INVALID_SIGNED_PACKET_SEQ: &str = "Pkarr-Invalid-Signed-Packet-Seq";
+/// Relay response header carrying the number of DHT nodes that acknowledged
+/// storing a published packet.
+pub const PKARR_DHT_STORED_NODES: &str = "Pkarr-Dht-Stored-Nodes";
 #[cfg(feature = "__client")]
 /// Default cache size: 1000
 pub const DEFAULT_CACHE_SIZE: usize = 1000;

--- a/pkarr/src/relay_client.rs
+++ b/pkarr/src/relay_client.rs
@@ -9,7 +9,9 @@ use reqwest::{
 use std::time::Duration;
 use url::Url;
 
-use crate::{PublicKey, ResolvePolicy, SignedPacket, PKARR_INVALID_SIGNED_PACKET_SEQ};
+use crate::{
+    PublicKey, ResolvePolicy, SignedPacket, PKARR_DHT_STORED_NODES, PKARR_INVALID_SIGNED_PACKET_SEQ,
+};
 
 const MEMENTO_DATETIME: &str = "memento-datetime";
 const CACHE_BYPASS: &str = "no-cache, no-store, must-revalidate";
@@ -62,15 +64,22 @@ impl RelayClient {
 
     /// Publish a [`SignedPacket`] to this relay.
     ///
+    /// # Returns
+    ///
+    /// Returns the number of DHT nodes that acknowledged storing the packet.
+    /// Older relays that do not return this count are treated as if one DHT
+    /// node acknowledged storing the packet.
+    ///
     /// # Errors
     ///
     /// Returns an error when the relay request fails, the relay returns a
-    /// non-success status, or the request times out.
+    /// non-success status, the request times out, or the relay returns a
+    /// malformed stored-node count header.
     pub async fn publish(
         &self,
         packet: &SignedPacket,
         cas: Option<Timestamp>,
-    ) -> Result<(), RelayError> {
+    ) -> Result<u32, RelayError> {
         let url = self.build_url(&packet.public_key(), None);
 
         let mut request = self
@@ -87,8 +96,9 @@ impl RelayClient {
         let status = response.status();
 
         if status.is_success() {
+            let stored_on = extract_dht_stored_nodes(&response)?;
             debug!("Successfully published to {url}");
-            return Ok(());
+            return Ok(stored_on);
         }
 
         let text = response.text().await.unwrap_or_default();
@@ -247,6 +257,10 @@ pub enum RelayError {
     #[error("relay returned a malformed Pkarr-Invalid-Signed-Packet-Seq header")]
     InvalidSignedPacketSeqHeader,
 
+    /// Relay returned a malformed DHT stored nodes header.
+    #[error("relay returned a malformed Pkarr-Dht-Stored-Nodes header")]
+    InvalidDhtStoredNodesHeader,
+
     /// Relay request contained an invalid header.
     #[error("relay request contained an invalid header: {0}")]
     InvalidHeader(header::InvalidHeaderValue),
@@ -326,6 +340,18 @@ fn extract_invalid_signed_packet_seq(response: &Response) -> Result<Option<i64>,
         .transpose()
 }
 
+fn extract_dht_stored_nodes(response: &Response) -> Result<u32, RelayError> {
+    let Some(value) = response.headers().get(PKARR_DHT_STORED_NODES) else {
+        return Ok(1);
+    };
+
+    value
+        .to_str()
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .ok_or(RelayError::InvalidDhtStoredNodesHeader)
+}
+
 fn invalid_seq_is_not_newer_than_request(seq: i64, newer_than: Option<&Timestamp>) -> bool {
     let Some(newer_than) = newer_than else {
         return false;
@@ -388,7 +414,7 @@ mod tests {
 
     use axum::{
         http::{HeaderMap, StatusCode as HttpStatusCode},
-        routing::get,
+        routing::{get, put},
         Router,
     };
     use ntimestamp::Timestamp;
@@ -411,6 +437,56 @@ mod tests {
             RelayError::from_status(StatusCode::SERVICE_UNAVAILABLE),
             RelayError::DhtUnavailable
         ));
+    }
+
+    #[tokio::test]
+    async fn publish_returns_dht_stored_nodes() {
+        let keypair = Keypair::random();
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            put(|| async { (HttpStatusCode::NO_CONTENT, [(PKARR_DHT_STORED_NODES, "7")]) }),
+        );
+        let client = test_client(serve(app).await);
+
+        let stored_on = client.publish(&signed_packet, None).await.unwrap();
+
+        assert_eq!(stored_on, 7);
+    }
+
+    #[tokio::test]
+    async fn publish_rejects_malformed_dht_stored_nodes_header() {
+        let keypair = Keypair::random();
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            put(|| async {
+                (
+                    HttpStatusCode::NO_CONTENT,
+                    [(PKARR_DHT_STORED_NODES, "not a count")],
+                )
+            }),
+        );
+        let client = test_client(serve(app).await);
+
+        let error = client.publish(&signed_packet, None).await.unwrap_err();
+
+        assert!(matches!(error, RelayError::InvalidDhtStoredNodesHeader));
+    }
+
+    #[tokio::test]
+    async fn publish_defaults_missing_dht_stored_nodes_header_to_one() {
+        let keypair = Keypair::random();
+        let signed_packet = SignedPacket::builder().sign(&keypair).unwrap();
+        let app = Router::new().route(
+            &format!("/{}", keypair.public_key()),
+            put(|| async { HttpStatusCode::NO_CONTENT }),
+        );
+        let client = test_client(serve(app).await);
+
+        let stored_on = client.publish(&signed_packet, None).await.unwrap();
+
+        assert_eq!(stored_on, 1);
     }
 
     #[tokio::test]

--- a/relay/src/dht_service.rs
+++ b/relay/src/dht_service.rs
@@ -50,12 +50,12 @@ impl DhtService {
     /// Publish a signed packet through the DHT and update the relay cache.
     pub(crate) async fn publish(
         &self,
-        public_key: &PublicKey,
         signed_packet: &SignedPacket,
         cas: Option<Timestamp>,
         real_ip: Option<&RealIp>,
-    ) -> Result<(), Error> {
-        let key = CacheKey::from(public_key);
+    ) -> Result<u32, Error> {
+        let public_key = signed_packet.public_key();
+        let key = CacheKey::from(&public_key);
         if let Some(cached) = self.cache.get_read_only(&key) {
             if cached.more_recent_than(signed_packet) {
                 return Err(Error::new(
@@ -67,8 +67,8 @@ impl DhtService {
 
         self.enforce_user_dht_rate_limit(real_ip)?;
 
-        let stored_at = self.dht.publish(signed_packet, cas).await?;
-        let warnings = self.report_policy.classify_publish_result(stored_at);
+        let stored_on = self.dht.publish(signed_packet, cas).await?;
+        let warnings = self.report_policy.classify_publish_result(stored_on);
         if !warnings.is_empty() {
             warn!(
                 ?public_key,
@@ -79,7 +79,7 @@ impl DhtService {
 
         self.update_cache_if_needed(&key, signed_packet);
 
-        Ok(())
+        Ok(stored_on)
     }
 
     /// Resolve a packet using relay cache and DHT policy semantics.

--- a/relay/src/handlers.rs
+++ b/relay/src/handlers.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use crate::error::Error;
 use crate::extractors::{IfMatch, IfModifiedSince, PublicKeyParam};
 use crate::real_ip::RealIp;
-use crate::response::SignedPacketResponse;
+use crate::response::{PutResponse, SignedPacketResponse};
 use crate::AppState;
 
 pub async fn put(
@@ -17,16 +17,13 @@ pub async fn put(
     IfMatch(cas): IfMatch,
     real_ip: Option<Extension<RealIp>>,
     body: Bytes,
-) -> Result<StatusCode, Error> {
+) -> Result<PutResponse, Error> {
     let real_ip = real_ip.as_ref().map(|extension| &extension.0);
     let signed_packet = SignedPacket::from_relay_payload(&public_key, &body)
         .map_err(|error| Error::new(StatusCode::BAD_REQUEST, error))?;
-    state
-        .dht
-        .publish(&public_key, &signed_packet, cas, real_ip)
-        .await?;
+    let stored_on = state.dht.publish(&signed_packet, cas, real_ip).await?;
 
-    Ok(StatusCode::NO_CONTENT)
+    Ok(PutResponse::new(stored_on))
 }
 
 pub async fn get(

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -35,7 +35,7 @@ use tracing::info;
 use pkarr::{
     dht::{DhtClient, ReportPolicy},
     extra::lmdb_cache::LmdbCache,
-    mainline, Timestamp, PKARR_INVALID_SIGNED_PACKET_SEQ,
+    mainline, Timestamp, PKARR_DHT_STORED_NODES, PKARR_INVALID_SIGNED_PACKET_SEQ,
 };
 use url::Url;
 
@@ -387,8 +387,11 @@ fn cors_layer() -> CorsLayer {
     let invalid_signed_packet_seq_header =
         HeaderName::from_bytes(PKARR_INVALID_SIGNED_PACKET_SEQ.as_bytes())
             .expect("Pkarr invalid signed packet seq header name is valid");
+    let dht_stored_nodes_header = HeaderName::from_bytes(PKARR_DHT_STORED_NODES.as_bytes())
+        .expect("Pkarr DHT stored nodes header name is valid");
 
-    CorsLayer::very_permissive().expose_headers([invalid_signed_packet_seq_header])
+    CorsLayer::very_permissive()
+        .expose_headers([invalid_signed_packet_seq_header, dht_stored_nodes_header])
 }
 
 fn to_socket_address_v4<T: ToSocketAddrs>(bootstrap: &[T]) -> Vec<SocketAddrV4> {
@@ -418,7 +421,9 @@ mod tests {
     use std::{net::Ipv4Addr, num::NonZeroU32, time::Duration};
 
     use http::StatusCode;
-    use pkarr::{Keypair, SignedPacket, Timestamp, PKARR_INVALID_SIGNED_PACKET_SEQ};
+    use pkarr::{
+        Keypair, SignedPacket, Timestamp, PKARR_DHT_STORED_NODES, PKARR_INVALID_SIGNED_PACKET_SEQ,
+    };
 
     use super::{to_socket_address_v4, RateLimiterConfig, Relay, RequestCountQuota};
 
@@ -446,6 +451,9 @@ mod tests {
         assert!(exposed_headers.split(',').any(|header| header
             .trim()
             .eq_ignore_ascii_case(PKARR_INVALID_SIGNED_PACKET_SEQ)));
+        assert!(exposed_headers
+            .split(',')
+            .any(|header| header.trim().eq_ignore_ascii_case(PKARR_DHT_STORED_NODES)));
 
         relay.shutdown();
     }
@@ -466,6 +474,14 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(put_response.status(), StatusCode::NO_CONTENT);
+        put_response
+            .headers()
+            .get(PKARR_DHT_STORED_NODES)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse::<u32>()
+            .unwrap();
 
         let local_cache_response = http
             .get(

--- a/relay/src/response.rs
+++ b/relay/src/response.rs
@@ -4,7 +4,27 @@ use http::{
     StatusCode,
 };
 use httpdate::HttpDate;
-use pkarr::SignedPacket;
+use pkarr::{SignedPacket, PKARR_DHT_STORED_NODES};
+
+pub(crate) struct PutResponse {
+    stored_on: u32,
+}
+
+impl PutResponse {
+    pub(crate) fn new(stored_on: u32) -> Self {
+        Self { stored_on }
+    }
+}
+
+impl IntoResponse for PutResponse {
+    fn into_response(self) -> axum::response::Response {
+        (
+            StatusCode::NO_CONTENT,
+            [(PKARR_DHT_STORED_NODES, self.stored_on.to_string())],
+        )
+            .into_response()
+    }
+}
 
 pub(crate) struct SignedPacketResponse {
     signed_packet: SignedPacket,


### PR DESCRIPTION
Add Pkarr-Dht-Stored-Nodes to successful relay PUT responses and
expose it through CORS. Parse the header in RelayClient::publish,
defaulting to 1 for old relays that do not return it.

BREAKING CHANGE: RelayClient::publish now returns Result<u32, RelayError>
instead of Result<(), RelayError>.
