### PR TITLE
docs: document client and relay architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ async fn main() -> anyhow::Result<()> {
 | **[Examples](./pkarr/examples/README.md)** | Code samples |
 | **[Specifications](./design/README.md)** | Protocol design documents |
 
+## Repository Components
+
+- **`pkarr`** — The Rust library for keys, signed DNS packets, caching,
+  publishing, and resolution.
+- **`pkarr-relay`** — An HTTP-to-DHT relay server for browsers and other
+  UDP-restricted clients. Install it with `cargo install pkarr-relay`, or run
+  the workspace binary with `cargo run -p pkarr-relay -- --help`. See the
+  [relay guide](./relay/README.md) for configuration and testnet usage.
+- **`@synonymdev/pkarr`** — JavaScript/WASM bindings under
+  [`bindings/js`](./bindings/js/README.md).
+
 ## Demo
 
 Try the [web app](https://pkdns.net) to resolve records in your browser.
@@ -78,6 +89,12 @@ sequenceDiagram
     Relay->>Client: Verified response
 ```
 
+The default native client configures both paths. `ClientBuilder` can instead
+select DHT-only or relay-only operation, and `ResolvePolicy` controls whether a
+lookup uses cached data or queries the configured networks. See the
+[integration guide](./docs/integration.md#client-abstractions) for the client
+structure and selection behavior.
+
 ### The Network
 
 PKARR uses the [Mainline DHT](https://en.wikipedia.org/wiki/Mainline_DHT), the same peer-to-peer network that powers BitTorrent. Records are stored using [BEP44](https://www.bittorrent.org/beps/bep_0044.html) (mutable items). With 15 years of proven reliability and 10+ million active nodes, there's no need to bootstrap a new network.
@@ -89,7 +106,8 @@ PKARR uses the [Mainline DHT](https://en.wikipedia.org/wiki/Mainline_DHT), the s
 - **Caching everywhere** — Clients and relays cache aggressively for performance
 - **Relays for browsers** — Web apps use HTTP relays since browsers cannot open UDP sockets
 
-PKARR is the I/O library that reads and writes DNS records to the DHT.
+The `pkarr` crate is the I/O library that reads and writes signed DNS packets
+through the DHT, HTTP relays, or both.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/pkarr)](https://crates.io/crates/pkarr) [![Documentation](https://docs.rs/pkarr/badge.svg)](https://docs.rs/pkarr) [![License](https://img.shields.io/badge/license-MIT-purple)](./LICENSE)
 
-PKARR turns Ed25519 public keys into domain names that you truly own. Publish DNS records to the Bittorrent peer-to-peer network with 10+ million nodes. No registrar can seize your domain. No platform can deplatform your identity.
+PKARR turns Ed25519 public keys into domain names that you truly own. Publish
+DNS records to the Mainline DHT without relying on a registrar or platform.
 
 Where we are going, this https://o4dksfbqk85ogzdb5osziw6befigbuxmuxkuxq8434q89uj56uyy resolves everywhere!
 
@@ -12,13 +13,14 @@ Where we are going, this https://o4dksfbqk85ogzdb5osziw6befigbuxmuxkuxq8434q89uj
 
 ```bash
 cargo add pkarr
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 ```rust
 use pkarr::{Client, Keypair, SignedPacket};
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Generate your identity
     let keypair = Keypair::random();
     println!("Your public key: {}", keypair.public_key());
@@ -59,7 +61,7 @@ async fn main() -> anyhow::Result<()> {
 - **`pkarr-relay`** — An HTTP-to-DHT relay server for browsers and other
   UDP-restricted clients. Install it with `cargo install pkarr-relay`, or run
   the workspace binary with `cargo run -p pkarr-relay -- --help`. See the
-  [relay guide](./relay/README.md) for configuration and testnet usage.
+  [relay guide](./relay/README.md) for configuration options.
 - **`@synonymdev/pkarr`** — JavaScript/WASM bindings under
   [`bindings/js`](./bindings/js/README.md).
 
@@ -71,7 +73,7 @@ Try the [web app](https://pkdns.net) to resolve records in your browser.
 
 1. **Generate a keypair** — Your public key becomes your domain name
 2. **Sign DNS records** — Standard A, AAAA, TXT, CNAME records, self-signed
-3. **Publish to the DHT** — Records stored on the [Mainline DHT](https://en.wikipedia.org/wiki/Mainline_DHT) (10M+ nodes)
+3. **Publish to the DHT** — Records are stored on the [Mainline DHT](https://en.wikipedia.org/wiki/Mainline_DHT)
 4. **Resolve anywhere** — Anyone can query and verify your records
 
 ```mermaid
@@ -89,11 +91,11 @@ sequenceDiagram
     Relay->>Client: Verified response
 ```
 
-The default native client configures both paths. `ClientBuilder` can instead
-select DHT-only or relay-only operation, and `ResolvePolicy` controls whether a
-lookup uses cached data or queries the configured networks. See the
-[integration guide](./docs/integration.md#client-abstractions) for the client
-structure and selection behavior.
+The default native client configures both DHT and relay backends.
+`ClientBuilder` can select DHT-only or relay-only operation, and `ResolvePolicy`
+controls whether a lookup uses cached data or queries the configured
+backends. See the [integration
+guide](./docs/integration.md#client-configuration) for configuration examples.
 
 ### The Network
 
@@ -105,9 +107,6 @@ PKARR uses the [Mainline DHT](https://en.wikipedia.org/wiki/Mainline_DHT), the s
 - **1000-byte limit** — PKARR is for discovery, not storage
 - **Caching everywhere** — Clients and relays cache aggressively for performance
 - **Relays for browsers** — Web apps use HTTP relays since browsers cannot open UDP sockets
-
-The `pkarr` crate is the I/O library that reads and writes signed DNS packets
-through the DHT, HTTP relays, or both.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -9,39 +9,6 @@ DNS records to the Mainline DHT without relying on a registrar or platform.
 
 Where we are going, this https://o4dksfbqk85ogzdb5osziw6befigbuxmuxkuxq8434q89uj56uyy resolves everywhere!
 
-## Quick Start
-
-```bash
-cargo add pkarr
-cargo add tokio --features macros,rt-multi-thread
-```
-
-```rust
-use pkarr::{Client, Keypair, SignedPacket};
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Generate your identity
-    let keypair = Keypair::random();
-    println!("Your public key: {}", keypair.public_key());
-
-    // Create and sign DNS records
-    let packet = SignedPacket::builder()
-        .txt("_hello".try_into()?, "world".try_into()?, 3600)
-        .sign(&keypair)?;
-
-    // Publish to the network
-    let client = Client::builder().build()?;
-    let stored_on = client.publish(&packet).await?;
-
-    println!(
-        "Published on at least {stored_on} DHT nodes! Resolve at: https://pkdns.net/?id={}",
-        keypair.public_key()
-    );
-    Ok(())
-}
-```
-
 ## Documentation
 
 | Guide | Description |
@@ -54,16 +21,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 | **[Examples](./pkarr/examples/README.md)** | Code samples |
 | **[Specifications](./design/README.md)** | Protocol design documents |
 
-## Repository Components
+## Crates and Packages
 
-- **`pkarr`** — The Rust library for keys, signed DNS packets, caching,
-  publishing, and resolution.
-- **`pkarr-relay`** — An HTTP-to-DHT relay server for browsers and other
-  UDP-restricted clients. Install it with `cargo install pkarr-relay`, or run
-  the workspace binary with `cargo run -p pkarr-relay -- --help`. See the
-  [relay guide](./relay/README.md) for configuration options.
-- **`@synonymdev/pkarr`** — JavaScript/WASM bindings under
-  [`bindings/js`](./bindings/js/README.md).
+- **[`pkarr`](./pkarr/README.md)** — The Rust library for creating and verifying
+  signed DNS packets, then publishing and resolving them over the DHT or HTTP
+  relays. Its README covers installation, features, and a runnable example.
+- **[`pkarr-relay`](./relay/README.md)** — An HTTP-to-DHT gateway that lets
+  browsers and other UDP-restricted clients publish and resolve Pkarr packets.
+  Its README covers installation and configuration.
+- **[`@synonymdev/pkarr`](./bindings/js/README.md)** — JavaScript/WASM bindings
+  for using Pkarr in browsers and Node.js.
 
 ## Demo
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -48,6 +48,50 @@ already enabled on native targets. If you disable default features, combine
 `endpoints`, `tls`, `reqwest-resolve`, or `reqwest-builder` with `dht` and/or
 `relays` as appropriate for your target.
 
+## Client Abstractions
+
+The client is organized in layers so applications choose behavior without
+depending on a concrete network implementation:
+
+```text
+ClientBuilder
+├── cache: InMemoryCache | custom Cache | disabled
+└── backend: DHT | HTTP relays | combined DHT + relays
+        ↓
+      Client
+      ├── publish(&SignedPacket)
+      └── resolve(&PublicKey, ResolvePolicy)
+```
+
+`ClientBuilder` owns configuration: network selection, cache choice, TTL
+bounds, request timeout, and backend-specific settings. `build()` validates
+that at least one network is available and constructs a cloneable `Client`.
+The concrete DHT, relay, and combined backend types are internal; use builder
+methods and Cargo features to select them.
+
+`Client` is the public I/O facade. It coordinates the optional local cache with
+the configured backend and maps backend-specific outcomes into `BuildError`,
+`PublishError`, and `ResolveError`. The `Cache` trait is the extension point for
+custom storage, while `ResolvePolicy` controls how a particular lookup balances
+cache latency against network freshness.
+
+With the default native features, the combined backend has these semantics:
+
+| Operation | Combined-backend behavior |
+|-----------|---------------------------|
+| `publish` | Publishes through DHT and relays concurrently. A successful result reports the maximum known stored-node count, not a sum. |
+| `resolve(..., CacheOnly)` | Checks the local cache, then relay caches; it never queries DHT nodes. |
+| `resolve(..., CacheFirst)` | Returns a fresh local hit immediately. Otherwise it races configured networks and can finish on the first fresh result that is not older than the cached packet. |
+| `resolve(..., NetworkOnly)` | Bypasses local cache reads, waits for configured networks, and selects the most recent observed network state. |
+
+Successful publishes and network resolutions update the local cache without
+replacing a newer cached packet. If `CacheFirst` selects an expired packet as
+its best backend result, that packet may still advance the cache before the
+client returns `ResolveError::NotFound`. Other outcomes are preserved: for
+example, a newer malformed mutable item returns
+`ResolveError::InvalidSignedPacket`, while backend failures may return their
+corresponding `ResolveError`.
+
 ## Client Configuration
 
 Use `Client::builder()` to customize the client for your environment.
@@ -138,6 +182,11 @@ let client = Client::builder()
     .cache(custom_cache)
     .build()?;
 ```
+
+`cache_size(0)` disables all caching, including a custom cache supplied with
+`cache()`. A custom `Cache` implementation must also override `capacity()` and
+return a nonzero value; the trait's default capacity is zero and is treated as
+disabled.
 
 The `lmdb-cache` feature provides a persistent cache implementation, but the
 client will not use it automatically. Enable the feature, create an
@@ -335,13 +384,15 @@ async fn republish_update(
 
 ## Resolve Policies
 
-Use [`ResolvePolicy::CacheFirst`] for normal application lookups. It returns fresh cached packets, or queries the network on a cache miss or expired cache entry. It does not fall back to expired local cache entries.
+Use `ResolvePolicy::CacheFirst` for normal application lookups. It returns
+fresh cached packets, or queries the network on a cache miss or expired cache
+entry. It does not fall back to expired local cache entries.
 
-Use [`ResolvePolicy::CacheOnly`] when a locally cached or relay-cached packet is
+Use `ResolvePolicy::CacheOnly` when a locally cached or relay-cached packet is
 acceptable even if it is expired. It may make an HTTP relay request after a
 local cache miss, but it never queries DHT nodes.
 
-Use [`ResolvePolicy::NetworkOnly`] when you need the most recent network state,
+Use `ResolvePolicy::NetworkOnly` when you need the most recent network state,
 for example before rebuilding and publishing an updated packet. Handle
 `ResolveError::InvalidSignedPacket` separately from `ResolveError::NotFound`:
 the former reports a newer mutable-item sequence that did not contain a valid

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,102 +1,14 @@
 # Pkarr Integration Guide
 
-This guide covers production integration patterns for pkarr. For basic usage, see the [quickstart](./quickstart.md). For feature flag selection, see [features](./features.md).
-
-## Feature Flag Decision Tree
-
-Choose features based on your deployment environment and requirements.
-
-### Environment-Based Selection
-
-```
-What is your target platform?
-|
-+-- Server/Native Application
-|   |
-|   +-- Need persistent cache? --> Add `lmdb-cache`
-|   +-- Need HTTPS/SVCB endpoint discovery? --> Add `endpoints`
-|   +-- Need reqwest DNS resolver integration? --> Add `reqwest-resolve`
-|   +-- Need a preconfigured reqwest client with Pkarr DNS/TLS? --> Add `reqwest-builder`
-|   +-- Otherwise --> Use default (`full-client`)
-|
-+-- Browser/WASM
-|   |
-|   +-- Use `relays` as the network feature (DHT is unavailable in browsers)
-|
-+-- Key management
-|   |
-|   +-- Just key generation? --> `default-features = false`
-|   +-- Signing packets offline? --> `signed_packet`
-|
-+-- Relay-only deployment
-    |
-    +-- `relays` (no DHT, smaller binary)
-```
-
-### Minimal Configurations
-
-| Use Case | Cargo.toml |
-|----------|------------|
-| Full native client | `pkarr = "7"` |
-| Native client + persistence | `pkarr = { version = "7", features = ["lmdb-cache"] }` |
-| Browser/WASM | `pkarr = { version = "7", default-features = false, features = ["relays"] }` |
-| Key utilities only | `pkarr = { version = "7", default-features = false }` |
-| Everything for native apps | `pkarr = { version = "7", features = ["full"] }` |
-
-Endpoint-related extras require the client API. With default features this is
-already enabled on native targets. If you disable default features, combine
-`endpoints`, `tls`, `reqwest-resolve`, or `reqwest-builder` with `dht` and/or
-`relays` as appropriate for your target.
-
-## Client Abstractions
-
-The client is organized in layers so applications choose behavior without
-depending on a concrete network implementation:
-
-```text
-ClientBuilder
-├── cache: InMemoryCache | custom Cache | disabled
-└── backend: DHT | HTTP relays | combined DHT + relays
-        ↓
-      Client
-      ├── publish(&SignedPacket)
-      └── resolve(&PublicKey, ResolvePolicy)
-```
-
-`ClientBuilder` owns configuration: network selection, cache choice, TTL
-bounds, request timeout, and backend-specific settings. `build()` validates
-that at least one network is available and constructs a cloneable `Client`.
-The concrete DHT, relay, and combined backend types are internal; use builder
-methods and Cargo features to select them.
-
-`Client` is the public I/O facade. It coordinates the optional local cache with
-the configured backend and maps backend-specific outcomes into `BuildError`,
-`PublishError`, and `ResolveError`. The `Cache` trait is the extension point for
-custom storage, while `ResolvePolicy` controls how a particular lookup balances
-cache latency against network freshness.
-
-With the default native features, the combined backend has these semantics:
-
-| Operation | Combined-backend behavior |
-|-----------|---------------------------|
-| `publish` | Publishes through DHT and relays concurrently. A successful result reports the maximum known stored-node count, not a sum. |
-| `resolve(..., CacheOnly)` | Checks the local cache, then relay caches; it never queries DHT nodes. |
-| `resolve(..., CacheFirst)` | Returns a fresh local hit immediately. Otherwise it races configured networks and can finish on the first fresh result that is not older than the cached packet. |
-| `resolve(..., NetworkOnly)` | Bypasses local cache reads, waits for configured networks, and selects the most recent observed network state. |
-
-Successful publishes and network resolutions update the local cache without
-replacing a newer cached packet. If `CacheFirst` selects an expired packet as
-its best backend result, that packet may still advance the cache before the
-client returns `ResolveError::NotFound`. Other outcomes are preserved: for
-example, a newer malformed mutable item returns
-`ResolveError::InvalidSignedPacket`, while backend failures may return their
-corresponding `ResolveError`.
+This guide covers production integration patterns for pkarr. For basic usage,
+see the [quickstart](./quickstart.md). For feature flag selection, see
+[features](./features.md).
 
 ## Client Configuration
 
 Use `Client::builder()` to customize the client for your environment.
 
-### Network Configuration
+### Backend Configuration
 
 ```rust
 use pkarr::Client;
@@ -285,7 +197,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Pkarr uses `async_compat` internally. If no Tokio runtime is detected, it automatically wraps futures for compatibility. This means pkarr works with async-std, smol, or any other executor.
+Pkarr uses `async_compat` internally. If no Tokio runtime is detected, it
+automatically wraps futures for compatibility. This means pkarr works with
+async-std, smol, or any other executor.
 
 ## WASM/Browser Integration
 
@@ -304,7 +218,8 @@ pkarr = { version = "7", default-features = false, features = ["relays"] }
 
 ## Republishing Patterns
 
-DHT records are ephemeral. Nodes drop records after a few hours. For persistent availability, implement periodic republishing.
+DHT records are ephemeral. Nodes drop records after a few hours. For persistent
+availability, implement periodic republishing.
 
 ### Basic Republishing Loop
 
@@ -385,8 +300,8 @@ async fn republish_update(
 ## Resolve Policies
 
 Use `ResolvePolicy::CacheFirst` for normal application lookups. It returns
-fresh cached packets, or queries the network on a cache miss or expired cache
-entry. It does not fall back to expired local cache entries.
+fresh cached packets, or queries the configured backends on a cache miss or
+expired cache entry. It does not fall back to expired local cache entries.
 
 Use `ResolvePolicy::CacheOnly` when a locally cached or relay-cached packet is
 acceptable even if it is expired. It may make an HTTP relay request after a
@@ -401,5 +316,5 @@ PKARR packet and must not be interpreted as an unused key.
 ## Next Steps
 
 - [API Documentation](https://docs.rs/pkarr/latest/pkarr/) - Complete API reference
-- [Examples](https://github.com/Pubky/pkarr/tree/main/pkarr/examples) - Working code samples
-- [Pkarr Relay](https://github.com/Pubky/pkarr/tree/main/relay) - Run your own relay
+- [Examples](https://github.com/pubky/pkarr/tree/main/pkarr/examples) - Working code samples
+- [Pkarr Relay](https://github.com/pubky/pkarr/tree/main/relay) - Run your own relay

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -252,7 +252,8 @@ To explore Pkarr:
 - Try the [web demo](https://pkdns.net) to resolve records
 - Read the [specification](../design/base.md) for implementation details
 - Check the [examples](../pkarr/examples/README.md) for code samples
-- Run your own [relay](../design/relays.md) to support the network
+- Run the [`pkarr-relay` binary](../relay/README.md) to support UDP-restricted
+  clients
 
 Pkarr gives you a permanent, portable, sovereign identity. What you build on
 top of it is up to you.

--- a/pkarr/README.md
+++ b/pkarr/README.md
@@ -1,23 +1,59 @@
 # Pkarr
 
-Rust implementation of [Pkarr](https://github.com/pubky/pkarr) for publishing and resolving DNS packets over [Mainline DHT](https://github.com/Pubky/mainline).
+Rust implementation of [Pkarr](https://github.com/pubky/pkarr) for signing,
+publishing, and resolving DNS packets over
+[Mainline DHT](https://github.com/Pubky/mainline) and HTTP relays.
 
-## Documentation
+## Client Abstractions
 
-- **[API Documentation](https://docs.rs/pkarr/latest/pkarr/)**
-- **[Examples](https://github.com/Pubky/pkarr/tree/main/pkarr/examples)**
+The public client API separates configuration, I/O, caching, and lookup
+freshness:
 
-## Features
+```text
+ClientBuilder
+├── cache: InMemoryCache | custom Cache | disabled
+└── backend: DHT | HTTP relays | combined DHT + relays
+        ↓
+      Client
+      ├── publish(&SignedPacket)
+      └── resolve(&PublicKey, ResolvePolicy)
+```
 
-### Runtime Support
+- `ClientBuilder` configures the cache, TTL bounds, timeouts, and available
+  network backends. The default native client uses both the DHT and the default
+  relays.
+- `Client` is the cloneable async facade that coordinates publishing,
+  resolution, cache updates, and consistent public errors.
+- `Cache` is replaceable. Clients use an in-memory LRU by default; a configured
+  cache size or custom-cache capacity of zero disables caching, and the
+  `lmdb-cache` feature provides an opt-in persistent implementation.
+- `ResolvePolicy` makes the source and freshness trade-off explicit:
+  `CacheOnly` avoids DHT queries, `CacheFirst` returns the fastest fresh result
+  without going backward from an expired cached packet, and `NetworkOnly`
+  aggregates the configured networks for their most recent observed state.
 
-- **Asynchronous by Default**: Built on async/await for optimal performance
-- **Runtime Agnostic**: Compatible with non-Tokio runtimes via `async_compat`
+The DHT, relay, and combined backend implementations are internal details.
+Select them through `ClientBuilder` rather than depending on their concrete
+types. With both backends enabled, publishing uses both concurrently;
+`NetworkOnly` resolution waits for both and selects the most recent result,
+while `CacheFirst` may finish as soon as a fresh result above the cache floor is
+available.
 
-### WebAssembly
+See the [integration guide](https://github.com/Pubky/pkarr/blob/main/docs/integration.md)
+for configuration examples and the
+[API documentation](https://docs.rs/pkarr/latest/pkarr/) for the full public
+surface.
 
-- **Browser Environment**: Designed for JavaScript/Wasm integration
-- **Relay Communication**: Uses browser's Fetch API for relay calls
-- **Limitations**: 
-  - Not compatible with WASI
-  - Cannot use WASI bindings for direct DHT access
+## Runtime and Platform Support
+
+- The client API is asynchronous.
+- On native targets, `async_compat` allows use with non-Tokio executors.
+- Browsers use the `relays` feature and Fetch-backed HTTP requests because they
+  cannot access the UDP DHT directly.
+- WASI is not supported.
+
+## More Documentation
+
+- [Quickstart](https://github.com/Pubky/pkarr/blob/main/docs/quickstart.md)
+- [Feature reference](https://github.com/Pubky/pkarr/blob/main/docs/features.md)
+- [Examples](https://github.com/Pubky/pkarr/tree/main/pkarr/examples)

--- a/pkarr/README.md
+++ b/pkarr/README.md
@@ -48,13 +48,13 @@ native targets, Pkarr also supports other executors through `async_compat`.
 
 ## Choosing Features
 
-| Use case | Dependency |
-|----------|------------|
-| Native application using DHT and relays | `pkarr = "7"` |
-| DHT only | `pkarr = { version = "7", default-features = false, features = ["dht"] }` |
-| Relay only or browser/WASM | `pkarr = { version = "7", default-features = false, features = ["relays"] }` |
-| Sign and verify packets without networking | `pkarr = { version = "7", default-features = false, features = ["signed_packet"] }` |
-| Key generation and parsing only | `pkarr = { version = "7", default-features = false }` |
+| Use case | Command |
+|----------|---------|
+| Native application using DHT and relays | `cargo add pkarr` |
+| DHT only | `cargo add pkarr --no-default-features --features dht` |
+| Relay only or browser/WASM | `cargo add pkarr --no-default-features --features relays` |
+| Sign and verify packets without networking | `cargo add pkarr --no-default-features --features signed_packet` |
+| Key generation and parsing only | `cargo add pkarr --no-default-features` |
 
 The default `full-client` feature enables both DHT and relay support. Browsers
 cannot access the UDP DHT directly and must use `relays`; WASI is not supported.

--- a/pkarr/README.md
+++ b/pkarr/README.md
@@ -1,59 +1,71 @@
 # Pkarr
 
-Rust implementation of [Pkarr](https://github.com/pubky/pkarr) for signing,
-publishing, and resolving DNS packets over
-[Mainline DHT](https://github.com/Pubky/mainline) and HTTP relays.
+Pkarr turns Ed25519 public keys into sovereign domain names. This crate creates
+and verifies signed DNS packets, then publishes and resolves them through the
+[Mainline DHT](https://github.com/Pubky/mainline), HTTP relays, or both.
 
-## Client Abstractions
+## Installation
 
-The public client API separates configuration, I/O, caching, and lookup
-freshness:
-
-```text
-ClientBuilder
-├── cache: InMemoryCache | custom Cache | disabled
-└── backend: DHT | HTTP relays | combined DHT + relays
-        ↓
-      Client
-      ├── publish(&SignedPacket)
-      └── resolve(&PublicKey, ResolvePolicy)
+```bash
+cargo add pkarr
 ```
 
-- `ClientBuilder` configures the cache, TTL bounds, timeouts, and available
-  network backends. The default native client uses both the DHT and the default
-  relays.
-- `Client` is the cloneable async facade that coordinates publishing,
-  resolution, cache updates, and consistent public errors.
-- `Cache` is replaceable. Clients use an in-memory LRU by default; a configured
-  cache size or custom-cache capacity of zero disables caching, and the
-  `lmdb-cache` feature provides an opt-in persistent implementation.
-- `ResolvePolicy` makes the source and freshness trade-off explicit:
-  `CacheOnly` avoids DHT queries, `CacheFirst` returns the fastest fresh result
-  without going backward from an expired cached packet, and `NetworkOnly`
-  aggregates the configured networks for their most recent observed state.
+The example below uses Tokio as its async runtime:
 
-The DHT, relay, and combined backend implementations are internal details.
-Select them through `ClientBuilder` rather than depending on their concrete
-types. With both backends enabled, publishing uses both concurrently;
-`NetworkOnly` resolution waits for both and selects the most recent result,
-while `CacheFirst` may finish as soon as a fresh result above the cache floor is
-available.
+```bash
+cargo add tokio --features macros,rt-multi-thread
+```
 
-See the [integration guide](https://github.com/Pubky/pkarr/blob/main/docs/integration.md)
-for configuration examples and the
-[API documentation](https://docs.rs/pkarr/latest/pkarr/) for the full public
-surface.
+## Quick Start
 
-## Runtime and Platform Support
+```rust,no_run
+use pkarr::{Client, Keypair, ResolvePolicy, SignedPacket};
 
-- The client API is asynchronous.
-- On native targets, `async_compat` allows use with non-Tokio executors.
-- Browsers use the `relays` feature and Fetch-backed HTTP requests because they
-  cannot access the UDP DHT directly.
-- WASI is not supported.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let keypair = Keypair::random();
+    println!("Public key: {}", keypair.public_key());
 
-## More Documentation
+    let packet = SignedPacket::builder()
+        .txt("_hello".try_into()?, "world".try_into()?, 300)
+        .sign(&keypair)?;
 
-- [Quickstart](https://github.com/Pubky/pkarr/blob/main/docs/quickstart.md)
-- [Feature reference](https://github.com/Pubky/pkarr/blob/main/docs/features.md)
-- [Examples](https://github.com/Pubky/pkarr/tree/main/pkarr/examples)
+    let client = Client::builder().build()?;
+    let stored_on = client.publish(&packet).await?;
+    println!("Stored on at least {stored_on} DHT nodes");
+
+    let resolved = client
+        .resolve(&keypair.public_key(), ResolvePolicy::CacheFirst)
+        .await?;
+    println!("Resolved:\n{resolved}");
+
+    Ok(())
+}
+```
+
+The client API is asynchronous. Tokio is used here to run the example; on
+native targets, Pkarr also supports other executors through `async_compat`.
+
+## Choosing Features
+
+| Use case | Dependency |
+|----------|------------|
+| Native application using DHT and relays | `pkarr = "7"` |
+| DHT only | `pkarr = { version = "7", default-features = false, features = ["dht"] }` |
+| Relay only or browser/WASM | `pkarr = { version = "7", default-features = false, features = ["relays"] }` |
+| Sign and verify packets without networking | `pkarr = { version = "7", default-features = false, features = ["signed_packet"] }` |
+| Key generation and parsing only | `pkarr = { version = "7", default-features = false }` |
+
+The default `full-client` feature enables both DHT and relay support. Browsers
+cannot access the UDP DHT directly and must use `relays`; WASI is not supported.
+Optional features also provide persistent LMDB caching, endpoint discovery,
+and reqwest integration. See the
+[feature reference](https://github.com/pubky/pkarr/blob/main/docs/features.md)
+for the complete list.
+
+## Next Steps
+
+- [Quickstart](https://github.com/pubky/pkarr/blob/main/docs/quickstart.md)
+- [Integration guide](https://github.com/pubky/pkarr/blob/main/docs/integration.md)
+- [Examples](https://github.com/pubky/pkarr/tree/main/pkarr/examples)
+- [API documentation](https://docs.rs/pkarr/latest/pkarr/)

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,28 +1,50 @@
 # Pkarr Relay
 
-A server that functions as a [pkarr relay](https://github.com/pubky/pkarr/blob/main/design/relays.md).
+The `pkarr-relay` binary is an HTTP gateway and cache for publishing and
+resolving Pkarr packets through the Mainline DHT. It implements the
+[Pkarr relay protocol](../design/relays.md).
 
-## Installation & Usage
-
-### Installation
+## Installation
 
 ```bash
 cargo install pkarr-relay
 ```
 
-### Running the Relay
+From a source checkout, inspect all CLI options with:
 
-#### With Custom Configuration
 ```bash
-pkarr-relay --config=./config.toml
+cargo run -p pkarr-relay -- --help
 ```
 
-You can find an example configuration file [here](https://github.com/pubky/pkarr/blob/main/relay/src/config.example.toml).
+## Running the Relay
 
-#### With Custom Logging
+Run with defaults:
+
 ```bash
-pkarr-relay  -t=pkarr=debug,tower_http=debug
+pkarr-relay
 ```
 
-Once running, the Pkarr relay will be accessible at http://localhost:6881 (unless the config file specifies another port number).
+By default, the HTTP server binds to `0.0.0.0:6881`, which exposes it on all
+IPv4 interfaces. It is available locally at `http://localhost:6881`, but it may
+also be reachable from the LAN or Internet. Apply appropriate firewall or
+reverse-proxy access controls on network-reachable hosts. The configuration
+file can change the port.
 
+Copy and edit the bundled
+[example configuration](./src/config.example.toml), then pass its path:
+
+```bash
+pkarr-relay --config ./config.toml
+```
+
+Configure logging with a tracing filter:
+
+```bash
+pkarr-relay --tracing-env-filter pkarr_relay=debug,tower_http=debug
+```
+
+For local development, start an isolated DHT and relay on port `15411`:
+
+```bash
+pkarr-relay --testnet
+```

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,8 +1,8 @@
 # Pkarr Relay
 
 The `pkarr-relay` binary is an HTTP gateway and cache for publishing and
-resolving Pkarr packets through the Mainline DHT. It implements the
-[Pkarr relay protocol](../design/relays.md).
+resolving Pkarr packets through the Mainline DHT. See
+[how Pkarr relays work](../design/relays.md).
 
 ## Installation
 
@@ -37,14 +37,12 @@ Copy and edit the bundled
 pkarr-relay --config ./config.toml
 ```
 
+Without `cache.path`, the relay creates a new cache in a temporary directory on
+each run. Configure a stable path if the cache should survive restarts. The
+example file also documents DHT, TTL, and rate-limit settings.
+
 Configure logging with a tracing filter:
 
 ```bash
 pkarr-relay --tracing-env-filter pkarr_relay=debug,tower_http=debug
-```
-
-For local development, start an isolated DHT and relay on port `15411`:
-
-```bash
-pkarr-relay --testnet
 ```


### PR DESCRIPTION
Describe builder, cache, backend, and resolve-policy interactions.
Add relay binary usage, current CLI options, and default network binding.
