### PR TITLE
build(cargo)!: simplify features and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "wasm-bindgen",
- "wasm-bindgen-futures",
  "wasm-bindgen-test",
 ]
 
@@ -1735,8 +1734,6 @@ dependencies = [
  "cfg_aliases",
  "console_error_panic_hook",
  "console_log",
- "futures-lite",
- "getrandom 0.4.3",
  "js-sys",
  "ntimestamp",
  "pkarr",
@@ -1745,7 +1742,6 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -1757,7 +1753,6 @@ dependencies = [
  "axum-server",
  "bytes",
  "clap",
- "futures-lite",
  "governor",
  "http",
  "httpdate",

--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -31,14 +31,6 @@ simple-dns = { workspace = true }
 ntimestamp = { version = "1.0.0", features = ["full"] }
 thiserror = "2.0.11"
 url = { version = "2.5.4" }
-futures-lite = { version = "2.6.0", default-features = false, features = ["std"] }
-
-# Required for WASM target
-[target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.4", default-features = false, features = ["wasm_js"] }
-
-[dev-dependencies]
-wasm-bindgen-test = "0.3.50"
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen = { version = "0.2.100", features = ["serde-serialize"] }

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(unused_crate_dependencies)]
+
 use js_sys::{Array, Uint8Array};
 use wasm_bindgen::prelude::*;
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -13,23 +13,26 @@ pkarr = "6"
 
 This includes both DHT and relay support, suitable for most server applications.
 
-## Core Features
+## Base API
 
-### `keys`
+### Key utilities
 
-Ed25519 key utilities for identity management.
+Ed25519 key utilities for identity management are always available, including
+when default features are disabled.
 
 ```toml
-pkarr = { version = "6", default-features = false, features = ["keys"] }
+pkarr = { version = "6", default-features = false }
 ```
 
 Provides:
 - `Keypair` - Generate and manage Ed25519 keypairs
 - `PublicKey` - Handle public keys and derive z-base32 identifiers
 
+## Core Features
+
 ### `signed_packet`
 
-DNS packet signing and verification. Automatically enables `keys`.
+DNS packet signing and verification.
 
 ```toml
 pkarr = { version = "6", default-features = false, features = ["signed_packet"] }
@@ -149,7 +152,7 @@ pkarr = { version = "6", features = ["full"] }
 |----------|---------------------|
 | Server application | `full-client` (default) |
 | Browser/WASM | `relays` only |
-| Key handling only | `keys` |
+| Key handling only | `default-features = false` |
 | Packet signing only | `signed_packet` |
 | With persistent cache | `lmdb-cache` |
 | Service discovery | `endpoints` |
@@ -160,7 +163,7 @@ pkarr = { version = "6", features = ["full"] }
 
 | Feature | Native | WASM |
 |---------|--------|------|
-| `keys` | Yes | Yes |
+| Base key API | Yes | Yes |
 | `signed_packet` | Yes | Yes |
 | `dht` | Yes | No |
 | `relays` | Yes | Yes |
@@ -170,9 +173,9 @@ pkarr = { version = "6", features = ["full"] }
 
 ## Minimal Configurations
 
-**Smallest footprint (keys only):**
+**Smallest footprint (key utilities only):**
 ```toml
-pkarr = { version = "6", default-features = false, features = ["keys"] }
+pkarr = { version = "6", default-features = false }
 ```
 
 **WASM browser client:**

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -25,7 +25,7 @@ What is your target platform?
 |
 +-- Key management
 |   |
-|   +-- Just key generation? --> `keys` only
+|   +-- Just key generation? --> `default-features = false`
 |   +-- Signing packets offline? --> `signed_packet`
 |
 +-- Relay-only deployment
@@ -40,7 +40,7 @@ What is your target platform?
 | Full native client | `pkarr = "6"` |
 | Native client + persistence | `pkarr = { version = "6", features = ["lmdb-cache"] }` |
 | Browser/WASM | `pkarr = { version = "6", default-features = false, features = ["relays"] }` |
-| Key utilities only | `pkarr = { version = "6", default-features = false, features = ["keys"] }` |
+| Key utilities only | `pkarr = { version = "6", default-features = false }` |
 | Everything for native apps | `pkarr = { version = "6", features = ["full"] }` |
 
 Endpoint-related extras require the client API. With default features this is

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -18,11 +18,10 @@ categories = ["network-programming"]
 
 [dependencies]
 base32 = "0.5.1"
-ed25519-dalek = { version = "3.0.0-rc.1", default-features = false }
-thiserror = "2.0.18"
-serde = { version = "1.0.228", features = ["derive"] }
-
 document-features = "0.2.12"
+ed25519-dalek = { version = "3.0.0-rc.1", default-features = false }
+serde = "1.0.228"
+thiserror = "2.0.18"
 
 #feat: signed_packet dependencies
 simple-dns = { workspace = true, optional = true }
@@ -58,7 +57,10 @@ mainline = { version = "7.0.0", default-features = false, features = ["async"], 
 
 # feat: relay dependencies
 reqwest = { workspace = true, optional = true }
-tokio = { version = "1.49.0", default-features = false, optional = true }
+tokio = { version = "1.49.0", default-features = false, features = [
+  "macros",
+  "rt",
+], optional = true }
 async-compat = { version = "0.2.5", optional = true }
 
 # feat: lmdb-cache defendencies
@@ -80,7 +82,6 @@ getrandom = { version = "0.4.1", default-features = false, features = [
 
 #feat: client dependencies
 log = { version = "0.4.29", optional = true }
-wasm-bindgen-futures = { version = "0.4.58", optional = true }
 
 # feat: relay dependencies
 reqwest = { workspace = true, optional = true }
@@ -109,10 +110,7 @@ console_log = { version = "1.0.0", features = ["color"] }
 cfg_aliases = "0.2.1"
 
 [features]
-# Basic types
-keys = []
 signed_packet = [
-  "keys",
   "dep:simple-dns",
   "dep:ntimestamp",
   "dep:bytes",
@@ -169,10 +167,9 @@ __client = [
   "dep:sha1_smol",
   "dep:futures-lite",
   "dep:async-compat",
-  "tokio/macros",
+  "dep:tokio",
   "dep:log",
   "dep:tracing",
-  "dep:wasm-bindgen-futures",
 ]
 
 [package.metadata.docs.rs]

--- a/pkarr/src/lib.rs
+++ b/pkarr/src/lib.rs
@@ -3,6 +3,7 @@
 #![doc = document_features::document_features!()]
 //!
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]

--- a/pkarr/src/types/mod.rs
+++ b/pkarr/src/types/mod.rs
@@ -1,12 +1,10 @@
 //! Protocol data types.
 
-#[cfg(feature = "keys")]
 mod keys;
 mod resolve_policy;
 #[cfg(feature = "signed_packet")]
 pub(crate) mod signed_packet;
 
-#[cfg(feature = "keys")]
 pub use keys::{Keypair, PublicKey};
 pub use resolve_policy::ResolvePolicy;
 #[cfg(feature = "signed_packet")]
@@ -18,7 +16,6 @@ pub type StoredNodeCount = u32;
 
 /// Exported type errors.
 pub mod errors {
-    #[cfg(feature = "keys")]
     pub use super::keys::PublicKeyError;
 
     #[cfg(feature = "signed_packet")]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -21,7 +21,13 @@ categories = ["network-programming"]
 [dependencies]
 anyhow = "1.0.101"
 axum = "0.8.8"
-tokio = { version = "1.49.0", features = ["fs", "macros", "rt-multi-thread", "signal"] }
+tokio = { version = "1.49.0", features = [
+    "fs",
+    "macros",
+    "rt-multi-thread",
+    "signal",
+    "time",
+] }
 tower-http = { version = "0.6.8", features = ["cors", "trace"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
@@ -39,7 +45,6 @@ pkarr = { path = "../pkarr", version = "6.0", default-features = false, features
     "dht",
     "lmdb-cache",
 ] }
-futures-lite = "2.6.1"
 
 [dev-dependencies]
 reqwest = { workspace = true }


### PR DESCRIPTION
Make key utilities unconditional so key-only builds need no explicit
feature. Remove unused dependencies from pkarr, relay, and the JS
bindings, and warn when new unused crate dependencies are introduced.

Declare the Tokio features used directly by pkarr and relay, and align
the feature documentation with the simplified configuration.

BREAKING CHANGE: Remove the pkarr `keys` Cargo feature. Consumers using
`features = ["keys"]` must remove it; key utilities remain available
with `default-features = false`.
