### PR TITLE
fix(relay): limit HTTP/1 connection buffers

### DIFF
--- a/relay/src/http_server.rs
+++ b/relay/src/http_server.rs
@@ -34,6 +34,7 @@ const INITIAL_REQUEST_HEADER_TIMEOUT: Duration = Duration::from_secs(30);
 const CONNECTION_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 const ACCEPT_ERROR_BACKOFF: Duration = Duration::from_secs(1);
 const HTTP1_HEADER_READ_TIMEOUT: Duration = Duration::from_secs(30);
+const HTTP1_MAX_BUFFER_SIZE: usize = 16 * 1024;
 const HTTP2_MAX_CONCURRENT_STREAMS: u32 = 100;
 const HTTP2_MAX_HEADER_LIST_SIZE: u32 = 16 * 1024;
 
@@ -102,7 +103,8 @@ async fn serve(
     builder
         .http1()
         .timer(TokioTimer::new())
-        .header_read_timeout(limits.http1_header_read_timeout);
+        .header_read_timeout(limits.http1_header_read_timeout)
+        .max_buf_size(HTTP1_MAX_BUFFER_SIZE);
     builder
         .http2()
         .max_concurrent_streams(HTTP2_MAX_CONCURRENT_STREAMS)

--- a/relay/src/http_server/tests.rs
+++ b/relay/src/http_server/tests.rs
@@ -13,7 +13,7 @@ use tokio::{
     time::{sleep, timeout},
 };
 
-use super::{HttpServer, Limits};
+use super::{HttpServer, Limits, HTTP1_MAX_BUFFER_SIZE};
 
 #[tokio::test]
 async fn connection_without_request_hits_initial_request_header_timeout() {
@@ -125,6 +125,25 @@ async fn incomplete_http1_headers_hit_header_timeout() {
         .await
         .expect("incomplete headers should time out")
         .unwrap();
+}
+
+#[tokio::test]
+async fn oversized_http1_headers_are_rejected() {
+    let server = TestServer::spawn(test_limits());
+    let mut stream = TcpStream::connect(server.address).await.unwrap();
+    let oversized_header = "a".repeat(HTTP1_MAX_BUFFER_SIZE);
+    let request =
+        format!("GET / HTTP/1.1\r\nHost: localhost\r\nX-Large: {oversized_header}\r\n\r\n");
+
+    stream.write_all(request.as_bytes()).await.unwrap();
+
+    let mut response = Vec::new();
+    timeout(Duration::from_secs(1), stream.read_to_end(&mut response))
+        .await
+        .expect("oversized HTTP/1 headers should be rejected promptly")
+        .unwrap();
+
+    assert!(response.starts_with(b"HTTP/1.1 431"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Cap HTTP/1 connection buffers at 16 KiB to reduce memory pressure
from clients sending oversized request headers.
