### PR TITLE
build(deps): update ed25519-dalek to stable v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-rc.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["network-programming"]
 [dependencies]
 base32 = "0.5.1"
 document-features = "0.2.12"
-ed25519-dalek = { version = "3.0.0-rc.1", default-features = false }
+ed25519-dalek = { version = "3", default-features = false }
 serde = "1.0.228"
 thiserror = "2.0.18"
 


### PR DESCRIPTION
Replace the release candidate with the stable v3 dependency and refresh
curve25519-dalek to its corresponding stable release.
