### PR TITLE
ci: update dependabot rust interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,15 @@ updates:
     - package-ecosystem: "cargo"
       directory: "/"
       schedule:
-          interval: "monthly"
+          interval: "weekly"
+          day: "sunday"
+          time: "08:00"
       commit-message:
           prefix: "deps"
       rebase-strategy: "auto"
+      # Cover both direct and transitive deps
+      allow:
+        - dependency-type: "all"
       groups:
           cargo-dependencies:
               patterns:


### PR DESCRIPTION
This PR updates the dependabot interval to weekly and also configures it to check and bump transitive dependencies.