### PR TITLE
Redirect GitHub Pages to repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="0; url=https://github.com/pubky/pkarr">
+    <link rel="canonical" href="https://github.com/pubky/pkarr">
+    <title>PKARR</title>
+    <script>
+      window.location.replace("https://github.com/pubky/pkarr");
+    </script>
+  </head>
+  <body>
+    <p><a href="https://github.com/pubky/pkarr">Continue to PKARR on GitHub</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
- Redirect the GitHub Pages landing page to the repository README.
- Keep existing deep documentation URLs available.