### PR TITLE
chore: release v8.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkarr"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/bindings/js/pkg/package.json
+++ b/bindings/js/pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synonymdev/pkarr",
   "description": "Public-Key Addressable Resource Records (Pkarr); publish and resolve DNS records over Mainline DHT",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pkarr/Cargo.toml
+++ b/pkarr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr"
-version = "8.0.0"
+version = "8.0.1"
 rust-version = "1.85"
 authors = [
   "Nuh <nuh@nuh.dev>",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkarr-relay"
-version = "2.0.0"
+version = "2.0.1"
 rust-version = "1.85"
 authors = [
     "Nuh <nuh@nuh.dev>",


### PR DESCRIPTION
### Added

- Configurable relay connection count and lifetime limits.
- HTTP connection, header, body, and drain timeouts.

### Changed

- Hardened HTTP/1 and HTTP/2 handling against resource exhaustion.
- Replaced `axum-server` with direct Hyper/Tokio handling.
- Reduced relay error-response memory usage.
- Improved client, relay, configuration, and feature documentation.
