### PR TITLE
chore: release v8.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkarr"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-js"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "cfg_aliases",
  "console_error_panic_hook",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr-js"
-version = "7.0.0"
+version = "8.0.0"
 rust-version = "1.85"
 authors = ["Nuh <nuh@nuh.dev>"]
 edition = "2021"

--- a/bindings/js/pkg/package.json
+++ b/bindings/js/pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/pkarr",
   "description": "Public-Key Addressable Resource Records (Pkarr); publish and resolve DNS records over Mainline DHT",
-  "version": "1.0.0",
+  "version": "8.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr"
-version = "7.0.0"
+version = "8.0.0"
 rust-version = "1.85"
 authors = [
   "Nuh <nuh@nuh.dev>",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr-relay"
-version = "1.0.0"
+version = "2.0.0"
 rust-version = "1.85"
 authors = [
     "Nuh <nuh@nuh.dev>",
@@ -42,7 +42,7 @@ toml = "1"
 clap = { version = "4", features = ["derive"] }
 httpdate = "1"
 url = "2"
-pkarr = { path = "../pkarr", version = "7", default-features = false, features = [
+pkarr = { path = "../pkarr", version = "8", default-features = false, features = [
     "dht",
     "lmdb-cache",
 ] }


### PR DESCRIPTION
  ### Breaking changes

  - Gate relay testnet support behind explicit configuration.
  - Upgrade `simple-dns` to 0.12.
  - Upgrade `mainline` to v8.

  ### Added

  - Add secure node IDs to the relay.
  - Add DHT configuration support required by the updated networking stack.

  ### Changed

  - Update Rust workspace dependencies.
  - Update Dependabot scheduling and configuration.
