### PR TITLE
refactor(relay): reduce error result size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -936,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1928,7 +1928,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2178,7 +2178,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2236,7 +2236,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2643,7 +2643,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3198,7 +3198,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/relay/src/error.rs
+++ b/relay/src/error.rs
@@ -11,7 +11,7 @@ use pkarr::{dht, PKARR_INVALID_SIGNED_PACKET_SEQ};
 pub struct Error {
     status: StatusCode,
     detail: Option<String>,
-    headers: HeaderMap,
+    headers: Option<Box<HeaderMap>>,
 }
 
 impl Default for Error {
@@ -19,7 +19,7 @@ impl Default for Error {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             detail: None,
-            headers: HeaderMap::new(),
+            headers: None,
         }
     }
 }
@@ -29,7 +29,7 @@ impl Error {
         Self {
             status,
             detail: None,
-            headers: HeaderMap::new(),
+            headers: None,
         }
     }
 
@@ -39,7 +39,7 @@ impl Error {
             status: status_code,
             // title: Self::canonical_reason_to_string(&status_code),
             detail: Some(message.to_string()),
-            headers: HeaderMap::new(),
+            headers: None,
         }
     }
 
@@ -48,7 +48,7 @@ impl Error {
             StatusCode::NOT_FOUND,
             format!("DHT mutable item at seq {seq} is not a valid signed packet"),
         );
-        error.headers.insert(
+        error.headers.get_or_insert_default().insert(
             PKARR_INVALID_SIGNED_PACKET_SEQ,
             HeaderValue::from_str(&seq.to_string())
                 .expect("i64 string is a valid HTTP header value"),
@@ -63,7 +63,9 @@ impl IntoResponse for Error {
             Some(detail) => (self.status, detail).into_response(),
             _ => (self.status,).into_response(),
         };
-        response.headers_mut().extend(self.headers);
+        if let Some(headers) = self.headers {
+            response.headers_mut().extend(*headers);
+        }
         response
     }
 }


### PR DESCRIPTION
Store response headers behind an optional box so common errors avoid
carrying a large HeaderMap. Preserve response behavior while resolving
Clippy's result_large_err warnings.

Refresh transitive dependency resolutions in the lockfile to fix cargo deny
issue.
