### PR TITLE
refactor(dht)!: decouple public API from mainline

### DIFF
--- a/.github/workflows/ci-js.yaml
+++ b/.github/workflows/ci-js.yaml
@@ -36,7 +36,7 @@ jobs:
           node-version: 'lts/*'
 
       - name: Build server
-        run: cargo build
+        run: cargo build -p pkarr-relay --features testnet
 
       - name: Build WASM package
         env:

--- a/.github/workflows/ci-wasm.yaml
+++ b/.github/workflows/ci-wasm.yaml
@@ -31,7 +31,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build server
-        run: cargo build
+        run: cargo build -p pkarr-relay --features testnet
 
       - name: Start server and run tests
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,7 @@ dependencies = [
  "governor",
  "http",
  "httpdate",
+ "mainline",
  "pkarr",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ resolver = "3"
 name = "pkarr"
 
 [workspace.dependencies]
+mainline = { version = "7", default-features = false, features = ["async"] }
 # rustls feature is needed for reqwest to work with HTTPS.
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }

--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -4,7 +4,8 @@ Wasm-pack wrap of [pkarr](https://github.com/pubky/pkarr) client.
 
 ## How To Build/Test the NPM Package
 
-1. Create a binary to run a testnet mainline DHT and Pkarr relay. Go to the root folder and `cargo build`
+1. Create a binary to run a testnet mainline DHT and Pkarr relay. Go to the root
+   folder and run `cargo build -p pkarr-relay --features testnet`
 2. Go to `bindings/js/pkg`
 3. Run `npm run build`
 5. Run tests with `npm run test`

--- a/bindings/js/pkg/README.md
+++ b/bindings/js/pkg/README.md
@@ -136,7 +136,7 @@ The client by **default** uses the following relays:
 To publish the records to a custom relay, compile the `pkarr-relay` binary from source. Navigate to the pkarr [repository](https://github.com/pubky/pkarr) and:
 
 ```bash
-cargo build
+cargo build -p pkarr-relay --features testnet
 ./target/debug/pkarr-relay --testnet
 ```
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -96,8 +96,8 @@ let client = Client::builder()
 Calling `build()` after `no_default_network()` without configuring at least one
 backend returns `BuildError::NoNetwork`.
 
-For a private DHT, use testnet diagnostic thresholds and customize the
-underlying `mainline::Config` when needed:
+For a private DHT, use testnet diagnostic thresholds and customize
+`pkarr::dht::DhtConfig` through `ClientBuilder::dht` when needed:
 
 ```rust
 use pkarr::{dht::ReportPolicy, Client};

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -53,7 +53,7 @@ getrandom = { version = "0.4", default-features = false }
 tracing = { version = "0.1", optional = true }
 
 # feat: dht dependencies
-mainline = { version = "7", default-features = false, features = ["async"], optional = true }
+mainline = { workspace = true, optional = true }
 
 # feat: relay dependencies
 reqwest = { workspace = true, optional = true }

--- a/pkarr/src/client/backend/backend_impl.rs
+++ b/pkarr/src/client/backend/backend_impl.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::client::{BuildError, PublishError, ResolveError};
 #[cfg(dht)]
-use crate::dht::{DhtClient, ReportPolicy};
+use crate::dht::{DhtClient, DhtConfig, ReportPolicy};
 use crate::{PublicKey, SignedPacket, StoredNodeCount};
 
 #[cfg(all(dht, relays))]
@@ -43,7 +43,7 @@ impl Backend {
 
     #[cfg(dht)]
     pub(in crate::client) fn dht(
-        config: mainline::Config,
+        config: DhtConfig,
         report_policy: ReportPolicy,
     ) -> Result<Self, BuildError> {
         let client = DhtClient::build(config).map_err(BuildError::DhtBuildError)?;

--- a/pkarr/src/client/builder.rs
+++ b/pkarr/src/client/builder.rs
@@ -5,6 +5,8 @@ use std::{sync::Arc, time::Duration};
 #[cfg(feature = "relays")]
 use url::Url;
 
+#[cfg(dht)]
+use crate::dht::DhtConfig;
 use crate::{Cache, DEFAULT_CACHE_SIZE, DEFAULT_MAXIMUM_TTL, DEFAULT_MINIMUM_TTL};
 
 use crate::{errors::BuildError, Client};
@@ -34,7 +36,7 @@ pub(crate) struct Config {
     pub cache: Option<Arc<dyn Cache>>,
 
     #[cfg(dht)]
-    pub dht: Option<mainline::Config>,
+    pub dht: Option<DhtConfig>,
     /// Policy used to classify DHT publish and resolve diagnostics.
     #[cfg(dht)]
     pub dht_report_policy: crate::dht::ReportPolicy,
@@ -128,11 +130,11 @@ pub struct ClientBuilder(Config);
 impl ClientBuilder {
     /// Similar to a crate's `--no-default-features` option, this method removes the
     /// default [`Self::bootstrap`] and [`Self::relays`], effectively disabling both
-    /// [`mainline`] and [relays](https://github.com/pubky/pkarr/blob/main/design/relays.md).
+    /// the DHT and [relays](https://github.com/pubky/pkarr/blob/main/design/relays.md).
     ///
     /// Use [`Self::relays`] to configure custom relays.
     ///
-    /// Similarly, use [`Self::bootstrap`] or [`Self::dht`] to configure [`mainline`].
+    /// Similarly, use [`Self::bootstrap`] or [`Self::dht`] to configure the DHT.
     pub fn no_default_network(&mut self) -> &mut Self {
         self.no_dht();
         self.no_relays();
@@ -151,10 +153,10 @@ impl ClientBuilder {
     }
 
     #[cfg(dht)]
-    /// Creates a [`mainline::Config`] when absent and allows it to be mutated with a callback.
+    /// Creates a [`crate::dht::DhtConfig`] when absent and allows it to be mutated with a callback.
     pub fn dht<F>(&mut self, f: F) -> &mut Self
     where
-        F: FnOnce(&mut mainline::Config) -> &mut mainline::Config,
+        F: FnOnce(&mut DhtConfig) -> &mut DhtConfig,
     {
         if self.0.dht.is_none() {
             self.0.dht = Some(make_dht_config(self.0.request_timeout));
@@ -347,8 +349,8 @@ impl ClientBuilder {
 }
 
 #[cfg(dht)]
-fn make_dht_config(request_timeout: Duration) -> mainline::Config {
-    mainline::Config {
+fn make_dht_config(request_timeout: Duration) -> DhtConfig {
+    DhtConfig {
         request_timeout,
         ..Default::default()
     }

--- a/pkarr/src/client/tests.rs
+++ b/pkarr/src/client/tests.rs
@@ -71,7 +71,7 @@ pub(crate) fn builder(
 #[tokio::test]
 async fn publish_resolve(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let a = builder(&relay, &testnet, networks).build().unwrap();
 
@@ -107,7 +107,7 @@ async fn publish_resolve(#[case] networks: Networks) {
 #[tokio::test]
 async fn client_send(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let a = builder(&relay, &testnet, networks).build().unwrap();
 
@@ -147,7 +147,7 @@ async fn client_send(#[case] networks: Networks) {
 #[tokio::test]
 async fn return_expired_packet_fallback(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let client = builder(&relay, &testnet, networks)
         .maximum_ttl(0)
@@ -186,7 +186,7 @@ async fn return_expired_packet_fallback(#[case] networks: Networks) {
 #[tokio::test]
 async fn cache_first_rejects_network_packet_older_than_expired_cache(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let publisher = builder(&relay, &testnet, networks).build().unwrap();
     let resolver = builder(&relay, &testnet, networks)
@@ -233,7 +233,7 @@ async fn cache_first_rejects_network_packet_older_than_expired_cache(#[case] net
 #[tokio::test]
 async fn network_only_ignores_newer_local_cache(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let publisher = builder(&relay, &testnet, networks).build().unwrap();
     let resolver = builder(&relay, &testnet, networks).build().unwrap();
@@ -272,7 +272,7 @@ async fn network_only_ignores_newer_local_cache(#[case] networks: Networks) {
 #[tokio::test]
 async fn ttl_0_test(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let client = builder(&relay, &testnet, networks)
         .maximum_ttl(0)
@@ -313,7 +313,7 @@ async fn ttl_0_test(#[case] networks: Networks) {
 #[tokio::test]
 async fn not_found(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
 
@@ -342,7 +342,7 @@ fn no_network() {
 #[tokio::test]
 async fn repeated_publish_query(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
 
@@ -770,7 +770,7 @@ async fn cache_first_waits_for_fresh_relay_after_expired_response() {
 #[tokio::test]
 async fn concurrent_resolve(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let a = builder(&relay, &testnet, networks).build().unwrap();
     let b = builder(&relay, &testnet, networks).build().unwrap();
@@ -809,7 +809,7 @@ async fn concurrent_resolve(#[case] networks: Networks) {
 #[tokio::test]
 async fn concurrent_publish_same_packet(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
 
@@ -842,7 +842,7 @@ async fn concurrent_publish_same_packet(#[case] networks: Networks) {
 #[tokio::test]
 async fn concurrent_publish_of_different_packets(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
 
@@ -890,7 +890,7 @@ async fn concurrent_publish_of_different_packets(#[case] networks: Networks) {
 #[tokio::test]
 async fn conflict_302(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(10).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let client = builder(&relay, &testnet, networks).build().unwrap();
 
@@ -1031,7 +1031,7 @@ fn no_tokio(#[case] networks: Networks) {
     futures_lite::future::block_on(async {
         let (relay, testnet) = async_compat::Compat::new(async {
             let testnet = mainline::Testnet::builder(5).build().unwrap();
-            let relay = Relay::run_test(&testnet).await.unwrap();
+            let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
             (relay, testnet)
         })
@@ -1072,7 +1072,7 @@ fn no_tokio(#[case] networks: Networks) {
 #[tokio::test]
 async fn zero_cache_size(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let a = builder(&relay, &testnet, networks).build().unwrap();
 
@@ -1130,7 +1130,7 @@ async fn zero_cache_size(#[case] networks: Networks) {
 #[tokio::test]
 async fn publish_resolve_most_recent_with_no_cache(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let a = builder(&relay, &testnet, networks).build().unwrap();
 
@@ -1162,7 +1162,7 @@ async fn publish_resolve_most_recent_with_no_cache(#[case] networks: Networks) {
 #[tokio::test]
 async fn republish_after_resolve(#[case] networks: Networks) {
     let testnet = mainline::Testnet::builder(5).build().unwrap();
-    let relay = Relay::run_test(&testnet).await.unwrap();
+    let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
     let keypair = Keypair::random();
     let signed_packet = SignedPacket::builder()
@@ -1192,7 +1192,7 @@ async fn republish_after_resolve(#[case] networks: Networks) {
 async fn discard_cache_with_zero_capacity() {
     use std::net::ToSocketAddrs;
 
-    let testnet = crate::mainline::Testnet::builder(2).build().unwrap();
+    let testnet = mainline::Testnet::builder(2).build().unwrap();
 
     // Create relay
     let storage = std::env::temp_dir().join(Timestamp::now().to_string());
@@ -1312,7 +1312,7 @@ mod reqwest_builder {
     #[tokio::test]
     async fn reqwest_pkarr_domain(#[case] networks: Networks) {
         let testnet = mainline::Testnet::builder(5).build().unwrap();
-        let relay = Relay::run_test(&testnet).await.unwrap();
+        let relay = Relay::run_test(&testnet.bootstrap).await.unwrap();
 
         let keypair = Keypair::random();
 

--- a/pkarr/src/dht/client.rs
+++ b/pkarr/src/dht/client.rs
@@ -2,13 +2,15 @@ use ed25519_dalek::Signature;
 use futures_lite::{Stream, StreamExt};
 use mainline::{
     async_dht::{AsyncDht, GetMutableDetailed},
-    Config, Dht, MutableItem,
+    Dht, MutableItem,
 };
 use ntimestamp::Timestamp;
 
 use crate::{PublicKey, SignedPacket, StoredNodeCount};
 
-use super::{DhtInfo, PublishError, ResolveError, ResolveOutcome, ResolveReport, ResolveResponse};
+use super::{
+    DhtConfig, DhtInfo, PublishError, ResolveError, ResolveOutcome, ResolveReport, ResolveResponse,
+};
 
 /// Pkarr DHT client.
 #[derive(Clone, Debug)]
@@ -17,9 +19,9 @@ pub struct DhtClient {
 }
 
 impl DhtClient {
-    /// Build a DHT client from a Mainline configuration.
-    pub fn build(config: Config) -> Result<Self, std::io::Error> {
-        let dht = Dht::new(config)?;
+    /// Build a DHT client from pkarr's DHT configuration.
+    pub fn build(config: DhtConfig) -> Result<Self, std::io::Error> {
+        let dht = Dht::new(config.into_mainline())?;
         Ok(Self {
             inner: dht.as_async(),
         })
@@ -37,7 +39,7 @@ impl DhtClient {
     ) -> Result<StoredNodeCount, PublishError> {
         Ok(self
             .inner
-            .put_mutable(signed_packet.into(), None)
+            .put_mutable(mutable_item_from_signed_packet(signed_packet), None)
             .await?
             .stored_at)
     }
@@ -52,7 +54,7 @@ impl DhtClient {
 
         self.inner
             .get_mutable(public_key.as_bytes(), None, more_recent_than)
-            .filter_map(|item| SignedPacket::try_from(item).ok())
+            .filter_map(|item| signed_packet_from_mutable_item(&item).ok())
     }
 
     /// Resolve signed packets newer than the given timestamp and return query diagnostics.
@@ -84,7 +86,7 @@ impl DhtClient {
             // older valid signed packets for this key.
             if seq >= highest_seq.unwrap_or(seq) {
                 highest_seq = Some(seq);
-                if let Ok(packet) = SignedPacket::try_from(&item) {
+                if let Ok(packet) = signed_packet_from_mutable_item(&item) {
                     let most_recent = packet.clone();
                     return ResolveResponse::new(
                         Some(packet),
@@ -110,45 +112,33 @@ impl DhtClient {
     }
 }
 
-impl From<&SignedPacket> for MutableItem {
-    fn from(s: &SignedPacket) -> Self {
-        Self::new_signed_unchecked(
-            s.public_key().to_bytes(),
-            s.signature().to_bytes(),
-            // Packet
-            s.inner.borrow_owner()[104..].into(),
-            s.timestamp().as_u64() as i64,
-            None,
-        )
-    }
+fn mutable_item_from_signed_packet(s: &SignedPacket) -> MutableItem {
+    MutableItem::new_signed_unchecked(
+        s.public_key().to_bytes(),
+        s.signature().to_bytes(),
+        // Packet
+        s.inner.borrow_owner()[104..].into(),
+        s.timestamp().as_u64() as i64,
+        None,
+    )
 }
 
-impl TryFrom<&MutableItem> for SignedPacket {
-    type Error = crate::errors::SignedPacketVerifyError;
+fn signed_packet_from_mutable_item(
+    i: &MutableItem,
+) -> Result<SignedPacket, crate::errors::SignedPacketVerifyError> {
+    let public_key = PublicKey::try_from(i.key())?;
+    let seq = i.seq() as u64;
+    let signature: Signature = i.signature().into();
 
-    fn try_from(i: &MutableItem) -> Result<Self, crate::errors::SignedPacketVerifyError> {
-        let public_key = PublicKey::try_from(i.key())?;
-        let seq = i.seq() as u64;
-        let signature: Signature = i.signature().into();
-
-        Ok(Self {
-            inner: crate::types::signed_packet::Inner::try_from_parts(
-                &public_key,
-                &signature,
-                seq,
-                i.value(),
-            )?,
-            last_seen: Timestamp::now(),
-        })
-    }
-}
-
-impl TryFrom<MutableItem> for SignedPacket {
-    type Error = crate::errors::SignedPacketVerifyError;
-
-    fn try_from(i: MutableItem) -> Result<Self, crate::errors::SignedPacketVerifyError> {
-        SignedPacket::try_from(&i)
-    }
+    Ok(SignedPacket {
+        inner: crate::types::signed_packet::Inner::try_from_parts(
+            &public_key,
+            &signature,
+            seq,
+            i.value(),
+        )?,
+        last_seen: Timestamp::now(),
+    })
 }
 
 async fn finish_resolve(
@@ -160,7 +150,7 @@ async fn finish_resolve(
         let seq = item.seq();
         if seq >= highest_seq.unwrap_or(seq) {
             highest_seq = Some(seq);
-            match SignedPacket::try_from(&item) {
+            match signed_packet_from_mutable_item(&item) {
                 Ok(packet)
                     if most_recent
                         .as_ref()
@@ -238,7 +228,7 @@ mod tests {
             .sign(&keypair)
             .unwrap();
 
-        let item: MutableItem = (&signed_packet).into();
+        let item = super::mutable_item_from_signed_packet(&signed_packet);
         let seq = signed_packet.timestamp().as_u64() as i64;
 
         let expected = MutableItem::new(

--- a/pkarr/src/dht/config.rs
+++ b/pkarr/src/dht/config.rs
@@ -1,0 +1,107 @@
+use std::{
+    fmt::Debug,
+    net::{Ipv4Addr, SocketAddrV4},
+    sync::Arc,
+    time::Duration,
+};
+
+/// Filters incoming DHT requests.
+pub trait RequestFilter: Debug + Send + Sync {
+    /// Return whether a request from `from` should be handled.
+    fn allow_request(&self, from: SocketAddrV4) -> bool;
+}
+
+/// Configuration for a [`super::DhtClient`].
+#[derive(Clone, Debug)]
+pub struct DhtConfig {
+    /// UDP port used by the DHT node.
+    ///
+    /// When `None`, the DHT implementation's default port is used.
+    pub port: Option<u16>,
+    /// Whether the DHT node should answer incoming requests.
+    pub server_mode: bool,
+    /// DHT nodes used to bootstrap discovery.
+    ///
+    /// When `None`, the DHT implementation's default bootstrap nodes are used.
+    pub bootstrap: Option<Vec<SocketAddrV4>>,
+    /// Local IPv4 address to bind the DHT socket to.
+    ///
+    /// When `None`, the operating system chooses the local address.
+    pub bind_address: Option<Ipv4Addr>,
+    /// Maximum duration for a DHT request.
+    pub request_timeout: Duration,
+    /// Filter for incoming DHT requests.
+    pub request_filter: Option<Arc<dyn RequestFilter>>,
+}
+
+impl Default for DhtConfig {
+    fn default() -> Self {
+        Self {
+            port: None,
+            server_mode: false,
+            bootstrap: None,
+            bind_address: None,
+            request_timeout: crate::DEFAULT_REQUEST_TIMEOUT,
+            request_filter: None,
+        }
+    }
+}
+
+impl DhtConfig {
+    pub(super) fn into_mainline(self) -> mainline::Config {
+        let mut config = mainline::Config {
+            bootstrap: self.bootstrap,
+            bind_address: self.bind_address,
+            request_timeout: self.request_timeout,
+            server_mode: self.server_mode,
+            ..Default::default()
+        };
+
+        if let Some(port) = self.port {
+            config.port = Some(port);
+        }
+
+        if let Some(filter) = self.request_filter {
+            config.server_settings = mainline::ServerSettings {
+                filter: Box::new(MainlineRequestFilter(filter)),
+                ..Default::default()
+            };
+        }
+
+        config
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MainlineRequestFilter(Arc<dyn RequestFilter>);
+
+impl mainline::RequestFilter for MainlineRequestFilter {
+    fn allow_request(&self, _request: &mainline::RequestSpecific, from: SocketAddrV4) -> bool {
+        self.0.allow_request(from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_client_configuration_to_mainline() {
+        let bootstrap = "127.0.0.1:6881".parse().unwrap();
+        let config = DhtConfig {
+            port: Some(6881),
+            server_mode: true,
+            bootstrap: Some(vec![bootstrap]),
+            bind_address: Some(Ipv4Addr::LOCALHOST),
+            request_timeout: Duration::from_secs(5),
+            ..Default::default()
+        };
+
+        let mainline = config.into_mainline();
+
+        assert_eq!(mainline.port, Some(6881));
+        assert_eq!(mainline.bootstrap, Some(vec![bootstrap]));
+        assert_eq!(mainline.bind_address, Some(Ipv4Addr::LOCALHOST));
+        assert_eq!(mainline.request_timeout, Duration::from_secs(5));
+    }
+}

--- a/pkarr/src/dht/config.rs
+++ b/pkarr/src/dht/config.rs
@@ -12,6 +12,7 @@ pub trait RequestFilter: Debug + Send + Sync {
 }
 
 /// Configuration for a [`super::DhtClient`].
+#[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct DhtConfig {
     /// UDP port used by the DHT node.
@@ -20,6 +21,10 @@ pub struct DhtConfig {
     pub port: Option<u16>,
     /// Whether the DHT node should answer incoming requests.
     pub server_mode: bool,
+    /// Known public IPv4 address used to generate a BEP 42 secure node ID.
+    ///
+    /// When `None`, the DHT discovers its public address from peers.
+    pub public_ip: Option<Ipv4Addr>,
     /// DHT nodes used to bootstrap discovery.
     ///
     /// When `None`, the DHT implementation's default bootstrap nodes are used.
@@ -39,6 +44,7 @@ impl Default for DhtConfig {
         Self {
             port: None,
             server_mode: false,
+            public_ip: None,
             bootstrap: None,
             bind_address: None,
             request_timeout: crate::DEFAULT_REQUEST_TIMEOUT,
@@ -51,15 +57,13 @@ impl DhtConfig {
     pub(super) fn into_mainline(self) -> mainline::Config {
         let mut config = mainline::Config {
             bootstrap: self.bootstrap,
+            port: self.port,
             bind_address: self.bind_address,
             request_timeout: self.request_timeout,
             server_mode: self.server_mode,
+            public_ip: self.public_ip,
             ..Default::default()
         };
-
-        if let Some(port) = self.port {
-            config.port = Some(port);
-        }
 
         if let Some(filter) = self.request_filter {
             config.server_settings = mainline::ServerSettings {
@@ -75,9 +79,15 @@ impl DhtConfig {
 #[derive(Clone, Debug)]
 struct MainlineRequestFilter(Arc<dyn RequestFilter>);
 
+impl MainlineRequestFilter {
+    fn is_allowed(&self, from: SocketAddrV4) -> bool {
+        self.0.allow_request(from)
+    }
+}
+
 impl mainline::RequestFilter for MainlineRequestFilter {
     fn allow_request(&self, _request: &mainline::RequestSpecific, from: SocketAddrV4) -> bool {
-        self.0.allow_request(from)
+        self.is_allowed(from)
     }
 }
 
@@ -91,6 +101,7 @@ mod tests {
         let config = DhtConfig {
             port: Some(6881),
             server_mode: true,
+            public_ip: Some("203.0.113.10".parse().unwrap()),
             bootstrap: Some(vec![bootstrap]),
             bind_address: Some(Ipv4Addr::LOCALHOST),
             request_timeout: Duration::from_secs(5),
@@ -100,8 +111,27 @@ mod tests {
         let mainline = config.into_mainline();
 
         assert_eq!(mainline.port, Some(6881));
+        assert_eq!(mainline.public_ip, Some("203.0.113.10".parse().unwrap()));
         assert_eq!(mainline.bootstrap, Some(vec![bootstrap]));
         assert_eq!(mainline.bind_address, Some(Ipv4Addr::LOCALHOST));
         assert_eq!(mainline.request_timeout, Duration::from_secs(5));
+        assert!(mainline.server_mode);
+    }
+
+    #[derive(Debug)]
+    struct LocalhostOnly;
+
+    impl RequestFilter for LocalhostOnly {
+        fn allow_request(&self, from: SocketAddrV4) -> bool {
+            from.ip().is_loopback()
+        }
+    }
+
+    #[test]
+    fn mainline_request_filter_delegates_to_dht_filter() {
+        let filter = MainlineRequestFilter(Arc::new(LocalhostOnly));
+
+        assert!(filter.is_allowed("127.0.0.1:6881".parse().unwrap()));
+        assert!(!filter.is_allowed("203.0.113.10:6881".parse().unwrap()));
     }
 }

--- a/pkarr/src/dht/mod.rs
+++ b/pkarr/src/dht/mod.rs
@@ -1,6 +1,7 @@
 //! Mainline DHT integration.
 
 mod client;
+mod config;
 mod error;
 mod info;
 mod report_policy;
@@ -8,6 +9,7 @@ mod resolve_report;
 mod resolve_response;
 
 pub use client::DhtClient;
+pub use config::{DhtConfig, RequestFilter};
 pub use error::{PublishError, ResolveError};
 pub use info::DhtInfo;
 pub use report_policy::{PublishWarning, ReportPolicy, ResolveWarning};

--- a/pkarr/src/extra/endpoints/mod.rs
+++ b/pkarr/src/extra/endpoints/mod.rs
@@ -124,9 +124,9 @@ impl std::fmt::Display for CouldNotResolveEndpoint {
 mod tests {
 
     use crate::dns::rdata::SVCB;
-    use crate::mainline::Testnet;
     use crate::{Client, Keypair};
     use crate::{PublicKey, SignedPacket};
+    use mainline::Testnet;
 
     use std::future::Future;
     use std::net::{IpAddr, Ipv4Addr};

--- a/pkarr/src/lib.rs
+++ b/pkarr/src/lib.rs
@@ -43,8 +43,6 @@ pub use client::{builder::DEFAULT_REQUEST_TIMEOUT, Client, ClientBuilder};
 pub use types::*;
 
 // Rexports
-#[cfg(dht)]
-pub use mainline;
 #[cfg(feature = "signed_packet")]
 pub use ntimestamp::Timestamp;
 #[cfg(feature = "signed_packet")]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -21,7 +21,7 @@ categories = ["network-programming"]
 [dependencies]
 anyhow = "1"
 axum = "0.8"
-mainline = { workspace = true }
+mainline = { workspace = true, optional = true }
 tokio = { version = "1", features = [
     "fs",
     "macros",
@@ -48,7 +48,11 @@ pkarr = { path = "../pkarr", version = "7", default-features = false, features =
 ] }
 
 [dev-dependencies]
+mainline = { workspace = true }
 reqwest = { workspace = true }
+
+[features]
+testnet = ["dep:mainline"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -21,6 +21,7 @@ categories = ["network-programming"]
 [dependencies]
 anyhow = "1"
 axum = "0.8"
+mainline = { workspace = true }
 tokio = { version = "1", features = [
     "fs",
     "macros",

--- a/relay/src/config.example.toml
+++ b/relay/src/config.example.toml
@@ -7,6 +7,9 @@ port = 6881
 [mainline]
 # Port to run the internal Mainline DHT node on.
 port = 6881
+# Known public IPv4 address used to generate a BEP 42 secure node ID.
+# When omitted, the DHT discovers its public address from peers.
+# public_ip = "203.0.113.10"
 
 # Cache settings
 [cache]

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -3,7 +3,10 @@
 use anyhow::{Context, Result};
 use pkarr::{DEFAULT_MAXIMUM_TTL, DEFAULT_MINIMUM_TTL};
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::{
+    net::Ipv4Addr,
+    path::{Path, PathBuf},
+};
 
 use crate::rate_limiting::RateLimiterConfig;
 
@@ -50,6 +53,7 @@ impl Default for HttpConfig {
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub struct MainlineConfig {
     pub port: Option<u16>,
+    pub public_ip: Option<Ipv4Addr>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -271,6 +271,7 @@ impl Relay {
     /// # Safety
     /// Homeserver uses LMDB, opening which is marked [unsafe](https://docs.rs/heed/latest/heed/struct.EnvOpenOptions.html#safety-1),
     /// because the possible Undefined Behavior (UB) if the lock file is broken.
+    #[cfg(feature = "testnet")]
     pub async unsafe fn run_testnet() -> anyhow::Result<Self> {
         let testnet = mainline::Testnet::builder(10).build()?;
 
@@ -312,10 +313,10 @@ impl Relay {
 }
 
 fn dht_config(config: &RelayConfig) -> DhtConfig {
-    DhtConfig {
-        port: config.mainline.port,
-        ..Default::default()
-    }
+    let mut dht_config = DhtConfig::default();
+    dht_config.port = config.mainline.port;
+    dht_config.public_ip = config.mainline.public_ip;
+    dht_config
 }
 
 struct RateLimiters {
@@ -422,7 +423,23 @@ mod tests {
         Keypair, SignedPacket, Timestamp, PKARR_DHT_STORED_NODES, PKARR_INVALID_SIGNED_PACKET_SEQ,
     };
 
-    use super::{to_socket_address_v4, RateLimiterConfig, Relay, RequestCountQuota};
+    use super::{dht_config, to_socket_address_v4, RateLimiterConfig, Relay, RequestCountQuota};
+
+    #[test]
+    fn relay_config_maps_public_ip_to_dht() {
+        let config: crate::config::RelayConfig = toml::from_str(
+            r#"
+[mainline]
+public_ip = "203.0.113.10"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            dht_config(&config).public_ip,
+            Some(Ipv4Addr::new(203, 0, 113, 10))
+        );
+    }
 
     #[tokio::test]
     async fn cors_exposes_invalid_signed_packet_seq_header() {

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -33,9 +33,9 @@ use tower_http::{cors::CorsLayer, trace::TraceLayer};
 use tracing::info;
 
 use pkarr::{
-    dht::{DhtClient, ReportPolicy},
+    dht::{DhtClient, DhtConfig, ReportPolicy},
     extra::lmdb_cache::LmdbCache,
-    mainline, Timestamp, PKARR_DHT_STORED_NODES, PKARR_INVALID_SIGNED_PACKET_SEQ,
+    Timestamp, PKARR_DHT_STORED_NODES, PKARR_INVALID_SIGNED_PACKET_SEQ,
 };
 use url::Url;
 
@@ -48,7 +48,7 @@ pub use rate_limiting::RateLimiterConfig;
 /// A builder for Pkarr [Relay]
 pub struct RelayBuilder {
     config: RelayConfig,
-    dht: mainline::Config,
+    dht: DhtConfig,
     report_policy: ReportPolicy,
 }
 
@@ -108,10 +108,10 @@ impl RelayBuilder {
         self
     }
 
-    /// Allows mutating the internal [pkarr::mainline] DHT configuration.
+    /// Allows mutating the DHT configuration.
     pub fn dht<F>(&mut self, f: F) -> &mut Self
     where
-        F: FnOnce(&mut pkarr::mainline::Config) -> &mut pkarr::mainline::Config,
+        F: FnOnce(&mut DhtConfig) -> &mut DhtConfig,
     {
         f(&mut self.dht);
 
@@ -157,14 +157,14 @@ impl Relay {
     /// # Returns
     /// A `Result` containing the `Relay` instance or an error.
     async unsafe fn run(config: RelayConfig) -> anyhow::Result<Self> {
-        let dht_config = mainline_config(&config);
+        let dht_config = dht_config(&config);
 
         unsafe { Self::run_with_dht(config, dht_config, ReportPolicy::mainnet()) }.await
     }
 
     async unsafe fn run_with_dht(
         config: RelayConfig,
-        mut dht_config: mainline::Config,
+        mut dht_config: DhtConfig,
         report_policy: ReportPolicy,
     ) -> anyhow::Result<Self> {
         tracing::debug!(?config, "Pkarr server config");
@@ -226,7 +226,7 @@ impl Relay {
     pub fn builder() -> RelayBuilder {
         RelayBuilder {
             config: Default::default(),
-            dht: Default::default(),
+            dht: dht_config(&RelayConfig::default()),
             report_policy: ReportPolicy::mainnet(),
         }
     }
@@ -245,20 +245,20 @@ impl Relay {
     /// Run an ephemeral Pkarr relay on a random port number for testing purposes.
     /// Binds to `127.0.0.1`.
     /// # Arguments
-    /// * `testnet` - A reference to a `mainline::Testnet` for bootstrapping the DHT.
+    /// * `bootstrap` - DHT node addresses used for bootstrapping.
     ///
     /// # Safety
     /// Homeserver uses LMDB, opening which is marked [unsafe](https://docs.rs/heed/latest/heed/struct.EnvOpenOptions.html#safety-1),
     /// because the possible Undefined Behavior (UB) if the lock file is broken.
-    pub async fn run_test(testnet: &pkarr::mainline::Testnet) -> anyhow::Result<Self> {
+    pub async fn run_test<T: ToSocketAddrs>(bootstrap: &[T]) -> anyhow::Result<Self> {
         let config = RelayConfig {
             http: config::HttpConfig { port: 0 },
             rate_limiter: None,
             ..Default::default()
         };
 
-        let mut dht_config = mainline_config(&config);
-        dht_config.bootstrap = Some(to_socket_address_v4(&testnet.bootstrap));
+        let mut dht_config = dht_config(&config);
+        dht_config.bootstrap = Some(to_socket_address_v4(bootstrap));
         dht_config.request_timeout = Duration::from_millis(100);
         dht_config.server_mode = true;
         dht_config.bind_address = Some(std::net::Ipv4Addr::LOCALHOST);
@@ -272,7 +272,7 @@ impl Relay {
     /// Homeserver uses LMDB, opening which is marked [unsafe](https://docs.rs/heed/latest/heed/struct.EnvOpenOptions.html#safety-1),
     /// because the possible Undefined Behavior (UB) if the lock file is broken.
     pub async unsafe fn run_testnet() -> anyhow::Result<Self> {
-        let testnet = pkarr::mainline::Testnet::builder(10).build()?;
+        let testnet = mainline::Testnet::builder(10).build()?;
 
         // Leaking the testnet to avoid dropping and shutting them down.
         for node in testnet.nodes {
@@ -285,7 +285,7 @@ impl Relay {
             ..Default::default()
         };
 
-        let mut dht_config = mainline_config(&config);
+        let mut dht_config = dht_config(&config);
         dht_config.bootstrap = Some(to_socket_address_v4(&testnet.bootstrap));
         dht_config.request_timeout = Duration::from_millis(100);
         dht_config.server_mode = true;
@@ -311,8 +311,8 @@ impl Relay {
     }
 }
 
-fn mainline_config(config: &RelayConfig) -> mainline::Config {
-    mainline::Config {
+fn dht_config(config: &RelayConfig) -> DhtConfig {
+    DhtConfig {
         port: config.mainline.port,
         ..Default::default()
     }
@@ -326,7 +326,7 @@ struct RateLimiters {
 
 async fn build_rate_limiters(
     rate_limiter_config: Option<&RateLimiterConfig>,
-    dht_config: &mut mainline::Config,
+    dht_config: &mut DhtConfig,
 ) -> anyhow::Result<RateLimiters> {
     let Some(rate_limiter_config) = rate_limiter_config else {
         return Ok(RateLimiters {
@@ -346,10 +346,7 @@ async fn build_rate_limiters(
         .await
         .map_err(|e| anyhow!("Failed to build DhtRateLimiter: {e}"))?;
 
-    dht_config.server_settings = pkarr::mainline::ServerSettings {
-        filter: Box::new(dht),
-        ..Default::default()
-    };
+    dht_config.request_filter = Some(Arc::new(dht));
 
     Ok(RateLimiters {
         http: Some(http),
@@ -429,7 +426,7 @@ mod tests {
 
     #[tokio::test]
     async fn cors_exposes_invalid_signed_packet_seq_header() {
-        let testnet = pkarr::mainline::Testnet::builder(2).build().unwrap();
+        let testnet = mainline::Testnet::builder(2).build().unwrap();
         let relay = run_rate_limited_relay(&testnet).await;
 
         let response = reqwest::Client::new()
@@ -460,7 +457,7 @@ mod tests {
 
     #[tokio::test]
     async fn user_dht_rate_limit_only_blocks_dht_operations() {
-        let testnet = pkarr::mainline::Testnet::builder(2).build().unwrap();
+        let testnet = mainline::Testnet::builder(2).build().unwrap();
         let relay = run_rate_limited_relay(&testnet).await;
         let http = reqwest::Client::new();
         let keypair = Keypair::random();
@@ -519,7 +516,7 @@ mod tests {
         relay.shutdown();
     }
 
-    async fn run_rate_limited_relay(testnet: &pkarr::mainline::Testnet) -> Relay {
+    async fn run_rate_limited_relay(testnet: &mainline::Testnet) -> Relay {
         let storage = std::env::temp_dir().join(format!("pkarr-relay-{}", Timestamp::now()));
         let mut builder = Relay::builder();
         builder

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -16,6 +16,7 @@ struct Cli {
     tracing_env_filter: Option<String>,
 
     /// Run a Pkarr relay on a local testnet (port 15411).
+    #[cfg(feature = "testnet")]
     #[clap(long)]
     testnet: bool,
 }
@@ -32,12 +33,24 @@ async fn main() -> Result<()> {
         .init();
 
     let relay = unsafe {
-        if args.testnet {
-            Relay::run_testnet().await?
-        } else if let Some(config_path) = args.config {
-            Relay::run_with_config_file(config_path).await?
-        } else {
-            Relay::builder().run().await?
+        #[cfg(feature = "testnet")]
+        {
+            if args.testnet {
+                Relay::run_testnet().await?
+            } else if let Some(config_path) = args.config {
+                Relay::run_with_config_file(config_path).await?
+            } else {
+                Relay::builder().run().await?
+            }
+        }
+
+        #[cfg(not(feature = "testnet"))]
+        {
+            if let Some(config_path) = args.config {
+                Relay::run_with_config_file(config_path).await?
+            } else {
+                Relay::builder().run().await?
+            }
         }
     };
 

--- a/relay/src/rate_limiting.rs
+++ b/relay/src/rate_limiting.rs
@@ -153,12 +153,8 @@ impl DhtRateLimiter {
     }
 }
 
-impl pkarr::mainline::RequestFilter for DhtRateLimiter {
-    fn allow_request(
-        &self,
-        _request: &pkarr::mainline::RequestSpecific,
-        from: std::net::SocketAddrV4,
-    ) -> bool {
+impl pkarr::dht::RequestFilter for DhtRateLimiter {
+    fn allow_request(&self, from: std::net::SocketAddrV4) -> bool {
         self.limiter.is_allowed(&IpAddr::from(*from.ip()))
     }
 }
@@ -236,7 +232,7 @@ mod tests {
 
     #[tokio::test]
     async fn dht_limiter_implements_request_filter() {
-        fn assert_request_filter<T: pkarr::mainline::RequestFilter>() {}
+        fn assert_request_filter<T: pkarr::dht::RequestFilter>() {}
         assert_request_filter::<DhtRateLimiter>();
 
         let config = RateLimiterConfig {


### PR DESCRIPTION
Add pkarr-owned DHT configuration and request filtering, keeping
Mainline types and packet conversions internal to the DHT adapter.

BREAKING CHANGE: `pkarr::mainline`, Mainline-based `DhtClient::build`,
and SignedPacket/MutableItem conversions are removed. Configure DHT
clients and relays with `pkarr::dht::DhtConfig`.
