### PR TITLE
Improve GitHub Pages rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PKARR
+# [PKARR](https://github.com/pubky/pkarr)
 
 > Own your identity. No registrars. No platforms. Just your keys.
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+title: PKARR

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,13 @@
+<script type="module">
+  import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.esm.min.mjs";
+
+  document.querySelectorAll("pre > code.language-mermaid").forEach((code) => {
+    const diagram = document.createElement("pre");
+    diagram.className = "mermaid";
+    diagram.textContent = code.textContent;
+    code.parentElement.replaceWith(diagram);
+  });
+
+  mermaid.initialize({ startOnLoad: false });
+  await mermaid.run({ nodes: document.querySelectorAll(".mermaid") });
+</script>


### PR DESCRIPTION
- Render Mermaid diagrams on GitHub Pages.
- Replace the duplicate site heading with a repository link.