### PR TITLE
chore: add 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
           interval: "weekly"
           day: "tuesday"
           time: "08:00"
+      cooldown:
+        default-days: 7
       commit-message:
           prefix: "deps"
       rebase-strategy: "auto"
@@ -26,6 +28,8 @@ updates:
       directory: "/bindings/js/pkg"
       schedule:
           interval: "monthly"
+      cooldown:
+        default-days: 7
       commit-message:
           prefix: "deps"
       rebase-strategy: "auto"


### PR DESCRIPTION
Set  on every Dependabot update entry that did not have one, per the org-wide convention from the Slack thread per @andrei-21: do not adopt brand-new releases until they have been out for at least 7 days.

Draft PR, one change per repo. Already covered: , .