### PR TITLE
chore: release v7.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -741,7 +741,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -982,7 +982,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.8",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -1682,7 +1682,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkarr"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-js"
-version = "3.8.0"
+version = "7.0.0"
 dependencies = [
  "cfg_aliases",
  "console_error_panic_hook",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "0.12.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2479,18 +2479,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spinning_top"

--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr-js"
-version = "3.8.0"
+version = "7.0.0"
 rust-version = "1.85"
 authors = ["Nuh <nuh@nuh.dev>"]
 edition = "2021"

--- a/bindings/js/pkg/package.json
+++ b/bindings/js/pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/pkarr",
   "description": "Public-Key Addressable Resource Records (Pkarr); publish and resolve DNS records over Mainline DHT",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,7 @@ With a basic dependency declaration, you get the `full-client` feature:
 
 ```toml
 [dependencies]
-pkarr = "6"
+pkarr = "7"
 ```
 
 This includes both DHT and relay support, suitable for most server applications.
@@ -21,7 +21,7 @@ Ed25519 key utilities for identity management are always available, including
 when default features are disabled.
 
 ```toml
-pkarr = { version = "6", default-features = false }
+pkarr = { version = "7", default-features = false }
 ```
 
 Provides:
@@ -35,7 +35,7 @@ Provides:
 DNS packet signing and verification.
 
 ```toml
-pkarr = { version = "6", default-features = false, features = ["signed_packet"] }
+pkarr = { version = "7", default-features = false, features = ["signed_packet"] }
 ```
 
 Provides:
@@ -48,7 +48,7 @@ Provides:
 Direct Mainline DHT access for publishing and resolving records.
 
 ```toml
-pkarr = { version = "6", default-features = false, features = ["dht"] }
+pkarr = { version = "7", default-features = false, features = ["dht"] }
 ```
 
 **Not available in WASM environments.**
@@ -58,7 +58,7 @@ pkarr = { version = "6", default-features = false, features = ["dht"] }
 HTTP relay support for environments without direct DHT access.
 
 ```toml
-pkarr = { version = "6", default-features = false, features = ["relays"] }
+pkarr = { version = "7", default-features = false, features = ["relays"] }
 ```
 
 **Required for WASM/browser applications.**
@@ -68,7 +68,7 @@ pkarr = { version = "6", default-features = false, features = ["relays"] }
 Both DHT and relay support combined.
 
 ```toml
-pkarr = "6"  # Equivalent to features = ["full-client"]
+pkarr = "7"  # Equivalent to features = ["full-client"]
 ```
 
 ## Extra Features
@@ -87,7 +87,7 @@ Returns an async `Stream` of endpoints. Downstream applications need `futures-li
 (or equivalent) to consume the stream with `.next()` and `StreamExt`.
 
 ```toml
-pkarr = { version = "6", features = ["endpoints"] }
+pkarr = { version = "7", features = ["endpoints"] }
 ```
 
 ### `lmdb-cache`
@@ -95,7 +95,7 @@ pkarr = { version = "6", features = ["endpoints"] }
 Persistent LMDB cache backend for the client.
 
 ```toml
-pkarr = { version = "6", features = ["lmdb-cache"] }
+pkarr = { version = "7", features = ["lmdb-cache"] }
 ```
 
 This feature makes `pkarr::extra::lmdb_cache::LmdbCache` available. It does not
@@ -107,7 +107,7 @@ to `ClientBuilder::cache()` to use it.
 TLS certificate support for secure connections. Enables `endpoints`.
 
 ```toml
-pkarr = { version = "6", features = ["tls"] }
+pkarr = { version = "7", features = ["tls"] }
 ```
 
 ### `reqwest-resolve`
@@ -115,7 +115,7 @@ pkarr = { version = "6", features = ["tls"] }
 Implement `reqwest::dns::Resolve` trait for the Client. Enables `endpoints`.
 
 ```toml
-pkarr = { version = "6", features = ["reqwest-resolve"] }
+pkarr = { version = "7", features = ["reqwest-resolve"] }
 ```
 
 ### `reqwest-builder`
@@ -123,7 +123,7 @@ pkarr = { version = "6", features = ["reqwest-resolve"] }
 Create a `reqwest::ClientBuilder` from the Pkarr Client. Enables `tls` and `reqwest-resolve`.
 
 ```toml
-pkarr = { version = "6", features = ["reqwest-builder"] }
+pkarr = { version = "7", features = ["reqwest-builder"] }
 ```
 
 ## Feature Combinations
@@ -135,7 +135,7 @@ and `reqwest-builder`; `reqwest-builder` enables `tls`, `reqwest-resolve`, and
 `endpoints`.
 
 ```toml
-pkarr = { version = "6", features = ["extra"] }
+pkarr = { version = "7", features = ["extra"] }
 ```
 
 ### `full`
@@ -143,7 +143,7 @@ pkarr = { version = "6", features = ["extra"] }
 Everything: `full-client` + `extra`.
 
 ```toml
-pkarr = { version = "6", features = ["full"] }
+pkarr = { version = "7", features = ["full"] }
 ```
 
 ## Decision Guide
@@ -175,15 +175,15 @@ pkarr = { version = "6", features = ["full"] }
 
 **Smallest footprint (key utilities only):**
 ```toml
-pkarr = { version = "6", default-features = false }
+pkarr = { version = "7", default-features = false }
 ```
 
 **WASM browser client:**
 ```toml
-pkarr = { version = "6", default-features = false, features = ["relays"] }
+pkarr = { version = "7", default-features = false, features = ["relays"] }
 ```
 
 **Server with persistence:**
 ```toml
-pkarr = { version = "6", features = ["lmdb-cache"] }
+pkarr = { version = "7", features = ["lmdb-cache"] }
 ```

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -37,11 +37,11 @@ What is your target platform?
 
 | Use Case | Cargo.toml |
 |----------|------------|
-| Full native client | `pkarr = "6"` |
-| Native client + persistence | `pkarr = { version = "6", features = ["lmdb-cache"] }` |
-| Browser/WASM | `pkarr = { version = "6", default-features = false, features = ["relays"] }` |
-| Key utilities only | `pkarr = { version = "6", default-features = false }` |
-| Everything for native apps | `pkarr = { version = "6", features = ["full"] }` |
+| Full native client | `pkarr = "7"` |
+| Native client + persistence | `pkarr = { version = "7", features = ["lmdb-cache"] }` |
+| Browser/WASM | `pkarr = { version = "7", default-features = false, features = ["relays"] }` |
+| Key utilities only | `pkarr = { version = "7", default-features = false }` |
+| Everything for native apps | `pkarr = { version = "7", features = ["full"] }` |
 
 Endpoint-related extras require the client API. With default features this is
 already enabled on native targets. If you disable default features, combine
@@ -145,7 +145,7 @@ client will not use it automatically. Enable the feature, create an
 
 ```toml
 [dependencies]
-pkarr = { version = "6", features = ["lmdb-cache"] }
+pkarr = { version = "7", features = ["lmdb-cache"] }
 ```
 
 ```rust
@@ -244,7 +244,7 @@ Pkarr uses `async_compat` internally. If no Tokio runtime is detected, it automa
 
 ```toml
 [dependencies]
-pkarr = { version = "6", default-features = false, features = ["relays"] }
+pkarr = { version = "7", default-features = false, features = ["relays"] }
 ```
 
 ### Constraints

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ Get up and running with Pkarr in 5 minutes.
 
 ```toml
 [dependencies]
-pkarr = "6"
+pkarr = "7"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr"
-version = "6.0.0"
+version = "7.0.0"
 rust-version = "1.85"
 authors = [
   "Nuh <nuh@nuh.dev>",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr-relay"
-version = "0.12.0"
+version = "1.0.0"
 rust-version = "1.85"
 authors = [
     "Nuh <nuh@nuh.dev>",
@@ -41,7 +41,7 @@ toml = "0.9.11"
 clap = { version = "4.5.57", features = ["derive"] }
 httpdate = "1.0.3"
 url = "2.5.8"
-pkarr = { path = "../pkarr", version = "6.0", default-features = false, features = [
+pkarr = { path = "../pkarr", version = "7.0.0", default-features = false, features = [
     "dht",
     "lmdb-cache",
 ] }


### PR DESCRIPTION
## Changes since v6.0.1

- Add explicit `CacheOnly`, `CacheFirst`, and `NetworkOnly` resolve policies.
- Return structured publish and resolve errors, including invalid packet sequence information.
- Return the number of DHT nodes storing a packet from client and relay publish operations.
- Add DHT query diagnostics and hide direct `mainline` access behind the new `DhtClient` abstraction.
- Add the public single-endpoint `RelayClient`.
- Split relay HTTP, inbound DHT, and user-triggered DHT rate limits.
- Improve relay cache freshness handling, request timeouts, shutdown behavior, and Docker support.
- Align the JavaScript bindings with the Rust client API, including resolve policies, structured errors, stored-node counts, normalized naming, and millisecond timestamps.
- Make key utilities always available and remove the `keys` Cargo feature.
- Update `ed25519-dalek` to stable v3 and remove unused dependencies.

## Breaking changes

- `Client::resolve` now requires a `ResolvePolicy` and returns `Result<SignedPacket, ResolveError>`.
- `Client::publish` now returns the stored-node count and no longer accepts a CAS timestamp.
- `ClientBlocking`, `Client::cache`, `Client::dht`, the public client relay module, and the previous client future helpers were removed.
- `ClientBuilder::dht` now configures `mainline::Config`.
- Relay rate-limiter configuration now requires separate HTTP, DHT-peer, and user-triggered DHT quotas.
- `RelayBuilder::pkarr` was replaced by DHT and request-timeout configuration methods.
- The `keys` Cargo feature was removed; key utilities remain available with default features disabled.
- JavaScript client methods, key accessors, error handling, and timestamp fields were updated to match the new API.